### PR TITLE
docs: add no-legacy-code policy + workspace lints

### DIFF
--- a/.agents/rules/AGENTS.md
+++ b/.agents/rules/AGENTS.md
@@ -25,6 +25,7 @@ discussion.
 
 - `determinism.md` — byte-identical output invariants.
 - `dependency-hierarchy.md` — crate layer graph + enforcement.
+- `no-legacy-code.md` — no indefinite deprecations, no dead code, no orphan shims.
 - `rule-engine-patterns.md` — how to add a rule.
 - `mcp-tool-patterns.md` — how to add an MCP tool.
 - `testing.md` — nextest + insta + proptest conventions.

--- a/.agents/rules/no-legacy-code.md
+++ b/.agents/rules/no-legacy-code.md
@@ -1,0 +1,87 @@
+# Rule: No legacy, deprecated, or unused code
+
+Plumb is an AI-driven project. Dead weight in the tree — deprecated
+items without an exit plan, commented-out blocks, orphaned
+compatibility shims, unused functions — costs token budget for every
+agent that reads the repo and confuses humans who read it later. The
+policy is simple: only keep what is used. When something stops being
+used, delete it in the same PR that removed its last caller.
+
+## What's banned
+
+- **Indefinite `#[deprecated]`.** Every `#[deprecated]` attribute MUST
+  carry a tracking-issue link and a concrete removal milestone in its
+  `note`. `note = "will remove eventually"` is not acceptable. Neither
+  is `note = "removed when X lands"` without a GitHub issue number.
+- **Commented-out code.** If the code is off, delete it. Git history is
+  the archive. `// old impl:` blocks, `/* TODO: restore this later */`,
+  and `if false { … }` dead branches are all rejected at review.
+- **`// TODO: remove later`** and similar open-ended removal markers.
+  Every TODO that promises future deletion MUST reference a tracking
+  issue (`// TODO(#123): remove when config v2 lands`).
+- **Orphaned compatibility shims.** Type aliases, re-exports, and
+  wrapper functions kept "just in case" — if nothing internal uses them
+  and no external crate published against them exists, they go.
+- **Unused imports, functions, fields, and enum variants.** These are
+  caught by the compiler under the lints below and fail CI.
+- **Renamed-to-`_` parameters or fields for backwards compatibility.**
+  If a parameter is unused, remove it. Don't prefix with `_` to silence
+  the warning — fix the call site instead.
+
+## What's required
+
+- **Deprecation plan of record.** The PR that adds a `#[deprecated]`
+  item MUST also file or link the tracking issue that owns its removal
+  milestone. The removal milestone is concrete: a release (`0.2.0`), a
+  ticket (`#123`), or a dependent feature landing (`after #456 merges`).
+- **Atomic removal PRs.** When the removal milestone is hit, the PR
+  that removes the deprecated item MUST also delete in the same commit
+  range:
+  - Its tests (unit, integration, golden snapshots).
+  - Its documentation (`docs/src/**`, rustdoc examples that reference
+    it, any `explain_rule` markdown).
+  - Its registration (`register_builtin`, tool descriptor, re-exports).
+  - Any `#[allow(deprecated)]` attributes that existed to silence its
+    usage.
+- **No drive-by deprecations.** Deprecating an item is a scoped change.
+  Don't bundle a deprecation with unrelated feature work — it hides the
+  removal clock inside an unrelated PR title.
+
+## How it's enforced
+
+- **Workspace `[lints.rust]`** in the root `Cargo.toml`:
+  - `dead_code = "deny"` — unused private functions, fields, and enum
+    variants fail the build.
+  - `unused_imports = "deny"` — orphaned `use` statements fail the
+    build.
+  - `deprecated = "deny"` — usage of any `#[deprecated]` item fails the
+    build unless the consumer has an explicit `#[allow(deprecated)]`
+    scoped to the exact registration site.
+- **CI `RUSTFLAGS: -Dwarnings`** in `.github/workflows/ci.yml` — every
+  remaining warn-level lint (`unused_variables`, `unused_mut`,
+  `unused_must_use`, etc.) is promoted to an error on every PR.
+- **Clippy `-D warnings`** in the preflight job — the same promotion
+  applies to clippy's unused-argument and redundant-clone lints.
+- **Review gate.** Human and AI reviewers MUST flag commented-out code,
+  open-ended TODOs, and orphaned shims. The 03-code-quality-reviewer
+  agent treats any of the above as a blocker.
+
+## The `#[allow(deprecated)]` escape hatch
+
+Registering a deprecated item inside the crate that owns it requires a
+local `#[allow(deprecated)]`. That attribute MUST be scoped as tightly
+as possible — a single `impl` block or `vec![…]` literal, not a whole
+module. Every occurrence of `#[allow(deprecated)]` is a marker for the
+removal PR to delete.
+
+## Anti-patterns
+
+- Keeping a "v1" API alongside a "v2" API "for migration." Either
+  migrate internal callers in the same PR that introduces v2, or don't
+  add v2 yet.
+- Leaving a `#[cfg(feature = "legacy")]` gate with no sunset plan.
+  Feature gates are for forward-looking optionality, not backwards
+  compatibility archaeology.
+- Silencing `dead_code` with `#[allow(dead_code)]` on a top-level item.
+  If it's truly unused, delete it. If it's used in tests only, gate it
+  behind `#[cfg(test)]`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ These are non-negotiable and enforced by CI. Violating them is never acceptable.
 - **Layer discipline.** `plumb-core` depends on nothing project-internal. `plumb-format` depends only on `plumb-core`. `plumb-cdp` owns all `unsafe`. `plumb-cli` is the only crate that may call `println!`/`eprintln!`.
 - **No `unwrap`/`expect` in libraries.** Return `Result` with `thiserror`-derived errors. `anyhow` is allowed only in `plumb-cli::main`.
 - **No `todo!`/`unimplemented!`/`dbg!` anywhere.** If something is unfinished, open a tracking issue and return a typed error.
