### PR TITLE
feat(cdp): add Chromium launch detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ name = "plumb-cdp"
 version = "0.0.1"
 dependencies = [
  "chromiumoxide",
+ "futures-util",
  "plumb-core",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rmcp = { version = "0.10", default-features = false, features = ["base64", "macr
 
 # Async runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "sync", "time", "fs", "process"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 # CLI parsing.
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }

--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -16,6 +16,7 @@ categories.workspace = true
 [dependencies]
 plumb-core = { workspace = true }
 chromiumoxide = { workspace = true }
+futures-util = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -6,7 +6,7 @@
 //! Plumb crate where `unsafe` is permitted — and only for FFI-adjacent
 //! hot spots, each with an explicit `// SAFETY:` comment. The walking
 //! skeleton doesn't yet use `unsafe`; the override exists to preempt
-//! future friction when the real CDP driver lands.
+//! future friction when snapshot conversion lands.
 //!
 //! ## Pinned Chromium version
 //!
@@ -14,19 +14,26 @@
 //! Plumb renders against. Pinning the browser is part of Plumb's
 //! determinism guarantee (`docs/local/prd.md` §9, §16).
 //!
-//! ## Walking-skeleton behavior
+//! ## Current behavior
 //!
-//! [`ChromiumDriver::snapshot`] currently returns [`CdpError::NotImplemented`].
-//! The `plumb-fake://` URL scheme in `plumb-cli` is handled by
-//! [`FakeDriver`] from this crate's `test-fake` wiring — that scheme is
-//! the only way to exercise the full pipeline until the real driver
-//! lands.
+//! [`ChromiumDriver::snapshot`] launches Chromium and validates
+//! [`Browser::version`](chromiumoxide::Browser::version), then returns
+//! [`CdpError::NotImplemented`] until DOMSnapshot conversion lands in
+//! Issue #15. The `plumb-fake://` URL scheme in `plumb-cli` is handled
+//! by [`FakeDriver`] from this crate's `test-fake` wiring.
 
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
 use plumb_core::{PlumbSnapshot, ViewportKey};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use chromiumoxide::detection::DetectionOptions;
+use chromiumoxide::{Browser, BrowserConfig, Handler};
+use futures_util::StreamExt;
+use tokio::task::JoinHandle;
 
 /// Pinned Chromium major version. Any CI or local run that boots a
 /// Chromium binary older or newer than this major version refuses to run.
@@ -52,12 +59,18 @@ pub struct Target {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum CdpError {
-    /// The driver isn't implemented yet (walking skeleton).
-    #[error("ChromiumDriver is not implemented yet; use `plumb-fake://` URLs until PR #2 lands")]
+    /// DOMSnapshot conversion is not implemented yet.
+    #[error("DOMSnapshot conversion is not implemented yet (Issue #15)")]
     NotImplemented,
     /// An unknown URL scheme was passed to the fake driver.
     #[error("FakeDriver does not recognize URL `{0}`")]
     UnknownFakeUrl(String),
+    /// No suitable Chromium or Chrome executable could be found.
+    #[error("Chromium executable not found. {install_hint}")]
+    ChromiumNotFound {
+        /// Human-readable installation and override guidance.
+        install_hint: String,
+    },
     /// The Chromium binary reported a major version we don't support.
     #[error("Chromium major version {found} is not supported (Plumb pins to {expected})")]
     UnsupportedChromium {
@@ -81,14 +94,64 @@ pub trait BrowserDriver: Send + Sync {
     ) -> impl std::future::Future<Output = Result<PlumbSnapshot, CdpError>> + Send;
 }
 
-/// Real Chromium-backed driver. Not yet implemented — see PR #2.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ChromiumDriver;
+/// Configuration for [`ChromiumDriver`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ChromiumOptions {
+    /// Explicit Chrome or Chromium executable path. When unset, Plumb asks
+    /// `chromiumoxide` to detect stable Chrome/Chromium installations.
+    pub executable_path: Option<PathBuf>,
+}
+
+/// Real Chromium-backed driver.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ChromiumDriver {
+    options: ChromiumOptions,
+}
+
+impl ChromiumDriver {
+    /// Build a driver with explicit options.
+    #[must_use]
+    pub fn new(options: ChromiumOptions) -> Self {
+        Self { options }
+    }
+
+    fn browser_config(&self, target: &Target) -> Result<BrowserConfig, CdpError> {
+        let builder = BrowserConfig::builder()
+            .chrome_detection(DetectionOptions {
+                msedge: false,
+                unstable: false,
+            })
+            .window_size(target.width, target.height);
+
+        let builder = if let Some(path) = &self.options.executable_path {
+            ensure_executable_path(path)?;
+            builder.chrome_executable(path)
+        } else {
+            builder
+        };
+
+        builder.build().map_err(|_| chromium_not_found())
+    }
+}
 
 impl BrowserDriver for ChromiumDriver {
-    #[allow(clippy::unused_async)]
-    async fn snapshot(&self, _target: Target) -> Result<PlumbSnapshot, CdpError> {
-        Err(CdpError::NotImplemented)
+    async fn snapshot(&self, target: Target) -> Result<PlumbSnapshot, CdpError> {
+        let config = self.browser_config(&target)?;
+        let mut session = ChromiumSession::launch(config).await?;
+
+        let result = match validate_browser_version(&session.browser).await {
+            Ok(()) => Err(CdpError::NotImplemented),
+            Err(err) => Err(err),
+        };
+
+        if let Err(cleanup_err) = session.shutdown().await {
+            tracing::debug!(error = %cleanup_err, "failed to clean up Chromium session");
+            if result.is_ok() {
+                return Err(cleanup_err);
+            }
+        }
+
+        result
     }
 }
 
@@ -113,4 +176,202 @@ impl BrowserDriver for FakeDriver {
 #[must_use]
 pub fn is_fake_url(url: &str) -> bool {
     url.starts_with("plumb-fake://")
+}
+
+fn ensure_executable_path(path: &Path) -> Result<(), CdpError> {
+    if path.is_file() {
+        Ok(())
+    } else {
+        Err(chromium_not_found())
+    }
+}
+
+fn chromium_not_found() -> CdpError {
+    CdpError::ChromiumNotFound {
+        install_hint: chromium_install_hint(),
+    }
+}
+
+fn chromium_install_hint() -> String {
+    let platform_hint = if cfg!(target_os = "macos") {
+        "macOS: install Google Chrome or run `brew install --cask chromium`."
+    } else if cfg!(target_os = "windows") {
+        "Windows: install Google Chrome or Chromium and pass the `.exe` path if it is not auto-detected."
+    } else {
+        "Linux: install `google-chrome-stable`, `chromium`, or `chromium-browser` with your package manager."
+    };
+
+    format!(
+        "Install Chrome/Chromium {PINNED_CHROMIUM_MAJOR} or pass `--executable-path <path>` to a compatible binary. {platform_hint}"
+    )
+}
+
+struct ChromiumSession {
+    browser: Browser,
+    handler_task: JoinHandle<()>,
+}
+
+impl ChromiumSession {
+    async fn launch(config: BrowserConfig) -> Result<Self, CdpError> {
+        let (browser, handler) = Browser::launch(config).await.map_err(map_launch_error)?;
+        let handler_task = poll_handler(handler);
+        Ok(Self {
+            browser,
+            handler_task,
+        })
+    }
+
+    async fn shutdown(&mut self) -> Result<(), CdpError> {
+        let close_result = self.browser.close().await.map_err(driver_error);
+        if let Err(close_err) = close_result {
+            if let Err(kill_err) = kill_browser(&mut self.browser).await {
+                tracing::debug!(error = %kill_err, "failed to kill Chromium after close error");
+            }
+            self.abort_handler().await;
+            return Err(close_err);
+        }
+
+        if let Err(wait_err) = self.browser.wait().await {
+            let cleanup_err = io_error(wait_err);
+            if let Err(kill_err) = kill_browser(&mut self.browser).await {
+                tracing::debug!(error = %kill_err, "failed to kill Chromium after wait error");
+            }
+            self.abort_handler().await;
+            return Err(cleanup_err);
+        }
+
+        self.abort_handler().await;
+        Ok(())
+    }
+
+    async fn abort_handler(&mut self) {
+        self.handler_task.abort();
+        if let Err(join_err) = (&mut self.handler_task).await {
+            if !join_err.is_cancelled() {
+                tracing::debug!(error = %join_err, "Chromium handler task failed");
+            }
+        }
+    }
+}
+
+fn poll_handler(mut handler: Handler) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(result) = handler.next().await {
+            if let Err(err) = result {
+                tracing::debug!(error = %err, "Chromium handler error");
+            }
+        }
+    })
+}
+
+async fn kill_browser(browser: &mut Browser) -> Result<(), CdpError> {
+    if let Some(result) = browser.kill().await {
+        result.map_err(io_error)?;
+    }
+    Ok(())
+}
+
+async fn validate_browser_version(browser: &Browser) -> Result<(), CdpError> {
+    let version = browser.version().await.map_err(driver_error)?;
+    validate_chromium_product_major(&version.product)
+}
+
+fn validate_chromium_product_major(product: &str) -> Result<(), CdpError> {
+    let found = chromium_major_from_product(product).ok_or_else(|| {
+        CdpError::Driver(Box::new(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not parse Chromium product version `{product}`"),
+        )))
+    })?;
+
+    if found == PINNED_CHROMIUM_MAJOR {
+        Ok(())
+    } else {
+        Err(CdpError::UnsupportedChromium {
+            expected: PINNED_CHROMIUM_MAJOR,
+            found,
+        })
+    }
+}
+
+fn chromium_major_from_product(product: &str) -> Option<u32> {
+    let (_, version) = product.split_once('/')?;
+    let major = version.split('.').next()?;
+    major.parse().ok()
+}
+
+fn map_launch_error(err: chromiumoxide::error::CdpError) -> CdpError {
+    match err {
+        chromiumoxide::error::CdpError::Io(io_err) => {
+            if io_err.kind() == io::ErrorKind::NotFound {
+                chromium_not_found()
+            } else {
+                io_error(io_err)
+            }
+        }
+        chromiumoxide::error::CdpError::LaunchIo(io_err, stderr) => {
+            if io_err.kind() == io::ErrorKind::NotFound {
+                chromium_not_found()
+            } else {
+                CdpError::Driver(Box::new(chromiumoxide::error::CdpError::LaunchIo(
+                    io_err, stderr,
+                )))
+            }
+        }
+        other => driver_error(other),
+    }
+}
+
+fn driver_error(err: chromiumoxide::error::CdpError) -> CdpError {
+    CdpError::Driver(Box::new(err))
+}
+
+fn io_error(err: io::Error) -> CdpError {
+    CdpError::Driver(Box::new(err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CdpError, PINNED_CHROMIUM_MAJOR};
+
+    #[test]
+    fn parses_product_major_versions() {
+        assert_eq!(
+            super::chromium_major_from_product("Chrome/131.0.6778.204"),
+            Some(131)
+        );
+        assert_eq!(
+            super::chromium_major_from_product("HeadlessChrome/131.0.6778.204"),
+            Some(131)
+        );
+        assert_eq!(
+            super::chromium_major_from_product("Chromium/131.0.6778.204"),
+            Some(131)
+        );
+        assert_eq!(super::chromium_major_from_product("Chrome"), None);
+        assert_eq!(
+            super::chromium_major_from_product("Chrome/not-a-version"),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_unsupported_chromium_major() {
+        let result = super::validate_chromium_product_major("Chrome/132.0.0.0");
+
+        assert!(matches!(
+            result,
+            Err(CdpError::UnsupportedChromium {
+                expected: PINNED_CHROMIUM_MAJOR,
+                found: 132,
+            })
+        ));
+    }
+
+    #[test]
+    fn accepts_pinned_chromium_major() {
+        let product = format!("HeadlessChrome/{PINNED_CHROMIUM_MAJOR}.0.0.0");
+
+        assert!(super::validate_chromium_product_major(&product).is_ok());
+    }
 }

--- a/crates/plumb-cdp/tests/driver_contract.rs
+++ b/crates/plumb-cdp/tests/driver_contract.rs
@@ -1,7 +1,8 @@
-//! Contract tests for [`BrowserDriver`]. Runs against `FakeDriver`;
-//! `ChromiumDriver` will be covered by integration tests once PR #2 lands.
+//! Contract tests for [`BrowserDriver`].
 
-use plumb_cdp::{BrowserDriver, CdpError, ChromiumDriver, FakeDriver, Target, is_fake_url};
+use plumb_cdp::{
+    BrowserDriver, CdpError, ChromiumDriver, ChromiumOptions, FakeDriver, Target, is_fake_url,
+};
 use plumb_core::ViewportKey;
 
 fn target(url: &str) -> Target {
@@ -15,35 +16,36 @@ fn target(url: &str) -> Target {
 }
 
 #[tokio::test]
-async fn fake_driver_returns_canned_snapshot() {
+async fn fake_driver_returns_canned_snapshot() -> Result<(), CdpError> {
     let driver = FakeDriver;
-    let snap = driver
-        .snapshot(target("plumb-fake://hello"))
-        .await
-        .expect("canned");
+    let snap = driver.snapshot(target("plumb-fake://hello")).await?;
     assert_eq!(snap.url, "plumb-fake://hello");
     assert_eq!(snap.viewport.as_str(), "desktop");
     assert!(!snap.nodes.is_empty());
+    Ok(())
 }
 
 #[tokio::test]
 async fn fake_driver_rejects_unknown_urls() {
     let driver = FakeDriver;
-    let err = driver
-        .snapshot(target("plumb-fake://unknown"))
-        .await
-        .unwrap_err();
-    assert!(matches!(err, CdpError::UnknownFakeUrl(_)));
+    let result = driver.snapshot(target("plumb-fake://unknown")).await;
+    assert!(matches!(result, Err(CdpError::UnknownFakeUrl(_))));
 }
 
 #[tokio::test]
-async fn real_driver_is_not_implemented_yet() {
-    let driver = ChromiumDriver;
-    let err = driver
-        .snapshot(target("https://example.com"))
-        .await
-        .unwrap_err();
-    assert!(matches!(err, CdpError::NotImplemented));
+async fn real_driver_reports_missing_explicit_executable() {
+    let driver = ChromiumDriver::new(ChromiumOptions {
+        executable_path: Some(std::path::PathBuf::from(
+            "/definitely/not/a/chromium/binary",
+        )),
+    });
+
+    let result = driver.snapshot(target("https://example.com")).await;
+
+    assert!(matches!(result, Err(CdpError::ChromiumNotFound { .. })));
+    if let Err(CdpError::ChromiumNotFound { install_hint }) = result {
+        assert!(install_hint.contains("--executable-path"));
+    }
 }
 
 #[test]

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use plumb_cdp::{BrowserDriver, FakeDriver, Target, is_fake_url};
+use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, FakeDriver, Target, is_fake_url};
 use plumb_core::{Config, Severity, ViewportKey};
 
 use crate::commands::OutputFormat;
@@ -15,14 +15,13 @@ use crate::commands::OutputFormat;
 pub async fn run(
     url: String,
     config_path: Option<PathBuf>,
+    executable_path: Option<PathBuf>,
     format: OutputFormat,
 ) -> Result<ExitCode> {
     tracing::debug!(url = %url, format = %format, "lint");
 
     let config = load_config(config_path.as_deref())?;
 
-    // Walking skeleton: real driver returns NotImplemented. Use the fake
-    // driver when the URL scheme matches; error out for real URLs.
     let snapshot = if is_fake_url(&url) {
         let driver = FakeDriver;
         let target = Target {
@@ -34,9 +33,15 @@ pub async fn run(
         };
         driver.snapshot(target).await.map_err(anyhow::Error::from)?
     } else {
-        anyhow::bail!(
-            "real URLs are not yet supported by the walking skeleton; use `plumb-fake://hello` to smoke-test the pipeline. The real Chromium driver lands in PR #2."
-        );
+        let driver = ChromiumDriver::new(ChromiumOptions { executable_path });
+        let target = Target {
+            url: url.clone(),
+            viewport: ViewportKey::new("desktop"),
+            width: 1280,
+            height: 800,
+            device_pixel_ratio: 1.0,
+        };
+        driver.snapshot(target).await.map_err(anyhow::Error::from)?
     };
 
     let violations = plumb_core::run(&snapshot, &config);

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -47,11 +47,14 @@ enum Command {
     /// Lint a URL against your design-system spec.
     Lint {
         /// URL to lint. The `plumb-fake://hello` scheme exercises the
-        /// walking skeleton; real URLs require the CDP driver (PR #2).
+        /// deterministic fake driver.
         url: String,
         /// Path to the config file. Defaults to `plumb.toml` in CWD.
         #[arg(long, short = 'c')]
         config: Option<PathBuf>,
+        /// Explicit Chrome or Chromium executable path.
+        #[arg(long, value_name = "PATH")]
+        executable_path: Option<PathBuf>,
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Pretty)]
         format: Format,
@@ -108,8 +111,9 @@ fn run(cli: Cli) -> Result<ExitCode> {
             Command::Lint {
                 url,
                 config,
+                executable_path,
                 format,
-            } => commands::lint::run(url, config, format.into()).await,
+            } => commands::lint::run(url, config, executable_path, format.into()).await,
             Command::Init { force } => commands::init::run(force),
             Command::Explain { rule } => commands::explain::run(&rule),
             Command::Schema => commands::schema::run(),

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -4,67 +4,89 @@ use assert_cmd::Command;
 use predicates::str::contains;
 
 #[test]
-fn lint_fake_url_emits_one_violation() {
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
+fn lint_fake_url_emits_one_violation() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello"])
         .assert()
         .code(3) // warning-only -> exit 3
         .stdout(contains("placeholder/hello-world"));
+    Ok(())
 }
 
 #[test]
-fn lint_fake_url_json_format() {
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
+fn lint_fake_url_json_format() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "json"])
         .assert()
         .code(3)
         .stdout(contains("\"rule_id\""));
+    Ok(())
 }
 
 #[test]
-fn lint_real_url_is_not_implemented() {
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
-        .args(["lint", "https://plumb.aramhammoudeh.com"])
+fn lint_real_url_with_missing_executable_path_reports_chromium_hint()
+-> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "https://plumb.aramhammoudeh.com",
+            "--executable-path",
+            "/definitely/not/a/chromium/binary",
+        ])
         .assert()
         .code(2)
-        .stderr(contains("walking skeleton"));
+        .stderr(contains("Chromium executable not found"))
+        .stderr(contains("--executable-path"));
+    Ok(())
 }
 
 #[test]
-fn schema_outputs_json_schema() {
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
+fn lint_fake_url_ignores_executable_path_override() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--executable-path",
+            "/definitely/not/a/chromium/binary",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("placeholder/hello-world"));
+    Ok(())
+}
+
+#[test]
+fn schema_outputs_json_schema() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
         .arg("schema")
         .assert()
         .success()
         .stdout(contains("\"$schema\""))
         .stdout(contains("viewports"));
+    Ok(())
 }
 
 #[test]
-fn explain_placeholder_rule() {
+fn explain_placeholder_rule() -> Result<(), Box<dyn std::error::Error>> {
     // `plumb explain` resolves docs relative to CWD. Run it from the
     // workspace root so it can find docs/src/rules/...
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..");
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
+    Command::cargo_bin("plumb")?
         .args(["explain", "placeholder/hello-world"])
         .current_dir(workspace_root)
         .assert()
         .success();
+    Ok(())
 }
 
 #[test]
-fn help_runs() {
-    Command::cargo_bin("plumb")
-        .expect("plumb binary")
+fn help_runs() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
         .arg("--help")
         .assert()
         .success()
         .stdout(contains("Deterministic"));
+    Ok(())
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [CLI](./cli.md)
 - [MCP server](./mcp.md)
 - [Configuration](./configuration.md)
+- [Install Chromium](./install-chromium.md)
 
 # Rules
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -6,12 +6,14 @@ The `plumb` binary is the primary entry point for developers and CI.
 
 ### `plumb lint <url>`
 
-Lint a URL. The walking skeleton supports the `plumb-fake://hello` URL
-scheme for end-to-end testing — the real Chromium driver lands in PR #2.
+Lint a URL. The `plumb-fake://hello` URL scheme is still available for
+local smoke tests. Real URLs require a Chrome or Chromium binary that
+matches Plumb's pinned Chromium major version.
 
 | Flag | Description |
 |------|-------------|
 | `-c`, `--config <path>` | Config file path. Defaults to `plumb.toml` in CWD. |
+| `--executable-path <path>` | Chrome or Chromium binary to use instead of auto-detection. |
 | `--format <pretty\|json\|sarif>` | Output format. Default: `pretty`. |
 | `-v`, `--verbose` | Increase log verbosity. `-vv` for trace. |
 

--- a/docs/src/install-chromium.md
+++ b/docs/src/install-chromium.md
@@ -1,0 +1,70 @@
+# Install Chromium
+
+Plumb drives Chrome or Chromium through the Chrome DevTools Protocol. The
+browser is not bundled with the `plumb` binary.
+
+Plumb currently pins Chromium major version 131. If the detected browser
+reports a different major version, `plumb lint` exits with an unsupported
+Chromium error instead of producing lint output.
+
+## macOS
+
+Install Chrome or Chromium:
+
+```bash
+brew install --cask google-chrome
+```
+
+Plumb checks common app locations such as:
+
+```text
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+/Applications/Chromium.app/Contents/MacOS/Chromium
+```
+
+To use a specific binary:
+
+```bash
+plumb lint https://example.com --executable-path "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+
+## Linux
+
+Install Chromium from your distribution packages:
+
+```bash
+sudo apt-get update
+sudo apt-get install chromium
+```
+
+Package names vary by distribution. On Debian or Ubuntu systems the binary
+is usually `chromium`, `chromium-browser`, or `google-chrome-stable`.
+
+To use a specific binary:
+
+```bash
+plumb lint https://example.com --executable-path /usr/bin/chromium
+```
+
+## Windows
+
+Install Chrome from the official installer, or install Chromium with a package
+manager you already use. Plumb checks the standard Chrome app registration and
+common install paths.
+
+To use a specific binary:
+
+```powershell
+plumb lint https://example.com --executable-path "C:\Program Files\Google\Chrome\Application\chrome.exe"
+```
+
+## Check the version
+
+Run the browser directly to confirm its major version:
+
+```bash
+chromium --version
+```
+
+The first number in the version must be `131`. If you have several Chrome or
+Chromium builds installed, pass `--executable-path` to select the matching one.


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #11

## Summary

- Adds `ChromiumDriver` launch support with BYO executable path override and stable Chrome/Chromium detection.
- Validates the detected browser major version against `PINNED_CHROMIUM_MAJOR` and returns typed `CdpError` variants with install guidance.
- Wires `plumb lint --executable-path` through the CLI and documents Chromium installation per OS.

## Crates touched

- [x] `plumb-core`
- [x] `plumb-format`
- [x] `plumb-cdp`
- [ ] `plumb-config`
- [x] `plumb-mcp`
- [x] `plumb-cli`
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [x] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [x] Dependency added / bumped (cargo-deny must still pass)
- [x] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `just validate` passes locally
- [ ] `cargo xtask pre-release` passes (if rule or schema changed)
- [x] `just determinism-check` passes (3x byte-diff clean)
- [x] `cargo deny check` passes
- [x] New/changed behavior has a test (unit, golden snapshot, or integration)

## Documentation

- [x] Rustdoc added for every new public item
- [x] `# Errors` section on every new public fallible fn
- [x] `docs/src/` updated when user-visible behavior changed
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [x] Humanizer skill run on docs changes

## Breaking change?

- [x] No
- [ ] Yes — describe migration path


## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/<primary>-<type>-<slug>`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [x] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

DOMSnapshot conversion remains out of scope for this issue and is still tracked by Issue #15; after successful Chromium launch/version validation, the real driver returns `CdpError::NotImplemented` until that lands.
