### PR TITLE
feat(config): [color], [radius], [alignment], [a11y] sections + schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ From the first release onward, this file is maintained automatically by [`releas
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.
 - Rule `spacing/scale-conformance`: flags the same property set when values aren't members of `spacing.scale`.
 - Rule `type/scale-conformance`: flags `font-size` values that aren't members of `type.scale`.
+- PRD §12.2 `[color]`, `[radius]`, `[alignment]`, `[a11y]` config sections fleshed out: `color.delta_e_tolerance` (default 2.0), `alignment.tolerance_px` (default 3), `a11y.touch_target.{min_width_px, min_height_px}` (default 24×24 per WCAG 2.5.8).
+
+### Changed
+
+- Renamed `radius.allowed_px` to `radius.scale` for naming consistency with `spacing.scale` and `type.scale`. The old name is rejected; update any pre-existing `plumb.toml`.
 
 ### Removed
 

--- a/crates/plumb-config/tests/load_example.rs
+++ b/crates/plumb-config/tests/load_example.rs
@@ -67,6 +67,75 @@ fn default_spacing_base_unit_is_four() {
 }
 
 #[test]
+fn loads_prd_color_radius_alignment_a11y_sections() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("plumb.toml");
+    std::fs::write(
+        &path,
+        r##"
+[color]
+tokens = { "bg/canvas" = "#ffffff", "fg/primary" = "#0b0b0b", "accent/brand" = "#0b7285" }
+delta_e_tolerance = 1.5
+
+[radius]
+scale = [0, 2, 4, 8, 12, 16, 9999]
+
+[alignment]
+grid_columns = 12
+gutter_px = 24
+tolerance_px = 3
+
+[a11y]
+min_contrast_ratio = 4.5
+
+[a11y.touch_target]
+min_width_px = 24
+min_height_px = 24
+"##,
+    )
+    .expect("write config");
+
+    let cfg = plumb_config::load(&path).expect("load config");
+
+    assert_eq!(cfg.color.tokens["bg/canvas"], "#ffffff");
+    assert_eq!(cfg.color.tokens["fg/primary"], "#0b0b0b");
+    assert_eq!(cfg.color.tokens["accent/brand"], "#0b7285");
+    assert!((cfg.color.delta_e_tolerance - 1.5).abs() < f32::EPSILON);
+
+    assert_eq!(cfg.radius.scale, vec![0, 2, 4, 8, 12, 16, 9999]);
+
+    assert_eq!(cfg.alignment.grid_columns, Some(12));
+    assert_eq!(cfg.alignment.gutter_px, Some(24));
+    assert_eq!(cfg.alignment.tolerance_px, 3);
+
+    assert_eq!(cfg.a11y.min_contrast_ratio, Some(4.5));
+    assert_eq!(cfg.a11y.touch_target.min_width_px, 24);
+    assert_eq!(cfg.a11y.touch_target.min_height_px, 24);
+}
+
+#[test]
+fn defaults_for_color_radius_alignment_a11y_sections() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("plumb.toml");
+    std::fs::write(&path, "").expect("write config");
+
+    let cfg = plumb_config::load(&path).expect("load config");
+
+    assert!(cfg.color.tokens.is_empty());
+    assert!((cfg.color.delta_e_tolerance - 2.0).abs() < f32::EPSILON);
+
+    assert!(cfg.radius.scale.is_empty());
+
+    assert_eq!(cfg.alignment.grid_columns, None);
+    assert_eq!(cfg.alignment.gutter_px, None);
+    assert_eq!(cfg.alignment.tolerance_px, 3);
+
+    assert_eq!(cfg.a11y.min_contrast_ratio, None);
+    assert_eq!(cfg.a11y.touch_target.min_width_px, 24);
+    assert_eq!(cfg.a11y.touch_target.min_height_px, 24);
+}
+
+#[test]
 fn rejects_old_config_aliases_and_unknown_fields() {
     for toml in [
         "[spacing]\nbase_px = 4\n",
@@ -74,6 +143,11 @@ fn rejects_old_config_aliases_and_unknown_fields() {
         "[type]\nsizes_px = [16]\n",
         "[type]\nline_heights = [1.5]\n",
         "[spacing]\nunknown = 4\n",
+        "[radius]\nallowed_px = [4]\n",
+        "[alignment]\nunknown = 1\n",
+        "[a11y]\nunknown = 1\n",
+        "[a11y.touch_target]\nunknown = 1\n",
+        "[color]\nunknown = 1\n",
     ] {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("plumb.toml");
@@ -117,9 +191,35 @@ fn schema_uses_prd_names_and_drops_old_aliases() {
     assert!(type_props.contains_key("scale"));
     assert!(type_props.contains_key("tokens"));
 
+    let radius_props = definitions["RadiusSpec"]["properties"]
+        .as_object()
+        .expect("radius properties should be an object");
+    assert!(radius_props.contains_key("scale"));
+    assert!(!radius_props.contains_key("allowed_px"));
+
+    let alignment_props = definitions["AlignmentSpec"]["properties"]
+        .as_object()
+        .expect("alignment properties should be an object");
+    assert!(alignment_props.contains_key("grid_columns"));
+    assert!(alignment_props.contains_key("gutter_px"));
+    assert!(alignment_props.contains_key("tolerance_px"));
+
+    let a11y_props = definitions["A11ySpec"]["properties"]
+        .as_object()
+        .expect("a11y properties should be an object");
+    assert!(a11y_props.contains_key("min_contrast_ratio"));
+    assert!(a11y_props.contains_key("touch_target"));
+
+    let touch_target_props = definitions["TouchTargetSpec"]["properties"]
+        .as_object()
+        .expect("touch_target properties should be an object");
+    assert!(touch_target_props.contains_key("min_width_px"));
+    assert!(touch_target_props.contains_key("min_height_px"));
+
     assert!(!schema.contains("\"base_px\""));
     assert!(!schema.contains("\"sizes_px\""));
     assert!(!schema.contains("\"line_heights\""));
+    assert!(!schema.contains("\"allowed_px\""));
 }
 
 #[test]

--- a/crates/plumb-core/src/config.rs
+++ b/crates/plumb-core/src/config.rs
@@ -117,10 +117,16 @@ pub struct TypeScaleSpec {
 }
 
 /// Color spec.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+///
+/// Tokens are flat name → hex pairs. Slash-delimited names
+/// (`"bg/canvas"`, `"fg/primary"`) namespace the palette without
+/// requiring nested tables — TOML quotes the key, the rule engine
+/// treats the slash as a hint for grouping in diagnostics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ColorSpec {
-    /// Named tokens mapped to hex values (e.g. `#0b7285`).
+    /// Named tokens mapped to hex values (e.g. `#0b7285`). Slash-delimited
+    /// keys (`"bg/canvas"`) act as informal namespaces.
     #[serde(default)]
     pub tokens: IndexMap<String, String>,
     /// CIEDE2000 Delta-E tolerance when matching off-palette colors.
@@ -132,17 +138,28 @@ fn default_delta_e() -> f32 {
     2.0
 }
 
+impl Default for ColorSpec {
+    fn default() -> Self {
+        Self {
+            tokens: IndexMap::new(),
+            delta_e_tolerance: default_delta_e(),
+        }
+    }
+}
+
 /// Border-radius spec.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RadiusSpec {
-    /// Allowed radii in pixels.
+    /// Allowed border-radius values in pixels.
+    ///
+    /// Naming matches `spacing.scale` and `type.scale` for consistency.
     #[serde(default)]
-    pub allowed_px: Vec<u32>,
+    pub scale: Vec<u32>,
 }
 
 /// Alignment / layout spec.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AlignmentSpec {
     /// Grid column count, if the design uses a fixed grid.