+- **No legacy code.** `#[deprecated]` items carry a tracking issue and a concrete removal milestone. No commented-out code, no orphan shims, no open-ended `TODO: remove later`. Unused imports, functions, and fields fail CI. Full policy: `.agents/rules/no-legacy-code.md`.
 - **Docs must be human.** The `humanizer` skill runs on every docs PR. Avoid AI-tell phrasing ("dive in", "comprehensive", "leverage", "seamless", etc.).
 
 ## Workflow expectations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,16 @@ unsafe_code = "forbid"
 missing_docs = "deny"
 unreachable_pub = "warn"
 rust_2024_compatibility = { level = "warn", priority = -1 }
+# No-legacy-code policy (.agents/rules/no-legacy-code.md). CI already
+# promotes every warn to an error via RUSTFLAGS=-Dwarnings; these
+# explicit denies encode the intent in the workspace manifest so
+# contributors see the policy at the source.
+dead_code = "deny"
+unused_imports = "deny"
+# `deprecated` stays overridable at the registration site via a tightly
+# scoped `#[allow(deprecated)]`. Every such allow is a marker for the
+# removal PR to delete alongside the deprecated item.
+deprecated = "deny"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/scripts/check-agents-md.sh
+++ b/scripts/check-agents-md.sh
@@ -28,7 +28,7 @@ declare -a SCOPES=(
     "docs/src/rules/AGENTS.md:40"
     "docs/runbooks/AGENTS.md:45"
     ".agents/AGENTS.md:40"
-    ".agents/rules/AGENTS.md:40"
+    ".agents/rules/AGENTS.md:42"
     ".agents/skills/AGENTS.md:40"
 )
 


### PR DESCRIPTION
## Summary

Codifies the "only keep what's used" policy: no indefinite deprecations, no commented-out code, no orphan shims. Promotes `dead_code`, `unused_imports`, and `deprecated` to `"deny"` at workspace level so the policy is visible in `Cargo.toml` rather than relying on `RUSTFLAGS=-Dwarnings` alone.

Motivating context: the bundled PR #17/#18/#19 retires the deprecated `placeholder/hello-world` rule whose `#[deprecated]` note said "removed when the first real rule lands" — no issue link, no milestone. This PR makes that shape of deprecation unacceptable going forward.

## Changes

- **New:** `.agents/rules/no-legacy-code.md` — the full policy. Covers indefinite `#[deprecated]`, commented-out code, orphan shims, unused items, the atomic-removal-PR requirement (tests + docs + registration + `#[allow(deprecated)]` all go together), and the `#[allow(deprecated)]` escape-hatch scoping rule.
- **Edited:** `.agents/rules/AGENTS.md` — adds the rule to the Current rules list.
- **Edited:** root `AGENTS.md` — adds a Hard rule bullet pointing at the policy.
- **Edited:** `Cargo.toml` `[workspace.lints.rust]` — `dead_code = "deny"`, `unused_imports = "deny"`, `deprecated = "deny"` with a comment explaining the relationship to `RUSTFLAGS=-Dwarnings`.
- **Edited:** `scripts/check-agents-md.sh` — bumps `.agents/rules/AGENTS.md` budget 40 → 42 to fit the new bullet.

## Non-changes

- No rule implementations touched. This is strictly docs + lint config.
- The existing `#[allow(deprecated)]` sites in `plumb-core/src/rules/{mod.rs,placeholder.rs}` still compile cleanly — local allow-attributes override the workspace deny. Those sites will be deleted when PR #17/#18/#19 retires the placeholder, which the new policy explicitly requires.

## Verification

- `cargo check --workspace --all-targets --all-features` — passes.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passes.
- `cargo fmt --all -- --check` — passes.
- `bash scripts/check-agents-md.sh` — passes (`14 AGENTS.md scopes OK`).

## Test plan

- [ ] CI preflight passes (fmt, clippy, check, agents-md).
- [ ] MSRV job passes.
- [ ] determinism job passes (unchanged; no core changes).
- [ ] Reviewer sanity-checks the `#[allow(deprecated)]` escape-hatch wording in the policy doc.

https://claude.ai/code/session_01NG4EKcPPxvB7ua9RSkeEX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG4EKcPPxvB7ua9RSkeEX8)_