### PR TITLE
chore(ci): lts dep refresh — rmcp 1.5, schemars 1.x, toml 1.1, thiserror 2, msrv 1.95

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,17 +12,11 @@ updates:
       - aram-devdocs
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     groups:
       patch-and-minor:
         update-types:
           - patch
           - minor
-    ignore:
-      # Major version bumps of chromiumoxide/rmcp require coordinated
-      # testing against a real Chromium build. Surface them via manual PRs.
-      - dependency-name: chromiumoxide
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
           if-no-files-found: ignore
 
   msrv:
-    name: MSRV (1.85)
+    name: MSRV (1.95)
     needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: cargo check
         run: cargo check --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -53,7 +53,7 @@ jobs:
         run: cargo nextest run --workspace --all-features --profile ci
       - name: Upload junit
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.os }}
           path: target/nextest/ci/junit.xml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: cargo check
@@ -77,10 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - name: just determinism-check
         run: just determinism-check
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -98,7 +98,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo llvm-cov
         run: cargo llvm-cov --workspace --all-features --lcov --output-path coverage.lcov
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           files: coverage.lcov
           fail_ci_if_error: false
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build release binary
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
 
   docs:
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: peaceiris/actions-mdbook@v2
@@ -152,7 +152,7 @@ jobs:
         run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: book
           path: book/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
@@ -35,7 +35,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ (github.ref_type == 'tag' && github.ref_name) || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-dist
         run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
@@ -44,7 +44,7 @@ jobs:
           echo "manifest<<EOF" >> "$GITHUB_OUTPUT"
           echo "$manifest" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan
           path: dist-manifest.json
@@ -72,7 +72,7 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -88,10 +88,10 @@ jobs:
       - name: cargo dist build
         shell: bash
         run: cargo dist build --tag "${{ github.ref_name }}" --target ${{ matrix.target }}
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/distrib/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-${{ matrix.target }}
           path: target/distrib/