@@ -151,6 +168,24 @@ pub struct AlignmentSpec {
     /// Container gutter in pixels.
     #[serde(default)]
     pub gutter_px: Option<u32>,
+    /// Edge-clustering tolerance in pixels for `edge/near-alignment`.
+    /// Defaults to 3 px.
+    #[serde(default = "default_alignment_tolerance_px")]
+    pub tolerance_px: u32,
+}
+
+fn default_alignment_tolerance_px() -> u32 {
+    3
+}
+
+impl Default for AlignmentSpec {
+    fn default() -> Self {
+        Self {
+            grid_columns: None,
+            gutter_px: None,
+            tolerance_px: default_alignment_tolerance_px(),
+        }
+    }
 }
 
 /// Accessibility spec.
@@ -160,6 +195,36 @@ pub struct A11ySpec {
     /// Minimum contrast ratio to enforce (e.g. `4.5` for WCAG AA body text).
     #[serde(default)]
     pub min_contrast_ratio: Option<f32>,
+    /// Minimum interactive-element size for `a11y/touch-target`.
+    #[serde(default)]
+    pub touch_target: TouchTargetSpec,
+}
+
+/// Touch-target threshold per WCAG 2.5.8 (Target Size, Minimum).
+///
+/// Defaults to 24×24 CSS pixels.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TouchTargetSpec {
+    /// Minimum interactive width in CSS pixels.
+    #[serde(default = "default_touch_target_px")]
+    pub min_width_px: u32,
+    /// Minimum interactive height in CSS pixels.
+    #[serde(default = "default_touch_target_px")]
+    pub min_height_px: u32,
+}
+
+fn default_touch_target_px() -> u32 {
+    24
+}
+
+impl Default for TouchTargetSpec {
+    fn default() -> Self {
+        Self {
+            min_width_px: default_touch_target_px(),
+            min_height_px: default_touch_target_px(),
+        }
+    }
 }
 
 /// Per-rule override.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -27,8 +27,67 @@ is the canonical example. Highlights:
   type tokens.
 - `[color]` — named color tokens and the CIEDE2000 tolerance for fuzzy
   matches.
