### PR TITLE
fix(ci): post Claude review verdict as sticky PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,9 @@
 name: Claude code review
 
 # Runs Claude Code as an automated code reviewer on every PR.
-# Leaves a review comment with a verdict + punch list.
+# Posts a sticky PR comment with the model's verdict + punch list.
+# The comment is replaced (not duplicated) on every rerun via a hidden
+# marker, so downstream automation can poll for the latest verdict.
 #
 # Requires repository secret: ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN.
 
@@ -30,7 +32,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1
+      - id: claude
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -65,3 +68,67 @@ jobs:
             --model claude-sonnet-4-6
             --allowed-tools "Bash(cargo *),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"
             --disallowed-tools "Bash(git push:*),Bash(git commit:*)"
+
+      # The action above runs Claude in automation mode (with `prompt:`),
+      # which by design does not post the model's response anywhere — it
+      # only buffers inline review comments. We extract the final assistant
+      # message from the action's execution log and post it as a sticky PR
+      # comment so the verdict is visible to humans and to the gh-issue
+      # poll-pr automation. The hidden marker keeps each rerun replacing
+      # the prior comment instead of stacking new ones.
+      - name: Post verdict as sticky PR comment
+        if: ${{ !cancelled() && steps.claude.outputs.execution_file != '' }}
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: '<!-- plumb:claude-review-verdict -->'
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$EXECUTION_FILE" ]; then
+            echo "::warning::Claude execution file is missing or empty; skipping verdict comment."
+            exit 0
+          fi
+
+          # The execution file is a JSON array of Turn objects from
+          # Claude Code's stream-json output. Prefer the final `result`
+          # turn (which captures the model's last assistant message
+          # verbatim); fall back to the last assistant text turn.
+          REVIEW=$(jq -r '
+            (
+              ([.[]? | select(.type == "result") | .result // empty] | last)
+              //
+              ([.[]? | select(.type == "assistant")
+                      | (.message.content // [])[]?
+                      | select(.type == "text") | .text] | last)
+              //
+              ""
+            )
+          ' "$EXECUTION_FILE")
+
+          if [ -z "$REVIEW" ]; then
+            echo "::warning::Could not extract a final assistant message; skipping verdict comment."
+            exit 0
+          fi
+
+          BODY_FILE="$RUNNER_TEMP/claude-review-body.md"
+          {
+            printf '%s\n\n' "$MARKER"
+            printf '%s\n' "$REVIEW"
+          } > "$BODY_FILE"
+
+          EXISTING_ID=$(gh api --paginate \
+                        "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+                        --jq "map(select(.body | contains(\"${MARKER}\"))) | .[0].id // empty")
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Updating prior verdict comment ${EXISTING_ID}"
+            jq -n --rawfile body "$BODY_FILE" '{body: $body}' \
+              | gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" --input -
+          else
+            echo "Creating new verdict comment"
+            jq -n --rawfile body "$BODY_FILE" '{body: $body}' \
+              | gh api -X POST "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" --input -
+          fi


### PR DESCRIPTION
## Summary

- The Claude review workflow (`anthropics/claude-code-action@v1` driven by a `prompt:` input) runs in **automation mode**, which by design does not post the model's response — only buffered inline review comments, and our prompt rarely produces any. The verdict ends up only in the action's stdout, invisible to humans and to the `gh-issue` `poll-pr` automation in `.agents/skills/gh-issue/scripts/gh_issue_run.py`.
- Capture the action's `execution_file` output, extract the model's final assistant message (preferring the `result` turn, falling back to the last assistant text turn), and post it as a PR comment guarded by a hidden marker (`<!-- plumb:claude-review-verdict -->`) so reruns replace the prior comment instead of stacking.
- Repro on PR #103 (https://github.com/aram-devdocs/plumb/pull/103): all checks green including "Claude review" but `gh api repos/aram-devdocs/plumb/issues/103/comments` returns `[]`. The verdict regex in `_poll_claude_review` (lines 308–322 of `gh_issue_run.py`) matches the workflow's emitted `Verdict: APPROVE | REQUEST_CHANGES | BLOCK` line verbatim, so once the comment lands, downstream automation converges.

The model prompt, model selection (`claude-sonnet-4-6`), and verdict format are unchanged. No new secrets or permissions — `pull-requests: write` is already granted.

## Test plan

- [ ] Wait for CI on this PR to run and confirm a sticky comment with the `<!-- plumb:claude-review-verdict -->` marker appears, ending in a `Verdict: ...` line.
- [ ] Push a second commit to this branch and confirm the prior comment is **edited in place** (same comment ID) rather than a new comment being added.
- [ ] Once merged, retrigger the workflow on PR #103 (`gh workflow run claude-code-review.yml --ref codex/16-feat-cli-viewport-flag-multirun` or push an empty commit) and confirm a comment appears containing `Verdict: APPROVE`.

https://claude.ai/code/session_01BgX3g9HE9E31T8ejEjX58F

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgX3g9HE9E31T8ejEjX58F)_