@@ -102,8 +102,8 @@ jobs:
     needs: [plan, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           path: target/distrib/
           pattern: artifacts-*
@@ -113,7 +113,7 @@ jobs:
       - run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
       - name: cargo dist build installers
         run: cargo dist build --tag "${{ github.ref_name }}" --artifacts=global
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-installers
           path: target/distrib/
@@ -123,8 +123,8 @@ jobs:
     needs: [plan, build, installers]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           path: target/distrib/
           pattern: artifacts-*

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing. This document covers prerequisites, th
 
 ## Prerequisites
 
-- **Rust 1.85+** via [rustup](https://rustup.rs/). The `rust-toolchain.toml` pins the exact version; rustup will install it automatically when you run any cargo command.
+- **Rust 1.95+** via [rustup](https://rustup.rs/). The `rust-toolchain.toml` pins the exact version; rustup will install it automatically when you run any cargo command.
 - **[`just`](https://github.com/casey/just)** — task runner. Install with `cargo install just` or `brew install just`.
 - **[`lefthook`](https://github.com/evilmartians/lefthook)** — git hooks. Install with `brew install lefthook` (macOS/Linux) or `scoop install lefthook` (Windows).
 - **Chromium** — required at runtime by the CDP driver (later PRs). Not needed for the walking skeleton.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -1266,7 +1266,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1415,7 +1415,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1964,6 +1964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2129,7 +2138,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2139,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2264,9 +2273,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2279,6 +2303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,10 +2319,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2297,6 +2339,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2895,6 +2943,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
  "chromiumoxide",
  "futures-util",
  "plumb-core",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1414,7 +1414,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -1432,7 +1432,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1454,7 +1454,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3014,7 +3014,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -491,11 +491,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -505,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1739,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.10.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b18323edc657390a6ed4d7a9110b0dec2dc3ed128eb2a123edfbafabdbddc5"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64",
@@ -1761,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.10.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75d0a62676bf8c8003c4e3c348e2ceb6a7b3e48323681aaf177fdccdac2ce50"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,12 +799,6 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1057,17 +1051,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -1409,7 +1392,7 @@ dependencies = [
  "figment",
  "miette",
  "plumb-core",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1423,13 +1406,13 @@ name = "plumb-core"
 version = "0.0.1"
 dependencies = [
  "ahash",
- "indexmap 2.14.0",
+ "indexmap",
  "insta",
  "miette",
  "palette",
  "proptest",
  "rayon",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1767,7 +1750,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1847,42 +1830,17 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "indexmap",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -1950,6 +1908,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1993,7 +1952,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2284,7 +2243,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -2317,7 +2276,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -2689,7 +2648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2702,7 +2661,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -3000,7 +2959,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3031,7 +2990,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -3050,7 +3009,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,8 @@ plumb-mcp = { path = "crates/plumb-mcp", version = "0.0.1" }
 # CDP driver.
 chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
 
-# MCP SDK. rmcp 0.10 moved its macro stack from unmaintained `paste`
-# to maintained `pastey`.
-rmcp = { version = "0.10", default-features = false, features = ["base64", "macros", "server", "transport-io", "schemars"] }
+# MCP SDK.
+rmcp = { version = "1.5", default-features = false, features = ["base64", "macros", "server", "transport-io", "schemars"] }
 
 # Async runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "sync", "time", "fs", "process"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ figment = { version = "0.10", features = ["toml", "yaml", "json", "env"] }
 
 # Diagnostics.
 miette = { version = "7", features = ["fancy"] }
-thiserror = "1"
+thiserror = "2"
 anyhow = "1"
 
 # Observability.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 authors = ["Aram Hammoudeh <aram.devdocs@gmail.com>"]
 homepage = "https://plumb.aramhammoudeh.com"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 # Serialization.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "1"
 serde_yaml = "0.9"
 
 # Schema emission.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ toml = "1"
 serde_yaml = "0.9"
 
 # Schema emission.
-schemars = { version = "0.8", features = ["indexmap2", "preserve_order"] }
+schemars = { version = "1", features = ["indexmap2", "preserve_order"] }
 
 # Config loading.
 figment = { version = "0.10", features = ["toml", "yaml", "json", "env"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml/badge.svg)](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.95+](https://img.shields.io/badge/rust-1.95%2B-orange.svg)](https://www.rust-lang.org)
 
 **A deterministic design-system linter for rendered websites.**
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,13 @@
-msrv = "1.85"
+msrv = "1.95"
 too-many-arguments-threshold = 12
 type-complexity-threshold = 500
 avoid-breaking-exported-api = false
+
+# ConfigError::Parse carries miette diagnostic payloads (NamedSource +
+# SourceSpan + boxed ConfigParseSource) that exceed the default 128-byte
+# Result-err budget. Bumping the threshold keeps rich diagnostics without
+# pushing the whole ConfigError behind a Box at every call site.
+large-error-threshold = 512
 
 # Tests are allowed to unwrap/expect/panic — assertions are how tests fail.
 # Production code still denies these via workspace lints.

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -246,10 +246,10 @@ impl ChromiumSession {
 
     async fn abort_handler(&mut self) {
         self.handler_task.abort();
-        if let Err(join_err) = (&mut self.handler_task).await {
-            if !join_err.is_cancelled() {
-                tracing::debug!(error = %join_err, "Chromium handler task failed");
-            }
+        if let Err(join_err) = (&mut self.handler_task).await
+            && !join_err.is_cancelled()
+        {
+            tracing::debug!(error = %join_err, "Chromium handler task failed");
         }
     }
 }

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -54,9 +54,9 @@ fn send_and_read(requests: Vec<Value>) -> Vec<Value> {
         if trimmed.is_empty() {
             continue;
         }
-        match serde_json::from_str::<Value>(trimmed) {
-            Ok(v) => responses.push(v),
-            Err(_) => continue, // log lines from tracing
+        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+            // log lines from tracing are skipped silently
+            responses.push(v);
         }
     }
 

--- a/crates/plumb-config/src/lib.rs
+++ b/crates/plumb-config/src/lib.rs
@@ -59,7 +59,7 @@ pub enum ConfigError {
         path: String,
         /// Underlying parse error.
         #[source]
-        source: ConfigParseSource,
+        source: Box<ConfigParseSource>,
         /// Source text for span-annotated diagnostics.
         #[source_code]
         source_code: Option<NamedSource<String>>,
@@ -109,7 +109,7 @@ fn extract_config(figment: &Figment, path: &Path) -> Result<Config, ConfigError>
         .extract::<Config>()
         .map_err(|source| ConfigError::Parse {
             path: config_error_path(&source).unwrap_or_else(|| path.display().to_string()),
-            source: ConfigParseSource::Figment(source),
+            source: Box::new(ConfigParseSource::Figment(source)),
             source_code: None,
             span: None,
         })
@@ -125,7 +125,7 @@ fn load_toml(path: &Path) -> Result<Config, ConfigError> {
         let span = source.span().and_then(source_span);
         ConfigError::Parse {
             path: path.display().to_string(),
-            source: ConfigParseSource::Toml(source),
+            source: Box::new(ConfigParseSource::Toml(source)),
             source_code: Some(
                 NamedSource::new(path.display().to_string(), contents).with_language("toml"),
             ),

--- a/crates/plumb-config/tests/load_example.rs
+++ b/crates/plumb-config/tests/load_example.rs
@@ -99,9 +99,9 @@ fn schema_uses_prd_names_and_drops_old_aliases() {
     assert!(properties.contains_key("type"));
     assert!(!properties.contains_key("type_scale"));
 
-    let definitions = schema_json["definitions"]
+    let definitions = schema_json["$defs"]
         .as_object()
-        .expect("schema definitions should be an object");
+        .expect("schema $defs should be an object");
     let spacing_props = definitions["SpacingSpec"]["properties"]
         .as_object()
         .expect("spacing properties should be an object");

--- a/crates/plumb-format/src/lib.rs
+++ b/crates/plumb-format/src/lib.rs
@@ -19,6 +19,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+use std::fmt::Write as _;
+
 use plumb_core::{Severity, Violation};
 use serde_json::{Value, json};
 
@@ -32,18 +34,19 @@ pub fn pretty(violations: &[Violation]) -> String {
     }
     let mut out = String::new();
     for v in violations {
-        out.push_str(&format!(
-            "{level:>7} {rule}\n         at {selector} [{viewport}]\n         {msg}\n",
+        let _ = writeln!(
+            out,
+            "{level:>7} {rule}\n         at {selector} [{viewport}]\n         {msg}",
             level = v.severity.label(),
             rule = v.rule_id,
             selector = v.selector,
             viewport = v.viewport.as_str(),
             msg = v.message,
-        ));
+        );
         if let Some(fix) = &v.fix {
-            out.push_str(&format!("         fix: {}\n", fix.description));
+            let _ = writeln!(out, "         fix: {}", fix.description);
         }
-        out.push_str(&format!("         docs: {}\n\n", v.doc_url));
+        let _ = writeln!(out, "         docs: {}\n", v.doc_url);
     }
     out.push_str(&summary_line(violations));
     out.push('\n');
@@ -125,14 +128,15 @@ pub fn sarif(violations: &[Violation]) -> Result<String, serde_json::Error> {
 pub fn mcp_compact(violations: &[Violation]) -> (String, Value) {
     let mut text = String::new();
     for v in violations {
-        text.push_str(&format!(
-            "{severity} {rule} @ {selector} [{viewport}]: {message}\n",
+        let _ = writeln!(
+            text,
+            "{severity} {rule} @ {selector} [{viewport}]: {message}",
             severity = v.severity.label(),
             rule = v.rule_id,
             selector = v.selector,
             viewport = v.viewport.as_str(),
             message = v.message,
-        ));
+        );
     }
     if violations.is_empty() {
         text.push_str("ok: 0 violations\n");

--- a/crates/plumb-format/tests/snapshots/format_snapshots__mcp_compact_structured.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__mcp_compact_structured.snap
@@ -1,39 +1,40 @@
 ---
 source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 34
 expression: structured
 ---
 {
-  "counts": {
-    "error": 0,
-    "info": 0,
-    "total": 1,
-    "warning": 1
-  },
   "violations": [
     {
-      "doc_url": "https://plumb.aramhammoudeh.com/rules/placeholder-hello-world",
+      "rule_id": "placeholder/hello-world",
+      "severity": "warning",
+      "message": "`body` has off-scale padding 13px; expected a value from the spacing token set.",
+      "selector": "html > body",
+      "viewport": "desktop",
+      "rect": {
+        "x": 0,
+        "y": 0,
+        "width": 1280,
+        "height": 800
+      },
       "dom_order": 2,
       "fix": {
-        "confidence": "medium",
-        "description": "Snap `body` padding to the nearest spacing token (16px).",
         "kind": {
-          "from": "13px",
           "kind": "css_property_replace",
           "property": "padding",
+          "from": "13px",
           "to": "16px"
-        }
+        },
+        "description": "Snap `body` padding to the nearest spacing token (16px).",
+        "confidence": "medium"
       },
-      "message": "`body` has off-scale padding 13px; expected a value from the spacing token set.",
-      "rect": {
-        "height": 800,
-        "width": 1280,
-        "x": 0,
-        "y": 0
-      },
-      "rule_id": "placeholder/hello-world",
-      "selector": "html > body",
-      "severity": "warning",
-      "viewport": "desktop"
+      "doc_url": "https://plumb.aramhammoudeh.com/rules/placeholder-hello-world"
     }
-  ]
+  ],
+  "counts": {
+    "error": 0,
+    "warning": 1,
+    "info": 0,
+    "total": 1
+  }
 }

--- a/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
@@ -1,14 +1,27 @@
 ---
 source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 27
 expression: out
 ---
 {
   "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
   "runs": [
     {
+      "tool": {
+        "driver": {
+          "name": "plumb",
+          "informationUri": "https://plumb.aramhammoudeh.com",
+          "rules": []
+        }
+      },
       "results": [
         {
+          "ruleId": "placeholder/hello-world",
           "level": "warning",
+          "message": {
+            "text": "`body` has off-scale padding 13px; expected a value from the spacing token set."
+          },
           "locations": [
             {
               "logicalLocations": [
@@ -18,28 +31,16 @@ expression: out
                 }
               ],
               "properties": {
-                "domOrder": 2,
-                "viewport": "desktop"
+                "viewport": "desktop",
+                "domOrder": 2
               }
             }
           ],
-          "message": {
-            "text": "`body` has off-scale padding 13px; expected a value from the spacing token set."
-          },
           "properties": {
             "docUrl": "https://plumb.aramhammoudeh.com/rules/placeholder-hello-world"
-          },
-          "ruleId": "placeholder/hello-world"
+          }
         }
-      ],
-      "tool": {
-        "driver": {
-          "informationUri": "https://plumb.aramhammoudeh.com",
-          "name": "plumb",
-          "rules": []
-        }
-      }
+      ]
     }
-  ],
-  "version": "2.1.0"
+  ]
 }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -19,7 +19,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
-use std::{borrow::Cow, io, sync::Arc};
+use std::io;
 
 use plumb_core::{Config, PlumbSnapshot, run};
 use plumb_format::mcp_compact;
@@ -27,8 +27,8 @@ use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
     handler::server::tool::schema_for_type,
     model::{
-        CallToolRequestParam, CallToolResult, Content, ErrorData, Implementation, JsonObject,
-        ListToolsResult, PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation, JsonObject,
+        ListToolsResult, PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo,
         Tool,
     },
     schemars::{self, JsonSchema},
@@ -91,38 +91,29 @@ impl PlumbServer {
         let config = Config::default();
         let violations = run(&snapshot, &config);
         let (text, structured) = mcp_compact(&violations);
-        Ok(CallToolResult {
-            content: vec![Content::text(text)],
-            structured_content: Some(structured),
-            is_error: Some(false),
-            meta: None,
-        })
+        let mut result = CallToolResult::success(vec![Content::text(text)]);
+        result.structured_content = Some(structured);
+        Ok(result)
     }
 }
 
 impl ServerHandler for PlumbServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "plumb".into(),
-                title: None,
-                version: env!("CARGO_PKG_VERSION").into(),
-                icons: None,
-                website_url: None,
-            },
-            instructions: Some(
-                "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
-                 use `echo` to smoke-test the transport."
-                    .into(),
-            ),
-        }
+        let mut info = ServerInfo::default();
+        info.protocol_version = ProtocolVersion::V_2024_11_05;
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.server_info = Implementation::new("plumb", env!("CARGO_PKG_VERSION"));
+        info.instructions = Some(
+            "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
+             use `echo` to smoke-test the transport."
+                .into(),
+        );
+        info
     }
 
     async fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let arguments = request.arguments.unwrap_or_default();
@@ -138,7 +129,7 @@ impl ServerHandler for PlumbServer {
 
     fn list_tools(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, ErrorData>> + Send + '_ {
         let tools = vec![
@@ -166,18 +157,9 @@ where
 
 fn tool_descriptor<T>(name: &'static str, description: &'static str) -> Tool
 where
-    T: JsonSchema,
+    T: JsonSchema + 'static,
 {
-    Tool {
-        name: Cow::Borrowed(name),
-        title: None,
-        description: Some(Cow::Borrowed(description)),
-        input_schema: Arc::new(schema_for_type::<T>()),
-        output_schema: None,
-        annotations: None,
-        icons: None,
-        meta: None,
-    }
+    Tool::new(name, description, schema_for_type::<T>())
 }
 
 /// Run the MCP server on stdin/stdout until EOF.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/schemas/plumb.toml.json
+++ b/schemas/plumb.toml.json
@@ -1,129 +1,105 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Config",
   "description": "Top-level Plumb configuration.\n\n`Eq` is not derived — several sub-structs carry `f32` fields.",
   "type": "object",
   "properties": {
     "viewports": {
       "description": "Named viewports to snapshot the page at.",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/ViewportSpec"
-      }
+        "$ref": "#/$defs/ViewportSpec"
+      },
+      "default": {}
     },
     "spacing": {
-      "description": "Spacing spec — the allowed discrete values for `gap`, `margin`, `padding`, etc.",
+      "description": "Spacing spec — the allowed discrete values for `gap`, `margin`,\n`padding`, etc.",
+      "$ref": "#/$defs/SpacingSpec",
       "default": {
         "base_unit": 4,
         "scale": [],
         "tokens": {}
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/SpacingSpec"
-        }
-      ]
+      }
     },
     "type": {
       "description": "Type scale spec.",
+      "$ref": "#/$defs/TypeScaleSpec",
       "default": {
         "families": [],
+        "weights": [],
         "scale": [],
-        "tokens": {},
-        "weights": []
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/TypeScaleSpec"
-        }
-      ]
+        "tokens": {}
+      }
     },
     "color": {
       "description": "Color palette spec.",
+      "$ref": "#/$defs/ColorSpec",
       "default": {
-        "delta_e_tolerance": 0.0,
-        "tokens": {}
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ColorSpec"
-        }
-      ]
+        "tokens": {},
+        "delta_e_tolerance": 0.0
+      }
     },
     "radius": {
       "description": "Border-radius spec.",
+      "$ref": "#/$defs/RadiusSpec",
       "default": {
         "allowed_px": []
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/RadiusSpec"
-        }
-      ]
+      }
     },
     "alignment": {
       "description": "Alignment / layout spec.",
+      "$ref": "#/$defs/AlignmentSpec",
       "default": {
         "grid_columns": null,
         "gutter_px": null
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/AlignmentSpec"
-        }
-      ]
+      }
     },
     "a11y": {
       "description": "Accessibility spec.",
+      "$ref": "#/$defs/A11ySpec",
       "default": {
         "min_contrast_ratio": null
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/A11ySpec"
-        }
-      ]
+      }
     },
     "rules": {
       "description": "Per-rule overrides — severity bumps, enable/disable.",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/RuleOverride"
-      }
+        "$ref": "#/$defs/RuleOverride"
+      },
+      "default": {}
     }
   },
   "additionalProperties": false,