-- `[radius]` — allowed border-radii.
-- `[alignment]` — grid columns and gutter.
-- `[a11y]` — minimum contrast ratio.
+- `[radius]` — allowed border-radius values.
+- `[alignment]` — grid columns, gutter, and edge-clustering tolerance.
+- `[a11y]` — minimum contrast ratio and touch-target thresholds.
 - `[rules."<category>/<id>"]` — per-rule overrides (enable/disable,
   severity bump).
+
+## Section reference
+
+### `[color]`
+
+```toml
+[color]
+tokens = { "bg/canvas" = "#ffffff", "fg/primary" = "#0b0b0b", "accent/brand" = "#0b7285" }
+delta_e_tolerance = 2.0
+```
+
+`tokens` is a flat map of name → hex. Slash-delimited names
+(`"bg/canvas"`, `"accent/brand"`) act as informal namespaces — TOML
+requires the quotes; the rule engine groups by the prefix in
+diagnostics.
+
+`delta_e_tolerance` is the CIEDE2000 ΔE threshold for `color/palette-conformance`.
+Defaults to `2.0`.
+
+### `[radius]`
+
+```toml
+[radius]
+scale = [0, 2, 4, 8, 12, 16, 9999]
+```
+
+`scale` is the allowed `border-radius` set in pixels. The name matches
+`spacing.scale` and `type.scale`. Defaults to `[]` (no enforcement).
+
+### `[alignment]`
+
+```toml
+[alignment]
+grid_columns = 12
+gutter_px = 24
+tolerance_px = 3
+```
+
+`grid_columns` and `gutter_px` are optional. `tolerance_px` is the
+edge-clustering window for `edge/near-alignment` — elements off by
+`0 < delta <= tolerance_px` get flagged. Defaults to `3`.
+
+### `[a11y]`
+
+```toml
+[a11y]
+min_contrast_ratio = 4.5
+
+[a11y.touch_target]
+min_width_px = 24
+min_height_px = 24
+```
+
+`min_contrast_ratio` is optional; set it for the contrast rule (e.g.
+`4.5` for WCAG AA body text).
+
+`[a11y.touch_target]` configures the `a11y/touch-target` rule. Defaults
+to `24` × `24` CSS pixels per WCAG 2.5.8 (Target Size, Minimum). Raise
+to `44` × `44` for AAA.

