### PR TITLE
fix: pin HOOK_SESSION_ID to stdin session_id so review gates compose

### DIFF
--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -10,14 +10,28 @@
 #   hook_allow            — emit JSON decision=allow and exit 0
 #   hook_block <reason>   — emit JSON decision=block with reason and exit 0
 #   hook_warn <hook> <msg> — write a stderr warning; never block
+#   hook_read_input       — cat hook input JSON from stdin
+#   hook_init <input>     — promote .session_id from the hook input JSON
+#                           into HOOK_SESSION_ID. Must be called after
+#                           hook_read_input in every hook that touches
+#                           session-scoped state.
 #   hook_read_role        — echo the current role (root|subagent:<name>|empty)
 #   hook_read_review_gates — echo `spec=<verdict>;code=<verdict>` or empty
 
 set -euo pipefail
 
 HOOK_CWD="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-HOOK_SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%s)-$$}"
 HOOK_STATE_DIR="$HOOK_CWD/.claude/state"
+
+# Initial value — prefer $CLAUDE_SESSION_ID when the harness exports it,
+# otherwise a stable per-worktree sentinel. Callers with stdin JSON in
+# hand should follow up with `hook_init "$input"` so state files align
+# across the hook chain. Historically the fallback was `date +%s-$$`,
+# but that produced a fresh id per hook invocation on harnesses that
+# don't export CLAUDE_SESSION_ID (e.g. Claude Desktop on macOS), which
+# broke every cross-hook read (role, review-gates, delegations, Stop
+# cleanup).
+HOOK_SESSION_ID="${CLAUDE_SESSION_ID:-current}"
 
 hook_allow() {
     printf '%s' '{"decision":"allow"}'
@@ -34,6 +48,20 @@ hook_warn() {
     local name="${1:-hook}"
     local msg="${2:-}"
     printf '[%s] %s\n' "$name" "$msg" >&2
+}
+
+hook_read_input() {
+    cat
+}
+
+hook_init() {
+    local input="${1:-}"
+    [ -z "$input" ] && return 0
+    local sid
+    sid="$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)"
+    if [ -n "$sid" ]; then
+        HOOK_SESSION_ID="$sid"
+    fi
 }
 
 hook_read_role() {
@@ -54,9 +82,5 @@ hook_read_review_gates() {
     fi
 }
 
-hook_read_input() {
-    cat
-}
-
-export -f hook_allow hook_block hook_warn hook_read_role hook_read_review_gates hook_read_input
+export -f hook_allow hook_block hook_warn hook_read_role hook_read_review_gates hook_read_input hook_init
 export HOOK_CWD HOOK_SESSION_ID HOOK_STATE_DIR

--- a/.claude/hooks/delegation-guard.sh
+++ b/.claude/hooks/delegation-guard.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
 role="$(hook_read_role)"
 

--- a/.claude/hooks/delegation-tracker.sh
+++ b/.claude/hooks/delegation-tracker.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 agent_type="$(printf '%s' "$input" | jq -r '.tool_input.subagent_type // .tool_input.agent_type // "unknown"' 2>/dev/null || echo unknown)"
 prompt="$(printf '%s' "$input" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)"
 snippet="$(printf '%s' "$prompt" | head -c 120 | tr '\n' ' ')"

--- a/.claude/hooks/plan-completion-guard.sh
+++ b/.claude/hooks/plan-completion-guard.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
+input="$(hook_read_input)"
+hook_init "$input"
+
 HOOK="plan-completion-guard"
 override="$HOOK_STATE_DIR/${HOOK_SESSION_ID}.plan-guard-override"
 

--- a/.claude/hooks/review-gate-guard.sh
+++ b/.claude/hooks/review-gate-guard.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 prompt="$(printf '%s' "$input" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)"
 subagent_type="$(printf '%s' "$input" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null || true)"
 

--- a/.claude/hooks/review-gate-tracker.sh
+++ b/.claude/hooks/review-gate-tracker.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 transcript="$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || true)"
 subagent="$(printf '%s' "$input" | jq -r '.subagent // empty' 2>/dev/null || true)"
 

--- a/.claude/hooks/role-marker.sh
+++ b/.claude/hooks/role-marker.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 agent_type="$(printf '%s' "$input" | jq -r '.agent_type // empty' 2>/dev/null || true)"
 
 if [ -n "$agent_type" ]; then

--- a/.claude/hooks/save-session.sh
+++ b/.claude/hooks/save-session.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
 input="$(hook_read_input)"
+hook_init "$input"
 mkdir -p "$HOOK_STATE_DIR"
 log="$HOOK_STATE_DIR/sessions.log"
 

--- a/.claude/hooks/state-cleanup.sh
+++ b/.claude/hooks/state-cleanup.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_lib.sh"
 
+input="$(hook_read_input)"
+hook_init "$input"
+
 if [ ! -d "$HOOK_STATE_DIR" ]; then
     exit 0
 fi

--- a/.claude/hooks/tests/test_review_gate_session_id.sh
+++ b/.claude/hooks/tests/test_review_gate_session_id.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# End-to-end test for the review-gate session id pinning.
+#
+# Regression test for the bug where HOOK_SESSION_ID fell back to
+# `$(date +%s)-$$` per hook invocation, so review-gate-tracker.sh and
+# review-gate-guard.sh wrote and read different state files and the
+# guard always blocked 03-code-quality-reviewer dispatch even after
+# 02-spec-reviewer approved.
+#
+# Simulates two separate bash processes (as the real harness would)
+# with CLAUDE_SESSION_ID UNSET, pushing a consistent .session_id via
+# the stdin JSON payload that Claude Code always sends.
+
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+STATE_DIR="$REPO_ROOT/.claude/state"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Drop anything we write into the real .claude/state so we don't pollute
+# the developer's session.
+cleanup_state() {
+    local sid="$1"
+    rm -f "$STATE_DIR/${sid}.review-gates" \
+          "$STATE_DIR/${sid}.role" \
+          "$STATE_DIR/${sid}.delegations" 2>/dev/null || true
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+pass() {
+    printf 'PASS: %s\n' "$1"
+}
+
+# --- Fixture: minimal transcript with a spec-reviewer APPROVE verdict.
+transcript="$TMP_DIR/spec-transcript.jsonl"
+cat >"$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"review"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Verdict: APPROVE"}]}}
+EOF
+
+session_id="sess-test-$$"
+cleanup_state "$session_id"
+
+# --- Step 1: run review-gate-tracker.sh in its own shell, no
+# CLAUDE_SESSION_ID exported. It must derive the session from stdin
+# JSON and write to $STATE_DIR/$session_id.review-gates.
+tracker_input="$(jq -n \
+    --arg sid "$session_id" \
+    --arg tp "$transcript" \
+    --arg cwd "$REPO_ROOT" \
+    --arg sub "02-spec-reviewer" \
+    '{session_id: $sid, transcript_path: $tp, cwd: $cwd, subagent: $sub}')"
+
+env -u CLAUDE_SESSION_ID \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    bash "$HOOKS_DIR/review-gate-tracker.sh" <<<"$tracker_input" >/dev/null
+
+gates_file="$STATE_DIR/${session_id}.review-gates"
+[ -f "$gates_file" ] || fail "tracker did not write $gates_file (session_id from stdin was ignored)"
+grep -q 'spec=APPROVE' "$gates_file" || fail "expected spec=APPROVE in $gates_file, got: $(cat "$gates_file")"
+pass "tracker wrote $gates_file with spec=APPROVE"
+
+# --- Step 2: a *different* bash process (new PID, possibly new epoch
+# second) runs review-gate-guard.sh with the same session_id in stdin
+# JSON. It must read the same state file and allow the dispatch.
+guard_input="$(jq -n \
+    --arg sid "$session_id" \
+    --arg cwd "$REPO_ROOT" \
+    '{session_id: $sid, cwd: $cwd, tool_input: {subagent_type: "03-code-quality-reviewer", prompt: "review the code"}}')"
+
+guard_output="$(env -u CLAUDE_SESSION_ID \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    bash "$HOOKS_DIR/review-gate-guard.sh" <<<"$guard_input")"
+
+decision="$(printf '%s' "$guard_output" | jq -r '.decision // empty')"
+[ "$decision" = "allow" ] || fail "guard should have allowed 03-code-quality-reviewer after spec APPROVE, got: $guard_output"
+pass "guard allows 03-code-quality-reviewer after spec APPROVE (cross-process session pinning works)"
+
+# --- Step 3: guard must still block when spec has NOT approved.
+cleanup_state "$session_id"
+
+guard_output="$(env -u CLAUDE_SESSION_ID \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    bash "$HOOKS_DIR/review-gate-guard.sh" <<<"$guard_input")"
+
+decision="$(printf '%s' "$guard_output" | jq -r '.decision // empty')"
+[ "$decision" = "block" ] || fail "guard should have blocked 03-code-quality-reviewer with no prior spec verdict, got: $guard_output"
+pass "guard still blocks 03-code-quality-reviewer when no spec verdict present"
+
+# --- Step 4: fallback path — when neither CLAUDE_SESSION_ID nor
+# .session_id in input is available, both hooks share the stable
+# "current" sentinel so ordering still holds.
+cleanup_state "current"
+
+fallback_tracker_input="$(jq -n \
+    --arg tp "$transcript" \
+    --arg cwd "$REPO_ROOT" \
+    --arg sub "02-spec-reviewer" \
+    '{transcript_path: $tp, cwd: $cwd, subagent: $sub}')"
+
+env -u CLAUDE_SESSION_ID \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    bash "$HOOKS_DIR/review-gate-tracker.sh" <<<"$fallback_tracker_input" >/dev/null
+
+[ -f "$STATE_DIR/current.review-gates" ] || fail "fallback tracker did not write $STATE_DIR/current.review-gates"
+
+fallback_guard_input="$(jq -n \
+    --arg cwd "$REPO_ROOT" \
+    '{cwd: $cwd, tool_input: {subagent_type: "03-code-quality-reviewer", prompt: "review"}}')"
+
+guard_output="$(env -u CLAUDE_SESSION_ID \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    bash "$HOOKS_DIR/review-gate-guard.sh" <<<"$fallback_guard_input")"
+
+decision="$(printf '%s' "$guard_output" | jq -r '.decision // empty')"
+[ "$decision" = "allow" ] || fail "fallback path: guard should allow 03-code-quality-reviewer, got: $guard_output"
+pass "fallback (no session_id anywhere) shares stable 'current' id"
+
+cleanup_state "current"
+cleanup_state "$session_id"
+pass "all review-gate session id tests passed"


