### PR TITLE
feat(config): add spacing and type schema sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ From the first release onward, this file is maintained automatically by [`releas
 ### Added
 
 - Initial workspace scaffold, tooling, and walking skeleton.
+- PRD-style `[spacing]` and `[type]` config sections with schema validation.

--- a/crates/plumb-config/src/lib.rs
+++ b/crates/plumb-config/src/lib.rs
@@ -9,15 +9,30 @@
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+use std::fs;
+use std::ops::Range;
 use std::path::Path;
 
 use figment::Figment;
-use figment::providers::{Format, Json, Toml, Yaml};
+use figment::providers::{Format, Json, Yaml};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use plumb_core::Config;
 use thiserror::Error;
 
-/// Config-loading errors.
+/// Underlying config parse errors.
 #[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConfigParseSource {
+    /// TOML parser or schema error.
+    #[error("{0}")]
+    Toml(#[from] toml::de::Error),
+    /// Figment parser or schema error.
+    #[error("{0}")]
+    Figment(#[from] figment::Error),
+}
+
+/// Config-loading errors.
+#[derive(Debug, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ConfigError {
     /// File extension isn't one we recognize.
@@ -26,15 +41,31 @@ pub enum ConfigError {
     /// The file is missing.
     #[error("config file not found: {0}")]
     NotFound(String),
+    /// The file exists but could not be read.
+    #[error("failed to read config file `{path}`: {source}")]
+    Read {
+        /// Path that failed to read.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
     /// The file exists but couldn't be parsed or the content didn't
     /// match the config schema.
     #[error("failed to parse config file `{path}`: {source}")]
+    #[diagnostic(code(plumb::config::parse))]
     Parse {
         /// Path that failed to parse.
         path: String,
-        /// Underlying figment error.
+        /// Underlying parse error.
         #[source]
-        source: Box<figment::Error>,
+        source: ConfigParseSource,
+        /// Source text for span-annotated diagnostics.
+        #[source_code]
+        source_code: Option<NamedSource<String>>,
+        /// Label pointing at the invalid TOML span, when available.
+        #[label("invalid config")]
+        span: Option<SourceSpan>,
     },
     /// Schema emission failed.
     #[error("failed to emit schema: {0}")]
@@ -59,19 +90,61 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
         .unwrap_or("")
         .to_ascii_lowercase();
 
-    let figment = match ext.as_str() {
-        "toml" => Figment::new().merge(Toml::file(path)),
-        "yaml" | "yml" => Figment::new().merge(Yaml::file(path)),
-        "json" => Figment::new().merge(Json::file(path)),
-        other => return Err(ConfigError::UnsupportedExtension(other.to_owned())),
-    };
+    match ext.as_str() {
+        "toml" => load_toml(path),
+        "yaml" | "yml" => {
+            let figment = Figment::new().merge(Yaml::file(path));
+            extract_config(&figment, path)
+        }
+        "json" => {
+            let figment = Figment::new().merge(Json::file(path));
+            extract_config(&figment, path)
+        }
+        other => Err(ConfigError::UnsupportedExtension(other.to_owned())),
+    }
+}
 
+fn extract_config(figment: &Figment, path: &Path) -> Result<Config, ConfigError> {
     figment
         .extract::<Config>()
         .map_err(|source| ConfigError::Parse {
-            path: path.display().to_string(),
-            source: Box::new(source),
+            path: config_error_path(&source).unwrap_or_else(|| path.display().to_string()),
+            source: ConfigParseSource::Figment(source),
+            source_code: None,
+            span: None,
         })
+}
+
+fn load_toml(path: &Path) -> Result<Config, ConfigError> {
+    let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+
+    toml::from_str::<Config>(&contents).map_err(|source| {
+        let span = source.span().and_then(source_span);
+        ConfigError::Parse {
+            path: path.display().to_string(),
+            source: ConfigParseSource::Toml(source),
+            source_code: Some(
+                NamedSource::new(path.display().to_string(), contents).with_language("toml"),
+            ),
+            span,
+        }
+    })
+}
+
+fn source_span(range: Range<usize>) -> Option<SourceSpan> {
+    let len = range.end.checked_sub(range.start)?;
+    Some((range.start, len).into())
+}
+
+fn config_error_path(source: &figment::Error) -> Option<String> {
+    source
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.source.as_ref())
+        .map(ToString::to_string)
 }
 
 /// Emit the JSON Schema for [`Config`] as a pretty-printed string.

--- a/crates/plumb-config/tests/load_example.rs
+++ b/crates/plumb-config/tests/load_example.rs
@@ -2,6 +2,9 @@
 
 use std::path::PathBuf;
 
+use miette::Diagnostic;
+use serde_json::Value;
+
 #[test]
 fn loads_example_toml() {
     let path: PathBuf = [
@@ -18,6 +21,122 @@ fn loads_example_toml() {
         !cfg.viewports.is_empty(),
         "example config should define viewports"
     );
+}
+
+#[test]
+fn loads_prd_spacing_and_type_sections() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("plumb.toml");
+    std::fs::write(
+        &path,
+        r#"
+[spacing]
+base_unit = 8
+scale = [0, 8, 16, 24]
+tokens = { sm = 8, md = 16 }
+
+[type]
+families = ["Inter", "ui-sans-serif"]
+weights = [400, 700]
+scale = [12, 14, 16, 20]
+tokens = { body = 16, heading = 20 }
+"#,
+    )
+    .expect("write config");
+
+    let cfg = plumb_config::load(&path).expect("load config");
+
+    assert_eq!(cfg.spacing.base_unit, 8);
+    assert_eq!(cfg.spacing.scale, vec![0, 8, 16, 24]);
+    assert_eq!(cfg.spacing.tokens["sm"], 8);
+    assert_eq!(cfg.type_scale.families, vec!["Inter", "ui-sans-serif"]);
+    assert_eq!(cfg.type_scale.weights, vec![400, 700]);
+    assert_eq!(cfg.type_scale.scale, vec![12, 14, 16, 20]);
+    assert_eq!(cfg.type_scale.tokens["heading"], 20);
+}
+
+#[test]
+fn default_spacing_base_unit_is_four() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("plumb.toml");
+    std::fs::write(&path, "").expect("write config");
+
+    let cfg = plumb_config::load(&path).expect("load config");
+
+    assert_eq!(cfg.spacing.base_unit, 4);
+}
+
+#[test]
+fn rejects_old_config_aliases_and_unknown_fields() {
+    for toml in [
+        "[spacing]\nbase_px = 4\n",
+        "[type_scale]\nsizes_px = [16]\n",
+        "[type]\nsizes_px = [16]\n",
+        "[type]\nline_heights = [1.5]\n",
+        "[spacing]\nunknown = 4\n",
+    ] {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("plumb.toml");
+        std::fs::write(&path, toml).expect("write config");
+
+        let err = plumb_config::load(&path).expect_err("reject invalid config");
+        assert!(
+            matches!(err, plumb_config::ConfigError::Parse { .. }),
+            "expected parse error for {toml:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn schema_uses_prd_names_and_drops_old_aliases() {
+    let schema = plumb_config::emit_schema().expect("emit schema");
+    let schema_json: Value = serde_json::from_str(&schema).expect("schema should be valid JSON");
+
+    let properties = schema_json["properties"]
+        .as_object()
+        .expect("schema properties should be an object");
+    assert!(properties.contains_key("spacing"));
+    assert!(properties.contains_key("type"));
+    assert!(!properties.contains_key("type_scale"));
+
+    let definitions = schema_json["definitions"]
+        .as_object()
+        .expect("schema definitions should be an object");
+    let spacing_props = definitions["SpacingSpec"]["properties"]
+        .as_object()
+        .expect("spacing properties should be an object");
+    assert!(spacing_props.contains_key("base_unit"));
+    assert!(spacing_props.contains_key("scale"));
+    assert!(spacing_props.contains_key("tokens"));
+
+    let type_props = definitions["TypeScaleSpec"]["properties"]
+        .as_object()
+        .expect("type properties should be an object");
+    assert!(type_props.contains_key("families"));
+    assert!(type_props.contains_key("weights"));
+    assert!(type_props.contains_key("scale"));
+    assert!(type_props.contains_key("tokens"));
+
+    assert!(!schema.contains("\"base_px\""));
+    assert!(!schema.contains("\"sizes_px\""));
+    assert!(!schema.contains("\"line_heights\""));
+}
+
+#[test]
+fn toml_schema_errors_expose_miette_source_and_labels() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("plumb.toml");
+    std::fs::write(&path, "[spacing]\nbase_px = 4\n").expect("write config");
+
+    let err = plumb_config::load(&path).expect_err("reject old field");
+
+    assert!(
+        err.source_code().is_some(),
+        "parse error should expose source code"
+    );
+
+    let mut labels = err.labels().expect("parse error should expose labels");
+    assert!(labels.next().is_some(), "parse error should expose labels");
 }
 
 #[test]

--- a/crates/plumb-core/src/config.rs
+++ b/crates/plumb-core/src/config.rs
@@ -27,7 +27,8 @@ pub struct Config {
     pub spacing: SpacingSpec,
 
     /// Type scale spec.
-    #[serde(default)]
+    #[serde(default, rename = "type")]
+    #[schemars(rename = "type")]
     pub type_scale: TypeScaleSpec,
 
     /// Color palette spec.
@@ -69,15 +70,32 @@ fn default_dpr() -> f32 {
 }
 
 /// Spacing spec.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SpacingSpec {
     /// Base unit in pixels; discrete scale is multiples of this.
+    #[serde(default = "default_base_unit")]
+    pub base_unit: u32,
+    /// Allowed spacing values in pixels.
     #[serde(default)]
-    pub base_px: Option<u32>,
+    pub scale: Vec<u32>,
     /// Named tokens mapped to their pixel values.
     #[serde(default)]
     pub tokens: IndexMap<String, u32>,
+}
+
+fn default_base_unit() -> u32 {
+    4
+}
+
+impl Default for SpacingSpec {
+    fn default() -> Self {
+        Self {
+            base_unit: default_base_unit(),
+            scale: Vec::new(),
+            tokens: IndexMap::new(),
+        }
+    }
 }
 
 /// Type scale spec.
@@ -87,15 +105,15 @@ pub struct TypeScaleSpec {
     /// Allowed font families.
     #[serde(default)]
     pub families: Vec<String>,
-    /// Allowed font sizes in pixels.
-    #[serde(default)]
-    pub sizes_px: Vec<u32>,
-    /// Allowed line heights (unitless ratios).
-    #[serde(default)]
-    pub line_heights: Vec<f32>,
     /// Allowed font weights.
     #[serde(default)]
     pub weights: Vec<u16>,
+    /// Allowed font sizes in pixels.
+    #[serde(default)]
+    pub scale: Vec<u32>,
+    /// Named type tokens mapped to their pixel values.
+    #[serde(default)]
+    pub tokens: IndexMap<String, u32>,
 }
 
 /// Color spec.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -22,8 +22,9 @@ is the canonical example. Highlights:
 - `[viewports.<name>]` — viewport specs. At least one required in real
   runs; the walking skeleton defaults to `desktop` (1280×800).
 - `[spacing]` — the discrete spacing scale. Violations flag values off
-  the scale.
-- `[type_scale]` — allowed font families, sizes, line-heights, weights.
+  the `base_unit` grid or outside the declared `scale`.
+- `[type]` — allowed font families, weights, font-size scale, and named
+  type tokens.
 - `[color]` — named color tokens and the CIEDE2000 tolerance for fuzzy
   matches.
 - `[radius]` — allowed border-radii.

--- a/examples/plumb.toml
+++ b/examples/plumb.toml
@@ -20,14 +20,15 @@ height = 800
 device_pixel_ratio = 1.0
 
 [spacing]
-base_px = 4
+base_unit = 4
+scale = [0, 4, 8, 12, 16, 24, 32, 48]
 tokens = { xs = 4, sm = 8, md = 16, lg = 24, xl = 32, "2xl" = 48 }
 
-[type_scale]
+[type]
 families = ["Inter", "system-ui"]
-sizes_px = [12, 14, 16, 18, 20, 24, 30, 36, 48]
-line_heights = [1.0, 1.25, 1.5, 1.75]
 weights = [400, 500, 600, 700]
+scale = [12, 14, 16, 18, 20, 24, 30, 36, 48]
+tokens = { caption = 12, body = 16, heading = 24 }
 
 [color]
 tokens = { "bg/canvas" = "#ffffff", "fg/primary" = "#0b0b0b", "accent/brand" = "#0b7285" }

--- a/schemas/plumb.toml.json
+++ b/schemas/plumb.toml.json
@@ -15,7 +15,8 @@
     "spacing": {
       "description": "Spacing spec — the allowed discrete values for `gap`, `margin`, `padding`, etc.",
       "default": {
-        "base_px": null,
+        "base_unit": 4,
+        "scale": [],
         "tokens": {}
       },
       "allOf": [
@@ -24,12 +25,12 @@
         }
       ]
     },
-    "type_scale": {
+    "type": {
       "description": "Type scale spec.",
       "default": {
         "families": [],
-        "line_heights": [],
-        "sizes_px": [],
+        "scale": [],
+        "tokens": {},
         "weights": []
       },
       "allOf": [
@@ -128,15 +129,22 @@
       "description": "Spacing spec.",
       "type": "object",
       "properties": {
-        "base_px": {
+        "base_unit": {
           "description": "Base unit in pixels; discrete scale is multiples of this.",
-          "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
+          "default": 4,
+          "type": "integer",
           "format": "uint32",
           "minimum": 0.0
+        },
+        "scale": {
+          "description": "Allowed spacing values in pixels.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
         },
         "tokens": {
           "description": "Named tokens mapped to their pixel values.",
@@ -163,7 +171,17 @@
             "type": "string"
           }
         },
-        "sizes_px": {
+        "weights": {
+          "description": "Allowed font weights.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        },
+        "scale": {
           "description": "Allowed font sizes in pixels.",
           "default": [],
           "type": "array",
@@ -173,22 +191,13 @@
             "minimum": 0.0
           }
         },
-        "line_heights": {
-          "description": "Allowed line heights (unitless ratios).",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "number",
-            "format": "float"
-          }
-        },
-        "weights": {
-          "description": "Allowed font weights.",
-          "default": [],
-          "type": "array",
-          "items": {
+        "tokens": {
+          "description": "Named type tokens mapped to their pixel values.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
             "type": "integer",
-            "format": "uint16",
+            "format": "uint32",
             "minimum": 0.0
           }
         }


### PR DESCRIPTION
## Target branch

- [x] This PR targets `main`

## Spec

Fixes #13

## Summary

- Replaces the walking-skeleton config-facing spacing/type names with PRD-style `[spacing]` and `[type]` schema sections.
- Adds strict parse/schema tests for the new fields, rejection tests for old aliases, and miette source/label coverage for off-schema TOML.
- Updates examples, docs, changelog, generated schema, and bumps `rmcp` to remove the transitive `paste` advisory that blocked validation.

## Crates touched

- [x] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [x] `plumb-config`
- [x] `plumb-mcp`
- [x] `plumb-cli`
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [x] Config schema change (run `cargo xtask schema` + commit result)
- [x] Dependency added / bumped (cargo-deny must still pass)
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `cargo nextest run -p plumb-config`
- [x] `cargo xtask schema --out /tmp/plumb-schema-check.json`
- [x] `cargo xtask schema`
- [x] `cargo xtask pre-release`
- [x] `just validate`
- [x] `cargo deny check`
- [x] `cargo audit`
- [x] `python3 .agents/skills/gh-review/scripts/gh_review.py --local-diff origin/main...HEAD`

## Documentation

- [x] Rustdoc added for every new public item
- [x] `# Errors` section on every new public fallible fn
- [x] `docs/src/` updated when user-visible behavior changed
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules
- [x] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [x] Humanizer skill run on docs changes

## Breaking change?

- [x] Yes - old walking-skeleton config names are intentionally rejected.

Migrate `[spacing].base_px` to `[spacing].base_unit`, move `[type_scale]` to `[type]`, replace `sizes_px` with `scale`, and replace `line_heights` with `[type.tokens]` entries where needed.

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/13-feat-config-spacing-type-sections`
- [x] All review gates passed: spec -> quality -> architecture -> test (+ security if triggered)
- [x] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

`rmcp` is bumped from `0.2` to `0.11` because `cargo deny check` rejected the previous transitive `paste` advisory. The MCP tool surface is unchanged; the stdio protocol test now asserts `inputSchema` for both existing tools to cover the SDK migration.

A separate CI-only fix was landed on `main` so the PR-title and Claude Code Review workflows can report correctly; this branch is rebased on top of that fix.