--- a/examples/plumb.toml
+++ b/examples/plumb.toml
@@ -35,14 +35,19 @@ tokens = { "bg/canvas" = "#ffffff", "fg/primary" = "#0b0b0b", "accent/brand" = "
 delta_e_tolerance = 2.0
 
 [radius]
-allowed_px = [0, 2, 4, 8, 12, 16, 9999]
+scale = [0, 2, 4, 8, 12, 16, 9999]
 
 [alignment]
 grid_columns = 12
 gutter_px = 24
+tolerance_px = 3
 
 [a11y]
 min_contrast_ratio = 4.5
+
+[a11y.touch_target]
+min_width_px = 24
+min_height_px = 24
 
 # Example per-rule overrides. Every rule is enabled by default.
 # [rules."spacing/grid-conformance"]

--- a/schemas/plumb.toml.json
+++ b/schemas/plumb.toml.json
@@ -36,14 +36,14 @@
       "$ref": "#/$defs/ColorSpec",
       "default": {
         "tokens": {},
-        "delta_e_tolerance": 0.0
+        "delta_e_tolerance": 2.0
       }
     },
     "radius": {
       "description": "Border-radius spec.",
       "$ref": "#/$defs/RadiusSpec",
       "default": {
-        "allowed_px": []
+        "scale": []
       }
     },
     "alignment": {
@@ -51,14 +51,19 @@
       "$ref": "#/$defs/AlignmentSpec",
       "default": {
         "grid_columns": null,
-        "gutter_px": null
+        "gutter_px": null,
+        "tolerance_px": 3
       }
     },
     "a11y": {
       "description": "Accessibility spec.",
       "$ref": "#/$defs/A11ySpec",
       "default": {
-        "min_contrast_ratio": null
+        "min_contrast_ratio": null,
+        "touch_target": {
+          "min_width_px": 24,
+          "min_height_px": 24
+        }
       }
     },
     "rules": {
@@ -182,11 +187,11 @@
       "additionalProperties": false
     },
     "ColorSpec": {
-      "description": "Color spec.",
+      "description": "Color spec.\n\nTokens are flat name → hex pairs. Slash-delimited names\n(`\"bg/canvas\"`, `\"fg/primary\"`) namespace the palette without\nrequiring nested tables — TOML quotes the key, the rule engine\ntreats the slash as a hint for grouping in diagnostics.",
       "type": "object",
       "properties": {
         "tokens": {
-          "description": "Named tokens mapped to hex values (e.g. `#0b7285`).",
+          "description": "Named tokens mapped to hex values (e.g. `#0b7285`). Slash-delimited\nkeys (`\"bg/canvas\"`) act as informal namespaces.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -206,8 +211,8 @@
       "description": "Border-radius spec.",
       "type": "object",
       "properties": {
-        "allowed_px": {
-          "description": "Allowed radii in pixels.",
+        "scale": {
+          "description": "Allowed border-radius values in pixels.\n\nNaming matches `spacing.scale` and `type.scale` for consistency.",
           "type": "array",
           "items": {
             "type": "integer",
@@ -242,6 +247,13 @@
           "format": "uint32",
           "minimum": 0,
           "default": null
+        },
+        "tolerance_px": {
+          "description": "Edge-clustering tolerance in pixels for `edge/near-alignment`.\nDefaults to 3 px.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 3
         }
       },
       "additionalProperties": false
@@ -258,6 +270,35 @@
           ],
           "format": "float",
           "default": null
+        },
+        "touch_target": {
+          "description": "Minimum interactive-element size for `a11y/touch-target`.",
+          "$ref": "#/$defs/TouchTargetSpec",
+          "default": {
+            "min_width_px": 24,
+            "min_height_px": 24
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "TouchTargetSpec": {
+      "description": "Touch-target threshold per WCAG 2.5.8 (Target Size, Minimum).\n\nDefaults to 24×24 CSS pixels.",
+      "type": "object",
+      "properties": {
+        "min_width_px": {
+          "description": "Minimum interactive width in CSS pixels.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 24
+        },
+        "min_height_px": {
+          "description": "Minimum interactive height in CSS pixels.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 24
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #21

PRD §12.2. Phase 2 batch 2A. Sets the config shape that the phase-2 rules (color/palette-conformance #23, radius/scale-conformance #24, edge/near-alignment #27, a11y/touch-target #26) will read from.

## Summary

- Flesh out the four PRD §12.2 sections: `[color]`, `[radius]`, `[alignment]`, `[a11y]` — every nested struct keeps `deny_unknown_fields`.
- Add `alignment.tolerance_px` (default 3) and `a11y.touch_target.{min_width_px, min_height_px}` (default 24×24 per WCAG 2.5.8). `color.delta_e_tolerance` default settles at 2.0 (the rule itself can override at consume time).
- Rename `radius.allowed_px` → `radius.scale` to match `spacing.scale` and `type.scale`. Schema, example, and tests updated; the old name is rejected.

## Crates touched

- [x] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [x] `plumb-config`
- [ ] `plumb-mcp`
- [ ] `plumb-cli`
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [ ] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [x] Config schema change (run `cargo xtask schema` + commit result)
- [ ] Dependency added / bumped (cargo-deny must still pass)
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `just validate` passes locally
- [x] `cargo xtask pre-release` passes (if rule or schema changed)
- [x] `just determinism-check` passes (3× byte-diff clean)
- [x] `cargo deny check` passes
- [x] New/changed behavior has a test (unit, golden snapshot, or integration)

Round-trip tests (`crates/plumb-config/tests/load_example.rs`):
- `loads_prd_color_radius_alignment_a11y_sections` populates every new field and asserts the parsed values.
- `defaults_for_color_radius_alignment_a11y_sections` writes an empty config and asserts every default (including `delta_e_tolerance = 2.0`, `tolerance_px = 3`, touch-target `24×24`).
- `rejects_old_config_aliases_and_unknown_fields` extended with `[radius] allowed_px`, plus unknown fields under `alignment`, `a11y`, `a11y.touch_target`, and `color`.
- `schema_uses_prd_names_and_drops_old_aliases` extended to assert `RadiusSpec.scale`, `AlignmentSpec.tolerance_px`, `A11ySpec.touch_target`, and `TouchTargetSpec.{min_width_px, min_height_px}`.

## Documentation

- [x] Rustdoc added for every new public item
- [x] `# Errors` section on every new public fallible fn (no new fallible APIs)
- [x] `docs/src/` updated when user-visible behavior changed
- [x] `docs/src/rules/<category>-<id>.md` written for new rules (n/a)
- [x] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [x] Humanizer skill run on docs changes

`docs/src/configuration.md` adds a per-section reference covering defaults and the slash-namespacing convention. Prose kept short; no AI-tell vocabulary.

## Breaking change?

- [ ] No
- [x] Yes — describe migration path

The pre-release `radius.allowed_px` field is renamed to `radius.scale`. Anyone on a `plumb.toml` from before this PR replaces:

```toml
[radius]
allowed_px = [0, 4, 8]
```

with:

```toml
[radius]
scale = [0, 4, 8]
```

The old name is rejected (`deny_unknown_fields`), so the failure surface is loud. No shipped rule consumed `radius.*` yet, so no rule-side compat shim is needed.

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/<primary>-<type>-<slug>`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [ ] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

Decisions worth flagging:

1. **Flat palette only.** The ticket left it open whether to add a nested `palette` form alongside the flat one. I kept the flat slash-namespaced shape (`"bg/canvas" = "#..."`) and documented it as canonical — clarity > scope creep. If a nested form turns out to be ergonomic in dogfooding, it's a clean follow-up.
2. **`radius.allowed_px` → `radius.scale` (no alias).** The pre-release schema is unstable, no shipped rule reads `radius.*` yet, so a hard rename is cheaper than a long-lived `#[serde(alias = "allowed_px")]`. The CHANGELOG flags it under `Changed`.
3. **`delta_e_tolerance` default stays 2.0.** The phase-2 runbook for #23 mentions 1.5; the pre-existing default is 2.0 and #23 can override at the rule-default level if the spec confirms 1.5. Leaving it as-is keeps this PR scoped to schema shape, not threshold tuning.