-  "definitions": {
+  "$defs": {
     "ViewportSpec": {
       "description": "Specification of a single named viewport.",
       "type": "object",
-      "required": [
-        "height",
-        "width"
-      ],
       "properties": {
         "width": {
           "description": "Width in CSS pixels.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "height": {
           "description": "Height in CSS pixels.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "device_pixel_ratio": {
           "description": "Device pixel ratio. Defaults to 1.0.",
-          "default": 1.0,
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "default": 1.0
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "width",
+        "height"
+      ]
     },
     "SpacingSpec": {
       "description": "Spacing spec.",
@@ -131,30 +107,30 @@
       "properties": {
         "base_unit": {
           "description": "Base unit in pixels; discrete scale is multiples of this.",
-          "default": 4,
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0,
+          "default": 4
         },
         "scale": {
           "description": "Allowed spacing values in pixels.",
-          "default": [],
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint32",
-            "minimum": 0.0
-          }
+            "minimum": 0
+          },
+          "default": []
         },
         "tokens": {
           "description": "Named tokens mapped to their pixel values.",
-          "default": {},
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "uint32",
-            "minimum": 0.0
-          }
+            "minimum": 0
+          },
+          "default": {}
         }
       },
       "additionalProperties": false
@@ -165,41 +141,42 @@
       "properties": {
         "families": {
           "description": "Allowed font families.",
-          "default": [],
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "default": []
         },
         "weights": {
           "description": "Allowed font weights.",
-          "default": [],
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
-          }
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "default": []
         },
         "scale": {
           "description": "Allowed font sizes in pixels.",
-          "default": [],
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint32",
-            "minimum": 0.0
-          }
+            "minimum": 0
+          },
+          "default": []
         },
         "tokens": {
           "description": "Named type tokens mapped to their pixel values.",
-          "default": {},
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "uint32",
-            "minimum": 0.0
-          }
+            "minimum": 0
+          },
+          "default": {}
         }
       },
       "additionalProperties": false
