### PR TITLE
fix(ci): use simple release-type with workspace-version extra-file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
@@ -21,8 +21,15 @@
     ".": {
       "component": "plumb",
       "package-name": "plumb",
-      "release-type": "rust",
-      "include-component-in-tag": false
+      "release-type": "simple",
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #99. Removing the `cargo-workspace` plugin wasn't enough — the `rust` release-type itself walks each member's Cargo.toml and rejects `version.workspace = true` with `value at path package.version is not tagged`.

Switch the root package to `release-type: simple` (language-agnostic) and add an `extra-files` entry that rewrites the single `[workspace.package] version = "x.y.z"` line in the root Cargo.toml. Workspace inheritance cascades that version to every member crate automatically — release-please only ever has to touch one file.

## Test plan

- [x] Trigger `release-please.yml` after merge and confirm it either opens a release PR or reports no releasable changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)