### PR TITLE
feat(cli,core,cdp): --viewport flag + viewport multi-run orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "predicates",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -92,6 +92,26 @@ pub trait BrowserDriver: Send + Sync {
         &self,
         target: Target,
     ) -> impl std::future::Future<Output = Result<PlumbSnapshot, CdpError>> + Send;
+
+    /// Snapshot a list of targets, reusing a single browser session
+    /// for the whole batch. The default implementation calls
+    /// [`snapshot`](BrowserDriver::snapshot) per target and is suitable
+    /// for cheap drivers (e.g. [`FakeDriver`]). Real drivers MUST
+    /// override this to launch the browser exactly once per batch.
+    ///
+    /// Snapshots are returned in the same order as `targets`.
+    fn snapshot_all(
+        &self,
+        targets: Vec<Target>,
+    ) -> impl std::future::Future<Output = Result<Vec<PlumbSnapshot>, CdpError>> + Send {
+        async move {
+            let mut out = Vec::with_capacity(targets.len());
+            for target in targets {
+                out.push(self.snapshot(target).await?);
+            }
+            Ok(out)
+        }
+    }
 }
 
 /// Configuration for [`ChromiumDriver`].
@@ -136,13 +156,35 @@ impl ChromiumDriver {
 
 impl BrowserDriver for ChromiumDriver {
     async fn snapshot(&self, target: Target) -> Result<PlumbSnapshot, CdpError> {
-        let config = self.browser_config(&target)?;
+        let mut snapshots = self.snapshot_all(vec![target]).await?;
+        snapshots.pop().ok_or_else(|| {
+            // Unreachable in practice: `snapshot_all` returns one snapshot per
+            // input target on the success path. Treat a violation of that
+            // contract as an internal driver fault rather than panicking.
+            CdpError::Driver(Box::new(io::Error::other(
+                "ChromiumDriver::snapshot_all returned no snapshot for a single target",
+            )))
+        })
+    }
+
+    async fn snapshot_all(&self, targets: Vec<Target>) -> Result<Vec<PlumbSnapshot>, CdpError> {
+        if targets.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Use the first target's dimensions for the initial launch. Once
+        // #15 lands, subsequent viewports will be applied via CDP
+        // `Page.setViewport` between per-target captures.
+        let first = &targets[0];
+        let config = self.browser_config(first)?;
         let mut session = ChromiumSession::launch(config).await?;
 
-        let result = match validate_browser_version(&session.browser).await {
-            Ok(()) => Err(CdpError::NotImplemented),
-            Err(err) => Err(err),
-        };
+        let result: Result<Vec<PlumbSnapshot>, CdpError> =
+            match validate_browser_version(&session.browser).await {
+                // TODO(#15): per-target snapshot via DOMSnapshot.captureSnapshot.
+                Ok(()) => Err(CdpError::NotImplemented),
+                Err(err) => Err(err),
+            };
 
         if let Err(cleanup_err) = session.shutdown().await {
             tracing::debug!(error = %cleanup_err, "failed to clean up Chromium session");
@@ -165,7 +207,11 @@ impl BrowserDriver for FakeDriver {
     #[allow(clippy::unused_async)]
     async fn snapshot(&self, target: Target) -> Result<PlumbSnapshot, CdpError> {
         if target.url == "plumb-fake://hello" {
-            Ok(PlumbSnapshot::canned())
+            let mut snap = PlumbSnapshot::canned();
+            snap.viewport = target.viewport.clone();
+            snap.viewport_width = target.width;
+            snap.viewport_height = target.height;
+            Ok(snap)
         } else {
             Err(CdpError::UnknownFakeUrl(target.url))
         }

--- a/crates/plumb-cdp/tests/snapshot_all_default.rs
+++ b/crates/plumb-cdp/tests/snapshot_all_default.rs
@@ -1,0 +1,39 @@
+//! Default-implementation contract for [`BrowserDriver::snapshot_all`].
+//!
+//! Verifies that the trait's default `snapshot_all` calls `snapshot`
+//! per target in input order and that [`FakeDriver`] is viewport-aware
+//! (carries each target's viewport name and dimensions onto the
+//! returned snapshot).
+
+use plumb_cdp::{BrowserDriver, CdpError, FakeDriver, Target};
+use plumb_core::ViewportKey;
+
+fn target(viewport: &str, width: u32, height: u32) -> Target {
+    Target {
+        url: "plumb-fake://hello".into(),
+        viewport: ViewportKey::new(viewport),
+        width,
+        height,
+        device_pixel_ratio: 1.0,
+    }
+}
+
+#[tokio::test]
+async fn fake_driver_snapshot_all_preserves_target_order_and_viewport() -> Result<(), CdpError> {
+    let driver = FakeDriver;
+    let targets = vec![target("mobile", 375, 812), target("desktop", 1280, 800)];
+
+    let snapshots = driver.snapshot_all(targets).await?;
+
+    assert_eq!(snapshots.len(), 2);
+
+    assert_eq!(snapshots[0].viewport, ViewportKey::new("mobile"));
+    assert_eq!(snapshots[0].viewport_width, 375);
+    assert_eq!(snapshots[0].viewport_height, 812);
+
+    assert_eq!(snapshots[1].viewport, ViewportKey::new("desktop"));
+    assert_eq!(snapshots[1].viewport_width, 1280);
+    assert_eq!(snapshots[1].viewport_height, 800);
+
+    Ok(())
+}

--- a/crates/plumb-cli/Cargo.toml
+++ b/crates/plumb-cli/Cargo.toml
@@ -26,6 +26,7 @@ plumb-mcp = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 miette = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -2,6 +2,11 @@
 //!
 //! Wires CLI → config loader → driver (fake for `plumb-fake://`) →
 //! engine → formatter → stdout.
+//!
+//! The orchestrator builds one [`Target`] per requested viewport and
+//! calls [`BrowserDriver::snapshot_all`] exactly once, so a real
+//! Chromium driver launches the browser only once per CLI invocation
+//! (PRD §10.3).
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -9,42 +14,53 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, FakeDriver, Target, is_fake_url};
 use plumb_core::{Config, Severity, ViewportKey};
+use thiserror::Error;
 
 use crate::commands::OutputFormat;
+
+/// CLI-side errors that never need to leak across the
+/// `commands::lint` boundary. Bubbles up to `main` via `anyhow::Error`,
+/// where `report_error` formats it onto stderr and `main` returns
+/// `ExitCode::from(2)` per PRD §13.3 ("CLI / infrastructure failure").
+#[derive(Debug, Error)]
+enum LintError {
+    /// One or more `--viewport` values were not present in `config.viewports`.
+    /// `unknown` is preserved in flag-input order; `available` is sorted
+    /// alphabetically for stable rendering.
+    #[error("unknown viewport(s): {}. configured viewports: {}", .unknown.join(", "), .available.join(", "))]
+    UnknownViewports {
+        unknown: Vec<String>,
+        available: Vec<String>,
+    },
+}
 
 pub async fn run(
     url: String,
     config_path: Option<PathBuf>,
     executable_path: Option<PathBuf>,
     format: OutputFormat,
+    viewports: Vec<String>,
 ) -> Result<ExitCode> {
-    tracing::debug!(url = %url, format = %format, "lint");
+    tracing::debug!(url = %url, format = %format, viewports = ?viewports, "lint");
 
     let config = load_config(config_path.as_deref())?;
+    let targets = resolve_targets(&url, &config, &viewports).map_err(anyhow::Error::from)?;
 
-    let snapshot = if is_fake_url(&url) {
+    let snapshots = if is_fake_url(&url) {
         let driver = FakeDriver;
-        let target = Target {
-            url: url.clone(),
-            viewport: ViewportKey::new("desktop"),
-            width: 1280,
-            height: 800,
-            device_pixel_ratio: 1.0,
-        };
-        driver.snapshot(target).await.map_err(anyhow::Error::from)?
+        driver
+            .snapshot_all(targets)
+            .await
+            .map_err(anyhow::Error::from)?
     } else {
         let driver = ChromiumDriver::new(ChromiumOptions { executable_path });
-        let target = Target {
-            url: url.clone(),
-            viewport: ViewportKey::new("desktop"),
-            width: 1280,
-            height: 800,
-            device_pixel_ratio: 1.0,
-        };
-        driver.snapshot(target).await.map_err(anyhow::Error::from)?
+        driver
+            .snapshot_all(targets)
+            .await
+            .map_err(anyhow::Error::from)?
     };
 
-    let violations = plumb_core::run(&snapshot, &config);
+    let violations = plumb_core::run_many(snapshots.iter(), &config);
 
     let out = match format {
         OutputFormat::Pretty => plumb_format::pretty(&violations),
@@ -59,6 +75,78 @@ pub async fn run(
     }
 
     Ok(exit_code_for(&violations))
+}
+
+/// Decide which viewports to snapshot.
+///
+/// Three branches:
+///
+/// 1. `config.viewports` is empty → fall back to a single
+///    `desktop` 1280x800 target (the walking-skeleton default that
+///    keeps `plumb lint plumb-fake://hello` working in a fresh
+///    checkout, with or without `--viewport`). Any `viewports_arg`
+///    passed in this mode is ignored: there is no configured set to
+///    filter against, so honoring the flag would silently invent
+///    viewports the user never declared. We deliberately do not
+///    error here — that would regress the no-config quickstart path.
+/// 2. `config.viewports` is non-empty and `viewports_arg` is empty →
+///    one target per configured viewport, in `IndexMap` insertion
+///    order (preserves the determinism invariant).
+/// 3. Both are non-empty → filter the configured set down to the
+///    named viewports. Any unknown name produces
+///    [`LintError::UnknownViewports`].
+fn resolve_targets(
+    url: &str,
+    config: &Config,
+    viewports_arg: &[String],
+) -> Result<Vec<Target>, LintError> {
+    if config.viewports.is_empty() {
+        return Ok(vec![Target {
+            url: url.to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            width: 1280,
+            height: 800,
+            device_pixel_ratio: 1.0,
+        }]);
+    }
+
+    if viewports_arg.is_empty() {
+        return Ok(config
+            .viewports
+            .iter()
+            .map(|(name, spec)| Target {
+                url: url.to_owned(),
+                viewport: ViewportKey::new(name.clone()),
+                width: spec.width,
+                height: spec.height,
+                device_pixel_ratio: spec.device_pixel_ratio,
+            })
+            .collect());
+    }
+
+    let unknown: Vec<String> = viewports_arg
+        .iter()
+        .filter(|name| !config.viewports.contains_key(name.as_str()))
+        .cloned()
+        .collect();
+    if !unknown.is_empty() {
+        let mut available: Vec<String> = config.viewports.keys().cloned().collect();
+        available.sort();
+        return Err(LintError::UnknownViewports { unknown, available });
+    }
+
+    Ok(viewports_arg
+        .iter()
+        .filter_map(|name| {
+            config.viewports.get(name.as_str()).map(|spec| Target {
+                url: url.to_owned(),
+                viewport: ViewportKey::new(name.clone()),
+                width: spec.width,
+                height: spec.height,
+                device_pixel_ratio: spec.device_pixel_ratio,
+            })
+        })
+        .collect())
 }
 
 fn load_config(path: Option<&Path>) -> Result<Config> {
@@ -99,5 +187,118 @@ fn exit_code_for(violations: &[plumb_core::Violation]) -> ExitCode {
         ExitCode::from(3)
     } else {
         ExitCode::SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LintError, resolve_targets};
+    use plumb_core::Config;
+    use plumb_core::config::ViewportSpec;
+
+    fn config_with(viewports: &[(&str, u32, u32)]) -> Config {
+        let mut config = Config::default();
+        for (name, width, height) in viewports {
+            config.viewports.insert(
+                (*name).to_owned(),
+                ViewportSpec {
+                    width: *width,
+                    height: *height,
+                    device_pixel_ratio: 1.0,
+                },
+            );
+        }
+        config
+    }
+
+    #[test]
+    fn empty_config_yields_single_default_desktop_target() {
+        let config = Config::default();
+        let targets = resolve_targets("plumb-fake://hello", &config, &[])
+            .expect("default fallback never errors");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].viewport.as_str(), "desktop");
+        assert_eq!(targets[0].width, 1280);
+        assert_eq!(targets[0].height, 800);
+    }
+
+    /// When `config.viewports` is empty the orchestrator falls back to
+    /// the walking-skeleton default and ignores `--viewport` values
+    /// rather than erroring — there is no configured set to validate
+    /// the names against. Erroring here would regress
+    /// `plumb lint plumb-fake://hello --viewport mobile` in a fresh
+    /// checkout that has no `plumb.toml` yet.
+    #[test]
+    fn empty_config_ignores_viewport_arg_and_returns_default() {
+        let config = Config::default();
+        let targets = resolve_targets("plumb-fake://hello", &config, &["mobile".to_owned()])
+            .expect("flag is ignored when no viewports are configured");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].viewport.as_str(), "desktop");
+    }
+
+    #[test]
+    fn configured_viewports_preserve_indexmap_order() {
+        let config = config_with(&[("mobile", 375, 812), ("desktop", 1280, 800)]);
+        let targets = resolve_targets("plumb-fake://hello", &config, &[]).expect("resolve targets");
+        let names: Vec<&str> = targets.iter().map(|t| t.viewport.as_str()).collect();
+        assert_eq!(names, vec!["mobile", "desktop"]);
+    }
+
+    #[test]
+    fn filter_to_named_viewport_returns_single_target() {
+        let config = config_with(&[("mobile", 375, 812), ("desktop", 1280, 800)]);
+        let targets = resolve_targets("plumb-fake://hello", &config, &["mobile".to_owned()])
+            .expect("mobile is configured");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].viewport.as_str(), "mobile");
+        assert_eq!(targets[0].width, 375);
+    }
+
+    #[test]
+    fn unknown_viewport_lists_available_alphabetically() {
+        let config = config_with(&[("mobile", 375, 812), ("desktop", 1280, 800)]);
+        let err = resolve_targets("plumb-fake://hello", &config, &["bogus".to_owned()])
+            .expect_err("bogus is not configured");
+        match err {
+            LintError::UnknownViewports { unknown, available } => {
+                assert_eq!(unknown, vec!["bogus"]);
+                assert_eq!(available, vec!["desktop", "mobile"]);
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_viewport_reports_only_missing_names() {
+        let config = config_with(&[("mobile", 375, 812), ("desktop", 1280, 800)]);
+        let err = resolve_targets(
+            "plumb-fake://hello",
+            &config,
+            &["mobile".to_owned(), "bogus".to_owned()],
+        )
+        .expect_err("bogus is not configured");
+        match err {
+            LintError::UnknownViewports { unknown, available } => {
+                assert_eq!(unknown, vec!["bogus"]);
+                assert_eq!(available, vec!["desktop", "mobile"]);
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_viewport_preserves_input_order_for_unknown_names() {
+        let config = config_with(&[("mobile", 375, 812), ("desktop", 1280, 800)]);
+        let err = resolve_targets(
+            "plumb-fake://hello",
+            &config,
+            &["bogus".to_owned(), "alpha".to_owned()],
+        )
+        .expect_err("neither name is configured");
+        match err {
+            LintError::UnknownViewports { unknown, available } => {
+                assert_eq!(unknown, vec!["bogus", "alpha"]);
+                assert_eq!(available, vec!["desktop", "mobile"]);
+            }
+        }
     }
 }

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -58,6 +58,13 @@ enum Command {
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Pretty)]
         format: Format,
+        /// Restrict the run to the named viewports (repeatable).
+        ///
+        /// Defaults to every viewport configured in `plumb.toml`, or
+        /// to a single 1280x800 `desktop` viewport when none are
+        /// configured.
+        #[arg(long = "viewport", value_name = "NAME", action = ArgAction::Append)]
+        viewports: Vec<String>,
     },
     /// Write a starter `plumb.toml` to the current directory.
     Init {
@@ -113,7 +120,8 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 config,
                 executable_path,
                 format,
-            } => commands::lint::run(url, config, executable_path, format.into()).await,
+                viewports,
+            } => commands::lint::run(url, config, executable_path, format.into(), viewports).await,
             Command::Init { force } => commands::init::run(force),
             Command::Explain { rule } => commands::explain::run(&rule),
             Command::Schema => commands::schema::run(),

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -1,7 +1,35 @@
 //! End-to-end CLI integration tests via `assert_cmd`.
 
+use std::fs;
+
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
+use tempfile::TempDir;
+
+fn workspace_with_two_viewports() -> Result<TempDir, Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    fs::write(
+        dir.path().join("plumb.toml"),
+        // `body { padding: 13px }` in the canned snapshot makes the
+        // placeholder rule fire at every viewport, so the orchestrator
+        // produces one violation per requested viewport.
+        "[viewports.mobile]\nwidth = 375\nheight = 812\n\n\
+         [viewports.desktop]\nwidth = 1280\nheight = 800\n",
+    )?;
+    Ok(dir)
+}
+
+fn workspace_with_three_viewports() -> Result<TempDir, Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    fs::write(
+        dir.path().join("plumb.toml"),
+        "[viewports.mobile]\nwidth = 375\nheight = 812\n\n\
+         [viewports.desktop]\nwidth = 1280\nheight = 800\n\n\
+         [viewports.tablet]\nwidth = 768\nheight = 1024\n",
+    )?;
+    Ok(dir)
+}
 
 #[test]
 fn lint_fake_url_emits_one_violation() -> Result<(), Box<dyn std::error::Error>> {
@@ -88,5 +116,68 @@ fn help_runs() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .success()
         .stdout(contains("Deterministic"));
+    Ok(())
+}
+
+#[test]
+fn lint_with_unknown_viewport_exits_input_error() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = workspace_with_two_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--viewport", "bogus"])
+        .current_dir(workspace.path())
+        .assert()
+        .code(2)
+        .stderr(contains("bogus"))
+        .stderr(contains("mobile"))
+        .stderr(contains("desktop"));
+    Ok(())
+}
+
+#[test]
+fn lint_runs_every_configured_viewport_when_flag_absent() -> Result<(), Box<dyn std::error::Error>>
+{
+    let workspace = workspace_with_two_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello"])
+        .current_dir(workspace.path())
+        .assert()
+        .code(3)
+        .stdout(contains("placeholder/hello-world"))
+        .stdout(contains("mobile"))
+        .stdout(contains("desktop"));
+    Ok(())
+}
+
+#[test]
+fn lint_filters_to_named_viewport() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = workspace_with_two_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--viewport", "mobile"])
+        .current_dir(workspace.path())
+        .assert()
+        .code(3)
+        .stdout(contains("mobile"))
+        .stdout(contains("desktop").not());
+    Ok(())
+}
+
+#[test]
+fn lint_repeats_viewport_flag() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = workspace_with_three_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--viewport",
+            "mobile",
+            "--viewport",
+            "desktop",
+        ])
+        .current_dir(workspace.path())
+        .assert()
+        .code(3)
+        .stdout(contains("mobile"))
+        .stdout(contains("desktop"))
+        .stdout(contains("tablet").not());
     Ok(())
 }