@@ -210,17 +187,17 @@
       "properties": {
         "tokens": {
           "description": "Named tokens mapped to hex values (e.g. `#0b7285`).",
-          "default": {},
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "default": {}
         },
         "delta_e_tolerance": {
           "description": "CIEDE2000 Delta-E tolerance when matching off-palette colors.",
-          "default": 2.0,
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "default": 2.0
         }
       },
       "additionalProperties": false
@@ -231,13 +208,13 @@
       "properties": {
         "allowed_px": {
           "description": "Allowed radii in pixels.",
-          "default": [],
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint32",
-            "minimum": 0.0
-          }
+            "minimum": 0
+          },
+          "default": []
         }
       },
       "additionalProperties": false
@@ -248,23 +225,23 @@
       "properties": {
         "grid_columns": {
           "description": "Grid column count, if the design uses a fixed grid.",
-          "default": null,
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0,
+          "default": null
         },
         "gutter_px": {
           "description": "Container gutter in pixels.",
-          "default": null,
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0,
+          "default": null
         }
       },
       "additionalProperties": false
@@ -275,12 +252,12 @@
       "properties": {
         "min_contrast_ratio": {
           "description": "Minimum contrast ratio to enforce (e.g. `4.5` for WCAG AA body text).",
-          "default": null,
           "type": [
             "number",
             "null"
           ],
-          "format": "float"
+          "format": "float",
+          "default": null
         }
       },
       "additionalProperties": false
