### PR TITLE
fix(ci): drop cargo-workspace plugin from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,12 +17,6 @@
     { "type": "build", "hidden": true },
     { "type": "style", "hidden": true }
   ],
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "merge": true
-    }
-  ],
   "packages": {
     ".": {
       "component": "plumb",


### PR DESCRIPTION
## Summary

The cargo-workspace plugin in release-please fails on member crates that use `version.workspace = true` because it reads each Cargo.toml directly and doesn't resolve workspace inheritance. Result: every release-please run exits with `package manifest at crates/plumb-core/Cargo.toml has an invalid [package.version]`.

Plumb is configured as a single release-please package rooted at "." with a single version tracked in .release-please-manifest.json, so the plugin was doing nothing useful — only blocking the workflow.

## Test plan

- [x] After merge, trigger release-please manually with `gh workflow run release-please.yml` and confirm it either opens a release PR or reports "no releasable changes" (both are success outcomes).