--- a/crates/plumb-core/src/engine.rs
+++ b/crates/plumb-core/src/engine.rs
@@ -17,10 +17,42 @@ use rayon::prelude::*;
 ///
 /// This function is pure — no wall-clock, no RNG, no environment access.
 /// Running it twice with the same inputs yields byte-identical output.
+///
+/// This is a thin wrapper over [`run_many`] for the single-snapshot case.
 #[must_use]
 pub fn run(snapshot: &PlumbSnapshot, config: &Config) -> Vec<Violation> {
+    run_many([snapshot], config)
+}
+
+/// Run every built-in rule against each snapshot in `snapshots` and
+/// return their merged, sorted, deduplicated violation list.
+///
+/// # Determinism
+///
+/// Output is byte-identical regardless of input order. The merge is
+/// re-sorted by [`Violation::sort_key`] —
+/// `(rule_id, viewport, selector, dom_order)`, the same key the
+/// single-snapshot path uses (see [`run_rules`])
+/// — so a `desktop`-first config and a `mobile`-first config yield
+/// the same `Vec<Violation>`. Like [`run`], this function performs no
+/// I/O, no RNG, and no clock reads.
+#[must_use]
+pub fn run_many<'a, I>(snapshots: I, config: &Config) -> Vec<Violation>
+where
+    I: IntoIterator<Item = &'a PlumbSnapshot>,
+{
     let rules = register_builtin();
-    run_rules(snapshot, config, &rules)
+    let mut buffer: Vec<Violation> = snapshots
+        .into_iter()
+        .flat_map(|snapshot| run_rules(snapshot, config, &rules))
+        .collect();
+
+    // Re-sort across snapshots; `run_rules` already sorts within one
+    // snapshot, but the cross-snapshot merge still needs an outer pass.
+    buffer.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+    buffer.dedup();
+
+    buffer
 }
 
 fn run_rules(snapshot: &PlumbSnapshot, config: &Config, rules: &[Box<dyn Rule>]) -> Vec<Violation> {

--- a/crates/plumb-core/src/engine.rs
+++ b/crates/plumb-core/src/engine.rs
@@ -32,8 +32,8 @@ pub fn run(snapshot: &PlumbSnapshot, config: &Config) -> Vec<Violation> {
 /// Output is byte-identical regardless of input order. The merge is
 /// re-sorted by [`Violation::sort_key`] —
 /// `(rule_id, viewport, selector, dom_order)`, the same key the
-/// single-snapshot path uses (see [`run_rules`])
-/// — so a `desktop`-first config and a `mobile`-first config yield
+/// single-snapshot path uses — so a `desktop`-first config and a
+/// `mobile`-first config yield
 /// the same `Vec<Violation>`. Like [`run`], this function performs no
 /// I/O, no RNG, and no clock reads.
 #[must_use]

--- a/crates/plumb-core/src/lib.rs
+++ b/crates/plumb-core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod snapshot;
 pub mod telemetry;
 
 pub use config::Config;
-pub use engine::run;
+pub use engine::{run, run_many};
 pub use report::{
     Confidence, Fix, FixKind, Rect, RunId, Severity, ViewportKey, Violation, ViolationSink,
 };

--- a/crates/plumb-core/tests/engine_run_many.rs
+++ b/crates/plumb-core/tests/engine_run_many.rs
@@ -1,0 +1,65 @@
+//! Multi-snapshot orchestration: `run_many` aggregates per-viewport
+//! snapshots into one deterministic, sorted, deduped violation list.
+
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, Violation, run_many};
+
+fn snapshot_for(viewport: &str, width: u32, height: u32) -> PlumbSnapshot {
+    let mut snap = PlumbSnapshot::canned();
+    snap.viewport = ViewportKey::new(viewport);
+    snap.viewport_width = width;
+    snap.viewport_height = height;
+    snap
+}
+
+fn keys(violations: &[Violation]) -> Vec<(&str, &str, &str, u64)> {
+    violations.iter().map(Violation::sort_key).collect()
+}
+
+#[test]
+fn run_many_collects_violations_from_every_snapshot() {
+    let mobile = snapshot_for("mobile", 375, 812);
+    let desktop = snapshot_for("desktop", 1280, 800);
+    let config = Config::default();
+
+    let violations = run_many([&mobile, &desktop], &config);
+
+    // Placeholder rule emits exactly one violation per snapshot — we
+    // expect both viewports represented after sort + dedup.
+    assert_eq!(violations.len(), 2);
+
+    let viewports: Vec<&str> = violations.iter().map(|v| v.viewport.as_str()).collect();
+    assert!(viewports.contains(&"mobile"));
+    assert!(viewports.contains(&"desktop"));
+}
+
+#[test]
+fn run_many_sorts_by_rule_id_viewport_selector_dom_order() {
+    let mobile = snapshot_for("mobile", 375, 812);
+    let desktop = snapshot_for("desktop", 1280, 800);
+    let config = Config::default();
+
+    let violations = run_many([&mobile, &desktop], &config);
+
+    // Sort key is (rule_id, viewport, selector, dom_order). Both
+    // violations share rule_id and selector, so viewport breaks the
+    // tie alphabetically: `desktop` < `mobile`.
+    assert_eq!(
+        keys(&violations),
+        vec![
+            ("placeholder/hello-world", "desktop", "html > body", 2_u64,),
+            ("placeholder/hello-world", "mobile", "html > body", 2_u64,),
+        ],
+    );
+}
+
+#[test]
+fn run_many_is_input_order_independent() {
+    let mobile = snapshot_for("mobile", 375, 812);
+    let desktop = snapshot_for("desktop", 1280, 800);
+    let config = Config::default();
+
+    let forward = run_many([&mobile, &desktop], &config);
+    let reverse = run_many([&desktop, &mobile], &config);
+
+    assert_eq!(forward, reverse);
+}


### PR DESCRIPTION
## Target branch

- [x] This PR targets `main`

## Spec

Fixes #16. Part of [#10](https://github.com/aram-devdocs/plumb/issues/10) Phase 1, Gate 2, Batch `1B` (sibling: #15 DOMSnapshot integration).

PRD references: [§10.3 (data flow / per-viewport pipeline)](docs/local/prd.md), §13.3 (exit codes), §15.4 (`plumb lint` flags).

## Summary

- Adds repeatable `--viewport <name>` flag to `plumb lint`. Filters the configured viewport set from `plumb.toml`; absent the flag, every configured viewport runs. Unknown names produce a clear input error (exit 2) listing the available viewports.
- New `BrowserDriver::snapshot_all` trait method with a default fan-out impl. `ChromiumDriver` overrides it so Chromium launches **exactly once per CLI invocation** for the full viewport batch (the per-viewport DOMSnapshot conversion still returns `CdpError::NotImplemented` until #15 lands).
- New `plumb_core::run_many` aggregates rule output across multiple snapshots, re-sorts by `(rule_id, viewport, selector, dom_order)`, and dedups. The existing `exit_code_for` then computes worst-severity-wins across all viewports (AC #4).

## Crates touched

- [x] `plumb-core` — new `run_many` entry point; `run` is now a thin wrapper.
- [ ] `plumb-format`
- [x] `plumb-cdp` — `BrowserDriver::snapshot_all` + viewport-aware `FakeDriver`.
- [ ] `plumb-config`
- [ ] `plumb-mcp`
- [x] `plumb-cli` — `--viewport` flag + orchestrator + `LintError` (`thiserror`).
- [ ] `xtask`
- [ ] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item — `plumb_core::run_many`, `BrowserDriver::snapshot_all`. Both have full rustdoc with `# Determinism` notes; both are infallible-or-`Result` shaped per the existing patterns.
- [ ] New MCP tool
- [ ] New rule
- [x] CDP / browser surface change — `BrowserDriver::snapshot_all` added; security-auditor reviewed.
- [ ] Config schema change
- [ ] Dependency added / bumped — `plumb-cli` adds `thiserror` (workspace dep already in tree); `tempfile` added to `[dev-dependencies]` only.
- [ ] Determinism invariant touched — `run_many` re-sorts + dedups across snapshots; tested input-order-independent.

## Architectural compliance

- [x] Layer discipline holds — `plumb-core` adds no internal deps; `plumb-cdp` still depends only on `plumb-core`; only `plumb-cli` prints.
- [x] Error shape — `LintError` is `thiserror`-derived; `anyhow` only at the orchestrator boundary.
- [x] No new `unwrap`/`expect`/`panic!` in libraries. The unreachable empty-pop case in `ChromiumDriver::snapshot` returns a typed `CdpError::Driver` rather than panicking.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (`IndexMap` throughout).
- [x] No new `#[allow(...)]` annotations.

## Test plan

- [x] `just validate` passes locally (54 tests, 0 failed).
- [ ] `cargo xtask pre-release` (no rule or schema change).
- [x] `just determinism-check` — three byte-identical runs.
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok.
- [x] New tests added:
  - `plumb-core::engine_run_many` — 3 cases (collects-from-every, sort order, input-order independence).
  - `plumb-cdp::snapshot_all_default::fake_driver_snapshot_all_preserves_target_order_and_viewport` — 1 case.
  - `plumb-cli::commands::lint::tests` — 7 cases on `resolve_targets` (default fallback, IndexMap order, filter, unknown-name error shape).
  - `plumb-cli::tests::cli_integration` — 4 new cases covering all four ACs end-to-end.

## Documentation

- [x] Rustdoc on every new public item (`run_many`, `snapshot_all`, `LintError`, the new `Lint::viewports` flag).
- [x] `# Errors` not needed for `run_many` (infallible) or `snapshot_all` (already documented `CdpError`).
- [ ] `docs/src/` — no user-facing book changes in this PR. CLI reference docs for `--viewport` will land alongside the broader CLI docs page in a later PR (humanizer pass deferred to that PR).
- [ ] `docs/src/rules/` — no new rules.
- [x] CHANGELOG — no entry needed; release-please owns it from PR #3 onward.
- [ ] Humanizer skill — not run (no `docs/src/**` changes).

## Breaking change?

- [x] No

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/16-feat-cli-viewport-flag-multirun`
- [x] All review gates passed: spec → quality → architecture → test (+ security).

## Reviewer notes

- The `ChromiumDriver` real path still returns `CdpError::NotImplemented` per #15. This PR's job is the orchestrator + single-launch invariant; the per-viewport DOMSnapshot conversion lands in #15. The two PRs can land in either order — they don't conflict.
- `Config::viewports` is empty by default. The default-fallback path (single `desktop` 1280×800 target) preserves the walking-skeleton quickstart so `plumb lint plumb-fake://hello` works in a fresh checkout. Once a `[viewports.*]` section is added to `plumb.toml`, the bare `plumb lint <url>` command begins running every configured viewport — that's per PRD §10.3.
- Empty-config + `--viewport <name>` arg silently falls back to the default desktop target rather than erroring. This is documented in `resolve_targets`'s rustdoc and asserted by `empty_config_ignores_viewport_arg_and_returns_default`. Erroring would regress the no-config quickstart.
- Unknown-viewport input error returns exit 2 ("CLI / infrastructure failure") per the existing `crates/plumb-cli/CLAUDE.md` mapping. Spec reviewer flagged this as a divergence from PRD §13.3's literal "exit 3 for input errors" but accepted it as consistent with the established CLI convention; if the PRD is canonical, that reconciliation is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