@@ -291,47 +268,41 @@
       "properties": {
         "enabled": {
           "description": "Enable or disable the rule entirely.",
-          "default": true,
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "severity": {
           "description": "Override the rule's default severity.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/Severity"
+              "$ref": "#/$defs/Severity"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         }
       },
       "additionalProperties": false
     },
     "Severity": {
-      "description": "How severe a violation is. Maps to CLI exit-code thresholds and to the SARIF `level` field.",
+      "description": "How severe a violation is. Maps to CLI exit-code thresholds and to the\nSARIF `level` field.",
       "oneOf": [
         {
           "description": "Suggestion — ignored by default CI thresholds.",
           "type": "string",
-          "enum": [
-            "info"
-          ]
+          "const": "info"
         },
         {
           "description": "Warning — CI-configurable.",
           "type": "string",
-          "enum": [
-            "warning"
-          ]
+          "const": "warning"
         },
         {
           "description": "Error — fails CI by default.",
           "type": "string",
-          "enum": [
-            "error"
-          ]
+          "const": "error"
         }
       ]
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 description = "Plumb developer task runner — emits schema, regenerates docs, runs pre-release checks."
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

One PR that brings the workspace to the latest stable dep chain, closes out every open dependabot PR (#86-#90), unblocks release-please, and stops the per-push dependabot failure email storm. No ignore rules added — breaking majors are migrated instead.

## What changed

### CI plumbing (root cause fixes)

- **xtask/Cargo.toml** inherits the workspace version (`version.workspace = true`) — unblocks release-please's cargo-workspace plugin.
- **.github/dependabot.yml** drops `include: scope` from the cargo ecosystem block so PR titles emit valid `chore(deps): Bump ...` (was emitting double-scoped `chore(deps)(deps):` that failed the semantic-PR allow-list).
- Existing chromiumoxide ignore removed — per project direction, majors surface as migration PRs rather than silenced risks.

### Dep upgrades

- **MSRV 1.85 -> 1.95** (latest stable). Plumb is pre-alpha (v0.0.1) with no crates.io consumers; bumping is non-breaking externally. 1.95 satisfies darling 0.23's 1.88+ floor transitively required by rmcp 1.x.
- **thiserror 1 -> 2** — drop-in.
- **toml 0.8 -> 1.1.2+spec-1.1.0** — source-compatible for our `from_str` + `Error::span()` usage.
- **schemars 0.8 -> 1.x** — JSON Schema now uses draft 2020-12 (`$defs` not `definitions`); `schemas/plumb.toml.json` regenerated; one test assertion updated; `insta` snapshots reaccepted for the new struct-declaration-order JSON output (deterministic either way).
- **rmcp 0.10 -> 1.5** — non-exhaustive struct migration: `CallToolResult`, `ServerInfo`, `Implementation`, and `Tool` now use constructor APIs instead of struct literals. `schema_for_type<T>` returns `Arc<JsonObject>` in 1.x — dropped the redundant `Arc::new` wrap. Added missing `T: JsonSchema + 'static` bound on `tool_descriptor`.

### GitHub Actions bumps (from dependabot #90, minus the bad rustup jump)

- actions/checkout v4 -> v6
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v8
- actions/attest-build-provenance v1 -> v4
- amannn/action-semantic-pull-request v5 -> v6
- extractions/setup-just v2 -> v4
- codecov/codecov-action v4 -> v6
- googleapis/release-please-action v4 -> v5

### Lint drift from rustc 1.95 stable

- `plumb-format`: `format!(..)` appended to String -> `writeln!` (format_push_string lint).
- `plumb-config`: `ConfigError::Parse.source` now `Box<ConfigParseSource>`; `large-error-threshold` raised to 512 in `clippy.toml` so we can keep the miette diagnostic payload inline.
- `plumb-cdp`: collapsed nested `if let ... if !` into a let-chain.
- `plumb-cli/tests`: dropped a redundant `continue`.

## Closes

Dependabot auto-closes each of these as stale once this PR lands at >= their targeted version:

- #86 (schemars 1.2.1) — landed at 1.x
- #87 (thiserror 2.0.18) — landed at 2.x
- #88 (toml 1.1.2+spec-1.1.0) — landed
- #89 (rmcp 1.5.0) — landed
- #90 (github-actions group) — benign bumps applied; rustup sub-bump deliberately not taken

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features` (39/39)
- [x] `cargo xtask pre-release`
- [x] `cargo deny check`
- [x] `cargo audit`
- [x] `just determinism-check`

## Breaking change?

- [x] Yes — MSRV bumped from 1.85 to 1.95. Workspace is pre-alpha and has no external consumers, so the externally visible impact is limited to CI toolchain pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)