### PR TITLE
feat(core): enrich snapshot context

### DIFF
--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -154,3 +154,41 @@ fn mcp_echo_round_trip() {
         .expect("text content");
     assert!(text.contains("hi plumb"), "unexpected text: {text}");
 }
+
+#[test]
+fn mcp_lint_url_returns_structured_content() {
+    let lint_url = json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "lint_url", "arguments": { "url": "plumb-fake://hello" } }
+    });
+    let responses = send_and_read(vec![init_request(1), initialized_notification(), lint_url]);
+    let lint_resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("lint_url response missing: got {responses:?}"));
+    let result = &lint_resp["result"];
+
+    assert_eq!(result["isError"].as_bool(), Some(false));
+
+    let content = result["content"].as_array().expect("content array");
+    assert_eq!(
+        content.len(),
+        1,
+        "lint_url must not return structured payload as extra text: {result}"
+    );
+    assert_eq!(content[0]["type"].as_str(), Some("text"));
+    let text = content[0]["text"].as_str().expect("text content");
+    assert!(
+        text.contains("warning placeholder/hello-world @ html > body [desktop]"),
+        "unexpected lint_url text: {text}"
+    );
+
+    let structured = result["structuredContent"]
+        .as_object()
+        .expect("structuredContent object");
+    assert_eq!(structured["counts"]["total"].as_u64(), Some(1));
+    assert_eq!(
+        structured["violations"][0]["rule_id"].as_str(),
+        Some("placeholder/hello-world")
+    );
+}

--- a/crates/plumb-core/src/engine.rs
+++ b/crates/plumb-core/src/engine.rs
@@ -5,7 +5,7 @@
 //! `(rule_id, viewport, selector, dom_order)` — see `docs/local/prd.md` §9.
 
 use crate::config::Config;
-use crate::report::{Violation, ViolationSink};
+use crate::report::{ViewportKey, Violation, ViolationSink};
 use crate::rules::{Rule, register_builtin};
 use crate::snapshot::{PlumbSnapshot, SnapshotCtx};
 use rayon::prelude::*;