### PR DESCRIPTION
## Summary

The review-gate hook chain (`review-gate-tracker.sh` on `SubagentStop` → `review-gate-guard.sh` on `PreToolUse`) relied on `HOOK_SESSION_ID` to name per-session state files. When `CLAUDE_SESSION_ID` was not exported to hook child processes (Claude Desktop on macOS doesn't), `_lib.sh:19` fell back to `$(date +%s)-$$` — a fresh id per hook invocation. The tracker and the guard ran in different bash processes, so they wrote and read different `.review-gates` files and the guard always blocked `03-code-quality-reviewer` dispatch with `"02-spec-reviewer has not returned APPROVE yet (current: none)"` even after spec approved.

The same fallback silently broke `role-marker` / `delegation-guard`, `delegation-tracker`, `save-session`, `plan-completion-guard`, and `state-cleanup` for the same reason — any hook pair that wrote in one process and read in another.

## Fix

Promote `.session_id` from the hook input JSON (Claude Code always sends it on stdin) into `HOOK_SESSION_ID` via a new `hook_init <input>` helper in `_lib.sh`. Fall back to a stable per-worktree `current` sentinel when neither `$CLAUDE_SESSION_ID` nor stdin carries it — matching the "only one review pipeline at a time per checkout" property.

Wire `hook_init "$input"` into every hook that touches session-scoped state. `state-cleanup.sh` and `plan-completion-guard.sh` now read stdin (they didn't before) so they can resolve the correct session id on Stop.

## Verification

New bash test at `.claude/hooks/tests/test_review_gate_session_id.sh` exercises four scenarios with `CLAUDE_SESSION_ID` unset, each hook in its own process:

- Tracker with `session_id=sess-xyz` on stdin writes to `sess-xyz.review-gates`.
- Guard with the same stdin `session_id` in a *different* process reads that file back and allows `03-code-quality-reviewer`.
- Guard without a prior spec verdict still blocks.
- Both hooks with no `session_id` anywhere converge on the `current` fallback and still compose.

The test was confirmed to fail against the pre-patch `_lib.sh` (tracker writes to `<epoch>-<pid>.review-gates` instead of the session id from stdin) and pass after the fix.

Also smoke-tested `state-cleanup.sh` and `plan-completion-guard.sh` end-to-end: cleanup now deletes the correct session's files; the override write/consume across two Stop invocations works.

## Test plan

- [x] `bash .claude/hooks/tests/test_review_gate_session_id.sh`
- [x] Confirm regression test fails against buggy `_lib.sh`
- [x] Smoke test `state-cleanup.sh` keyed by stdin `session_id`
- [x] Smoke test `plan-completion-guard.sh` override lifecycle
- [ ] End-to-end in a Claude Desktop session: `02-spec-reviewer` → `03-code-quality-reviewer` without `CLAUDE_SESSION_ID` exported

https://claude.ai/code/session_015BzhUP1i7uunxE6wcwWqiD

---
_Generated by [Claude Code](https://claude.ai/code/session_015BzhUP1i7uunxE6wcwWqiD)_