@@ -24,7 +24,14 @@ pub fn run(snapshot: &PlumbSnapshot, config: &Config) -> Vec<Violation> {
 }
 
 fn run_rules(snapshot: &PlumbSnapshot, config: &Config, rules: &[Box<dyn Rule>]) -> Vec<Violation> {
-    let ctx = SnapshotCtx::new(snapshot);
+    let ctx = if config.viewports.is_empty() {
+        SnapshotCtx::new(snapshot)
+    } else {
+        SnapshotCtx::with_viewports(
+            snapshot,
+            config.viewports.keys().cloned().map(ViewportKey::new),
+        )
+    };
     let mut buffer: Vec<Violation> = rules
         .par_iter()
         .filter(|rule| {

--- a/crates/plumb-core/src/rules/placeholder.rs
+++ b/crates/plumb-core/src/rules/placeholder.rs
@@ -48,7 +48,7 @@ impl Rule for HelloWorld {
                 ),
                 selector: node.selector.clone(),
                 viewport: ctx.snapshot().viewport.clone(),
-                rect: node.rect,
+                rect: ctx.rect_for(node.dom_order),
                 dom_order: node.dom_order,
                 fix: Some(Fix {
                     kind: FixKind::CssPropertyReplace {

--- a/crates/plumb-core/src/snapshot.rs
+++ b/crates/plumb-core/src/snapshot.rs
@@ -126,13 +126,30 @@ impl PlumbSnapshot {
 #[derive(Debug)]
 pub struct SnapshotCtx<'a> {
     snapshot: &'a PlumbSnapshot,
+    viewports: Vec<ViewportKey>,
+    rects_by_dom_order: IndexMap<u64, Rect>,
 }
 
 impl<'a> SnapshotCtx<'a> {
     /// Wrap a borrowed snapshot.
     #[must_use]
     pub fn new(snapshot: &'a PlumbSnapshot) -> Self {
-        Self { snapshot }
+        Self::with_viewports(snapshot, [snapshot.viewport.clone()])
+    }
+
+    /// Wrap a borrowed snapshot with the full viewport set for this run.
+    ///
+    /// The caller-provided order is preserved.
+    #[must_use]
+    pub fn with_viewports(
+        snapshot: &'a PlumbSnapshot,
+        viewports: impl IntoIterator<Item = ViewportKey>,
+    ) -> Self {
+        Self {
+            snapshot,
+            viewports: viewports.into_iter().collect(),
+            rects_by_dom_order: rect_index(snapshot),
+        }
     }
 
     /// The underlying snapshot.
@@ -141,8 +158,28 @@ impl<'a> SnapshotCtx<'a> {
         self.snapshot
     }
 
+    /// The viewports included in the current engine run.
+    #[must_use]
+    pub fn viewports(&self) -> &[ViewportKey] {
+        &self.viewports
+    }
+
+    /// Return the bounding rect for a node by document-order index.
+    #[must_use]
+    pub fn rect_for(&self, dom_order: u64) -> Option<Rect> {
+        self.rects_by_dom_order.get(&dom_order).copied()
+    }
+
     /// Iterate nodes in document order.
     pub fn nodes(&self) -> impl Iterator<Item = &SnapshotNode> {
         self.snapshot.nodes.iter()
     }
+}
+
+fn rect_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, Rect> {
+    snapshot
+        .nodes
+        .iter()
+        .filter_map(|node| node.rect.map(|rect| (node.dom_order, rect)))
+        .collect()
 }

--- a/crates/plumb-core/tests/golden_hello_world.rs
+++ b/crates/plumb-core/tests/golden_hello_world.rs
@@ -3,7 +3,7 @@
 //! Proves `engine::run` produces deterministic, sorted output given the
 //! canned snapshot + default config.
 
-use plumb_core::{Config, PlumbSnapshot, run};
+use plumb_core::{Config, PlumbSnapshot, Rect, SnapshotCtx, ViewportKey, run};
 
 #[test]
 fn hello_world_golden() -> Result<(), serde_json::Error> {
@@ -26,4 +26,50 @@ fn engine_run_is_deterministic() -> Result<(), serde_json::Error> {
     assert_eq!(a, b);
     assert_eq!(b, c);
     Ok(())
+}
+
+#[test]
+fn snapshot_ctx_new_exposes_snapshot_viewport() {
+    let snapshot = PlumbSnapshot::canned();
+    let ctx = SnapshotCtx::new(&snapshot);
+
+    assert_eq!(ctx.viewports(), &[ViewportKey::new("desktop")]);
+}
+
+#[test]
+fn snapshot_ctx_with_viewports_preserves_supplied_order() {
+    let snapshot = PlumbSnapshot::canned();
+    let viewports = vec![
+        ViewportKey::new("mobile"),
+        ViewportKey::new("tablet"),
+        ViewportKey::new("desktop"),
+    ];
+    let ctx = SnapshotCtx::with_viewports(&snapshot, viewports);
+
+    assert_eq!(
+        ctx.viewports(),
+        &[
+            ViewportKey::new("mobile"),
+            ViewportKey::new("tablet"),
+            ViewportKey::new("desktop"),
+        ],
+    );
+}
+
+#[test]
+fn snapshot_ctx_rect_for_uses_precomputed_rect_index() {
+    let snapshot = PlumbSnapshot::canned();
+    let ctx = SnapshotCtx::new(&snapshot);
+
+    let full_viewport_rect = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 1280,
+        height: 800,
+    });
+
+    assert_eq!(ctx.rect_for(0), full_viewport_rect);
+    assert_eq!(ctx.rect_for(1), None);
+    assert_eq!(ctx.rect_for(2), full_viewport_rect);
+    assert_eq!(ctx.rect_for(99), None);
 }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -91,19 +91,12 @@ impl PlumbServer {
         let config = Config::default();
         let violations = run(&snapshot, &config);
         let (text, structured) = mcp_compact(&violations);
-        // rmcp 0.2 CallToolResult carries text/image/resource content
-        // directly. Ship the structured JSON as an additional text block;
-        // agents that want strict JSON parse the second block.
-        let structured_text = serde_json::to_string(&structured).map_err(|error| {
-            ErrorData::internal_error(
-                format!("failed to serialize structured MCP result: {error}"),
-                None,
-            )
-        })?;
-        Ok(CallToolResult::success(vec![
-            Content::text(text),
-            Content::text(structured_text),
-        ]))
+        Ok(CallToolResult {
+            content: vec![Content::text(text)],
+            structured_content: Some(structured),
+            is_error: Some(false),
+            meta: None,
+        })
     }
 }
 


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

<!-- Link the issue, runbook spec, or ADR this PR implements. -->

Fixes #14

## Summary

- Enriches `SnapshotCtx` with active viewport context and an O(1) rect index.
- Wires `engine::run` to pass configured viewport keys when present, while preserving the current single-snapshot fallback.
- Updates `rmcp` to remove the transitive `paste` advisory and returns MCP lint payloads through `structuredContent`.

## Crates touched

- [x] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [ ] `plumb-config`
- [x] `plumb-mcp`
- [x] `plumb-cli`
- [ ] `xtask`
- [ ] `docs/`
- [ ] `.agents` or `.claude`
- [ ] `.github/`

## System impact

- [x] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [x] Dependency added / bumped (cargo-deny must still pass)
- [x] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `just validate` passes locally
- [ ] `cargo xtask pre-release` passes (if rule or schema changed)
- [x] `just determinism-check` passes (3x byte-diff clean)
- [x] `cargo deny check` passes
- [x] New/changed behavior has a test (unit, golden snapshot, or integration)

## Documentation

- [x] Rustdoc added for every new public item
- [ ] `# Errors` section on every new public fallible fn
- [ ] `docs/src/` updated when user-visible behavior changed
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [ ] Humanizer skill run on docs changes

## Breaking change?

- [x] No
- [ ] Yes — describe migration path



## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/14-feat-core-snapshot-ctx-viewport`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [x] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

Review gates passed: spec, code quality, architecture, test, and security. Security was required because the PR updates `rmcp`; `cargo audit --deny warnings` and `cargo deny check` both pass after removing the transitive `paste` advisory.
