### PR TITLE
feat(config): span-annotated validation errors via miette

### DIFF
--- a/crates/plumb-config/src/lib.rs
+++ b/crates/plumb-config/src/lib.rs
@@ -19,6 +19,12 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use plumb_core::Config;
 use thiserror::Error;
 
+mod span;
+mod validate;
+
+use span::{SourceFormat, locate_path};
+use validate::ValidationIssue;
+
 /// Underlying config parse errors.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -63,8 +69,27 @@ pub enum ConfigError {
         /// Source text for span-annotated diagnostics.
         #[source_code]
         source_code: Option<NamedSource<String>>,
-        /// Label pointing at the invalid TOML span, when available.
+        /// Label pointing at the invalid config span, when available.
         #[label("invalid config")]
+        span: Option<SourceSpan>,
+    },
+    /// The file parsed structurally but failed semantic validation
+    /// (e.g. a palette token whose value isn't a hex color).
+    #[error("invalid config value at `{value_path}` in `{path}`: {message}")]
+    #[diagnostic(code(plumb::config::validation))]
+    Validation {
+        /// Path of the file that failed validation.
+        path: String,
+        /// Dotted path of the offending value (e.g. `color.tokens.bg`).
+        value_path: String,
+        /// Why the value is invalid.
+        message: String,
+        /// Source text for span-annotated diagnostics.
+        #[source_code]
+        source_code: Option<NamedSource<String>>,
+        /// Label pointing at the offending value, when the source format
+        /// allows span recovery.
+        #[label("invalid value")]
         span: Option<SourceSpan>,
     },
     /// Schema emission failed.
@@ -78,7 +103,9 @@ pub enum ConfigError {
 ///
 /// Returns [`ConfigError::NotFound`] if the file is missing,
 /// [`ConfigError::UnsupportedExtension`] if the extension is unrecognized,
-/// or [`ConfigError::Parse`] if parsing or schema validation fails.
+/// [`ConfigError::Parse`] if structural parsing fails, or
+/// [`ConfigError::Validation`] if a value fails semantic validation
+/// (e.g. a non-hex palette token).
 pub fn load(path: &Path) -> Result<Config, ConfigError> {
     if !path.exists() {
         return Err(ConfigError::NotFound(path.display().to_string()));
@@ -90,48 +117,127 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
         .unwrap_or("")
         .to_ascii_lowercase();
 
-    match ext.as_str() {
-        "toml" => load_toml(path),
+    let (config, contents, format) = match ext.as_str() {
+        "toml" => {
+            let (cfg, body) = load_toml(path)?;
+            (cfg, body, SourceFormat::Toml)
+        }
         "yaml" | "yml" => {
-            let figment = Figment::new().merge(Yaml::file(path));
-            extract_config(&figment, path)
+            let (cfg, body) = load_yaml(path)?;
+            (cfg, body, SourceFormat::Yaml)
         }
         "json" => {
-            let figment = Figment::new().merge(Json::file(path));
-            extract_config(&figment, path)
+            let (cfg, body) = load_json(path)?;
+            (cfg, body, SourceFormat::Json)
         }
-        other => Err(ConfigError::UnsupportedExtension(other.to_owned())),
+        other => return Err(ConfigError::UnsupportedExtension(other.to_owned())),
+    };
+
+    if let Some(issue) = validate::validate(&config) {
+        return Err(validation_error(path, contents, format, issue));
+    }
+
+    Ok(config)
+}
+
+fn validation_error(
+    path: &Path,
+    contents: String,
+    format: SourceFormat,
+    issue: ValidationIssue,
+) -> ConfigError {
+    let span = locate_path(&contents, format, &issue.path_segments);
+    let language = match format {
+        SourceFormat::Toml => "toml",
+        SourceFormat::Yaml => "yaml",
+        SourceFormat::Json => "json",
+    };
+    ConfigError::Validation {
+        path: path.display().to_string(),
+        value_path: issue.path_segments.join("."),
+        message: issue.message,
+        source_code: Some(
+            NamedSource::new(path.display().to_string(), contents).with_language(language),
+        ),
+        span,
     }
 }
 
-fn extract_config(figment: &Figment, path: &Path) -> Result<Config, ConfigError> {
-    figment
-        .extract::<Config>()
-        .map_err(|source| ConfigError::Parse {
-            path: config_error_path(&source).unwrap_or_else(|| path.display().to_string()),
-            source: Box::new(ConfigParseSource::Figment(source)),
-            source_code: None,
-            span: None,
-        })
-}
-
-fn load_toml(path: &Path) -> Result<Config, ConfigError> {
+fn load_toml(path: &Path) -> Result<(Config, String), ConfigError> {
     let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
         path: path.display().to_string(),
         source,
     })?;
 
-    toml::from_str::<Config>(&contents).map_err(|source| {
+    let parsed = toml::from_str::<Config>(&contents).map_err(|source| {
         let span = source.span().and_then(source_span);
         ConfigError::Parse {
             path: path.display().to_string(),
             source: Box::new(ConfigParseSource::Toml(source)),
             source_code: Some(
-                NamedSource::new(path.display().to_string(), contents).with_language("toml"),
+                NamedSource::new(path.display().to_string(), contents.clone())
+                    .with_language("toml"),
             ),
             span,
         }
-    })
+    })?;
+
+    Ok((parsed, contents))
+}
+
+fn load_yaml(path: &Path) -> Result<(Config, String), ConfigError> {
+    let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+
+    let figment = Figment::new().merge(Yaml::file(path));
+    let cfg = figment
+        .extract::<Config>()
+        .map_err(|source| build_figment_parse_error(path, &contents, SourceFormat::Yaml, source))?;
+    Ok((cfg, contents))
+}
+
+fn load_json(path: &Path) -> Result<(Config, String), ConfigError> {
+    let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+
+    let figment = Figment::new().merge(Json::file(path));
+    let cfg = figment
+        .extract::<Config>()
+        .map_err(|source| build_figment_parse_error(path, &contents, SourceFormat::Json, source))?;
+    Ok((cfg, contents))
+}
+
+fn build_figment_parse_error(
+    path: &Path,
+    contents: &str,
+    format: SourceFormat,
+    source: figment::Error,
+) -> ConfigError {
+    let segments: Vec<String> = source.path.clone();
+    let span = if segments.is_empty() {
+        None
+    } else {
+        locate_path(contents, format, &segments)
+    };
+    let language = match format {
+        SourceFormat::Toml => "toml",
+        SourceFormat::Yaml => "yaml",
+        SourceFormat::Json => "json",
+    };
+    let display_path = config_error_path(&source).unwrap_or_else(|| path.display().to_string());
+    ConfigError::Parse {
+        path: display_path,
+        source: Box::new(ConfigParseSource::Figment(source)),
+        source_code: Some(
+            NamedSource::new(path.display().to_string(), contents.to_owned())
+                .with_language(language),
+        ),
+        span,
+    }
 }
 
 fn source_span(range: Range<usize>) -> Option<SourceSpan> {

--- a/crates/plumb-config/src/span.rs
+++ b/crates/plumb-config/src/span.rs
@@ -1,0 +1,191 @@
+//! Resolve a dotted config path to a byte span in the original source.
+//!
+//! TOML span recovery is precise via [`toml::de::DeTable`] (and its
+//! recursive [`toml::de::DeValue`] companion), both of which preserve
+//! per-key offsets. YAML and JSON span recovery is best-effort: we
+//! fall back to a textual search for the leaf key.
+
+// `pub(crate)` is the workspace convention for in-crate-only items; it
+// trips `clippy::redundant_pub_crate` (because the module is private)
+// while bare `pub` trips `unreachable_pub`. Allow the clippy lint to
+// match the rest of the codebase (see `plumb-core::rules::util`).
+#![allow(clippy::redundant_pub_crate)]
+
+use std::ops::Range;
+
+use miette::SourceSpan;
+use toml::de::{DeTable, DeValue};
+
+/// Source format of a config file.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SourceFormat {
+    /// `.toml` — span recovery is precise.
+    Toml,
+    /// `.yaml` / `.yml` — span recovery is best-effort.
+    Yaml,
+    /// `.json` — span recovery is best-effort.
+    Json,
+}
+
+/// Resolve a dotted path to a byte span in `source`.
+///
+/// Returns `None` if span recovery isn't possible (path doesn't exist,
+/// source is malformed, the format doesn't expose offsets).
+pub(crate) fn locate_path(
+    source: &str,
+    format: SourceFormat,
+    segments: &[String],
+) -> Option<SourceSpan> {
+    if segments.is_empty() {
+        return None;
+    }
+
+    match format {
+        SourceFormat::Toml => locate_in_toml(source, segments),
+        SourceFormat::Yaml | SourceFormat::Json => locate_by_key_search(source, segments),
+    }
+}
+
+fn locate_in_toml(source: &str, segments: &[String]) -> Option<SourceSpan> {
+    let document = DeTable::parse(source).ok()?;
+    walk_table(document.get_ref(), segments).map(into_source_span)
+}
+
+fn walk_table(table: &DeTable<'_>, segments: &[String]) -> Option<Range<usize>> {
+    let (head, rest) = segments.split_first()?;
+    let mut entry_iter = table.iter();
+    let (_key, value) = entry_iter.find(|(k, _)| k.get_ref().as_ref() == head.as_str())?;
+    if rest.is_empty() {
+        return Some(value.span());
+    }
+    match value.get_ref() {
+        DeValue::Table(child) => walk_table(child, rest).or_else(|| Some(value.span())),
+        _ => Some(value.span()),
+    }
+}
+
+fn into_source_span(range: Range<usize>) -> SourceSpan {
+    let len = range.end.saturating_sub(range.start);
+    (range.start, len).into()
+}
+
+/// Best-effort key-based span recovery for YAML/JSON. We can't easily
+/// re-parse with offsets in those formats, so we look for the leaf
+/// segment as a key in the source and return a span covering the
+/// rest of that line.
+fn locate_by_key_search(source: &str, segments: &[String]) -> Option<SourceSpan> {
+    let leaf = segments.last()?;
+
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        if let Some(idx) = find_word(line, leaf) {
+            // Verify it's a key (followed by `:` or `=` after optional
+            // closing quote and whitespace).
+            let after = &line[idx + leaf.len()..];
+            let after_trim = after.trim_start_matches('"').trim_start();
+            if after_trim.starts_with(':') || after_trim.starts_with('=') {
+                let line_start = offset + idx;
+                let line_end = offset + line.trim_end_matches(['\n', '\r']).len();
+                let len = line_end.saturating_sub(line_start);
+                return Some((line_start, len).into());
+            }
+        }
+        offset += line.len();
+    }
+
+    // Fallback: span the bare token if present.
+    if let Some(idx) = find_word(source, leaf) {
+        return Some((idx, leaf.len()).into());
+    }
+    None
+}
+
+/// Find the first occurrence of `needle` in `haystack` not embedded in
+/// a larger identifier. Allows leading `"` (quoted JSON/YAML keys).
+fn find_word(haystack: &str, needle: &str) -> Option<usize> {
+    let bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.is_empty() || bytes.len() < needle_bytes.len() {
+        return None;
+    }
+    for i in 0..=bytes.len() - needle_bytes.len() {
+        if &bytes[i..i + needle_bytes.len()] != needle_bytes {
+            continue;
+        }
+        let prev_ok = i == 0
+            || matches!(
+                bytes[i - 1],
+                b' ' | b'\t' | b'\n' | b'\r' | b'"' | b'\'' | b':' | b',' | b'{' | b'['
+            );
+        let next = i + needle_bytes.len();
+        let next_ok = next >= bytes.len()
+            || !matches!(bytes[next], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_');
+        if prev_ok && next_ok {
+            return Some(i);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locates_nested_toml_value_span() {
+        let source = "\
+[color.tokens]
+brand = \"#0b7285\"
+bg = \"not-a-hex\"
+";
+        let span = locate_path(
+            source,
+            SourceFormat::Toml,
+            &["color".to_owned(), "tokens".to_owned(), "bg".to_owned()],
+        )
+        .expect("should locate bg");
+        let start = span.offset();
+        let end = start + span.len();
+        let snippet = &source[start..end];
+        assert!(
+            snippet.contains("not-a-hex"),
+            "snippet {snippet:?} should contain not-a-hex"
+        );
+    }
+
+    #[test]
+    fn locates_unknown_top_level_toml_key_value() {
+        let source = "\
+bogus_top_level = true
+
+[viewports.mobile]
+width = 320
+height = 568
+";
+        let span = locate_path(source, SourceFormat::Toml, &["bogus_top_level".to_owned()])
+            .expect("should locate top-level key");
+        let start = span.offset();
+        let end = start + span.len();
+        let snippet = &source[start..end];
+        assert!(snippet.contains("true"), "snippet {snippet:?}");
+    }
+
+    #[test]
+    fn locates_yaml_leaf_via_key_search() {
+        let source = "\
+color:
+  tokens:
+    bg: not-a-hex
+";
+        let span = locate_path(
+            source,
+            SourceFormat::Yaml,
+            &["color".to_owned(), "tokens".to_owned(), "bg".to_owned()],
+        )
+        .expect("yaml key search");
+        let start = span.offset();
+        let end = start + span.len();
+        let snippet = &source[start..end];
+        assert!(snippet.contains("bg"), "snippet {snippet:?}");
+    }
+}

--- a/crates/plumb-config/src/span.rs
+++ b/crates/plumb-config/src/span.rs
@@ -5,10 +5,7 @@
 //! per-key offsets. YAML and JSON span recovery is best-effort: we
 //! fall back to a textual search for the leaf key.
 
-// `pub(crate)` is the workspace convention for in-crate-only items; it
-// trips `clippy::redundant_pub_crate` (because the module is private)
-// while bare `pub` trips `unreachable_pub`. Allow the clippy lint to
-// match the rest of the codebase (see `plumb-core::rules::util`).
+// pub(crate) in a private mod triggers redundant_pub_crate; bare pub triggers unreachable_pub.
 #![allow(clippy::redundant_pub_crate)]
 
 use std::ops::Range;

--- a/crates/plumb-config/src/validate.rs
+++ b/crates/plumb-config/src/validate.rs
@@ -1,0 +1,78 @@
+//! Post-deserialization semantic validation.
+//!
+//! Returns a single [`ValidationIssue`] describing the first invalid
+//! value encountered. The walk is deterministic (uses [`indexmap`]
+//! iteration order), so repeated runs against the same config surface
+//! the same diagnostic.
+
+#![allow(clippy::redundant_pub_crate)]
+
+use plumb_core::Config;
+
+/// A single semantic validation problem.
+#[derive(Debug, Clone)]
+pub(crate) struct ValidationIssue {
+    /// Dotted path of the offending value, broken into segments suitable
+    /// for [`crate::span::locate_path`]. Map keys appear as their key
+    /// strings (no quoting).
+    pub(crate) path_segments: Vec<String>,
+    /// Human-readable explanation of what's wrong.
+    pub(crate) message: String,
+}
+
+/// Walk the deserialized [`Config`] and return the first semantic
+/// validation problem, or `None` if everything is valid.
+pub(crate) fn validate(cfg: &Config) -> Option<ValidationIssue> {
+    for (token, value) in &cfg.color.tokens {
+        if !is_valid_hex_color(value) {
+            return Some(ValidationIssue {
+                path_segments: vec!["color".to_owned(), "tokens".to_owned(), token.clone()],
+                message: format!(
+                    "`{value}` is not a valid hex color (expected `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`)"
+                ),
+            });
+        }
+    }
+    None
+}
+
+/// Returns `true` if `value` is a `#`-prefixed hex color of length
+/// 3, 4, 6, or 8 nibbles.
+fn is_valid_hex_color(value: &str) -> bool {
+    let Some(body) = value.strip_prefix('#') else {
+        return false;
+    };
+    let len = body.len();
+    if !(len == 3 || len == 4 || len == 6 || len == 8) {
+        return false;
+    }
+    body.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_hex_color;
+
+    #[test]
+    fn accepts_canonical_six_digit_hex() {
+        assert!(is_valid_hex_color("#0b7285"));
+        assert!(is_valid_hex_color("#FFFFFF"));
+    }
+
+    #[test]
+    fn accepts_short_and_alpha_forms() {
+        assert!(is_valid_hex_color("#fff"));
+        assert!(is_valid_hex_color("#fffe"));
+        assert!(is_valid_hex_color("#0b728580"));
+    }
+
+    #[test]
+    fn rejects_missing_hash_or_bad_chars() {
+        assert!(!is_valid_hex_color("0b7285"));
+        assert!(!is_valid_hex_color("#0b72g5"));
+        assert!(!is_valid_hex_color("#12345"));
+        assert!(!is_valid_hex_color("not-a-hex"));
+        assert!(!is_valid_hex_color(""));
+        assert!(!is_valid_hex_color("#"));
+    }
+}

--- a/crates/plumb-config/tests/validation_errors.rs
+++ b/crates/plumb-config/tests/validation_errors.rs
@@ -1,0 +1,190 @@
+//! Span-annotated validation diagnostics.
+//!
+//! Each test exercises one of the four documented failure classes and
+//! asserts that the returned [`plumb_config::ConfigError`] surfaces a
+//! miette `Diagnostic` with a non-empty source span pointing at the
+//! offending line.
+
+// Helpers deliberately use `expect`/`expect_err` to surface failures
+// loudly. The crate's `clippy.toml` allows this in tests, but
+// integration-test helpers don't carry the `#[test]` proximity that
+// clippy looks for, so we opt them in explicitly.
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use miette::Diagnostic;
+use plumb_config::ConfigError;
+
+/// Read the byte slice covered by a diagnostic label and assert it
+/// non-empty. The label may live on either the [`ConfigError::Parse`]
+/// or [`ConfigError::Validation`] variant.
+fn assert_span_points_at(err: &ConfigError, expected_substring: &str) {
+    let source = err
+        .source_code()
+        .expect("config diagnostic should expose source code");
+
+    let mut labels = err
+        .labels()
+        .expect("config diagnostic should expose labels")
+        .collect::<Vec<_>>();
+    let label = labels
+        .pop()
+        .expect("config diagnostic should expose at least one label");
+
+    let span = label.inner();
+    let contents = source
+        .read_span(span, 0, 0)
+        .expect("source should be readable for span");
+    let bytes = contents.data();
+    let text = std::str::from_utf8(bytes).expect("source bytes are utf-8");
+
+    assert!(
+        !text.trim().is_empty(),
+        "span should cover non-empty source text, got {text:?}"
+    );
+    assert!(
+        text.contains(expected_substring),
+        "span text {text:?} should contain {expected_substring:?}",
+    );
+}
+
+fn write_config(name: &str, body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, body).expect("write config");
+    (dir, path)
+}
+
+fn load(path: &Path) -> ConfigError {
+    plumb_config::load(path).expect_err("config should fail to load")
+}
+
+#[test]
+fn unknown_top_level_key_surfaces_span() {
+    // The unknown key must precede any `[table]` header so TOML grammar
+    // parses it as a top-level key rather than a member of the active
+    // table.
+    let (_dir, path) = write_config(
+        "plumb.toml",
+        "\
+bogus_top_level = true
+
+[viewports.mobile]
+width = 320
+height = 568
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Parse { .. }),
+        "expected Parse, got {err:?}"
+    );
+    assert_span_points_at(&err, "bogus_top_level");
+}
+
+#[test]
+fn unknown_nested_key_surfaces_span() {
+    let (_dir, path) = write_config(
+        "plumb.toml",
+        "\
+[spacing]
+base_unit = 8
+made_up_field = 12
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Parse { .. }),
+        "expected Parse, got {err:?}"
+    );
+    assert_span_points_at(&err, "made_up_field");
+}
+
+#[test]
+fn wrong_type_surfaces_span() {
+    let (_dir, path) = write_config(
+        "plumb.toml",
+        "\
+[spacing]
+base_unit = \"eight\"
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Parse { .. }),
+        "expected Parse, got {err:?}"
+    );
+    assert_span_points_at(&err, "eight");
+}
+
+#[test]
+fn bad_palette_value_surfaces_span() {
+    let (_dir, path) = write_config(
+        "plumb.toml",
+        "\
+[color.tokens]
+brand = \"#0b7285\"
+bg = \"not-a-hex\"
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Validation { .. }),
+        "expected Validation, got {err:?}"
+    );
+    assert_span_points_at(&err, "not-a-hex");
+}
+
+#[test]
+fn bad_palette_value_in_yaml_surfaces_diagnostic() {
+    let (_dir, path) = write_config(
+        "plumb.yaml",
+        "\
+color:
+  tokens:
+    brand: \"#0b7285\"
+    bg: not-a-hex
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Validation { .. }),
+        "expected Validation, got {err:?}"
+    );
+    // YAML span recovery is best-effort: assert the diagnostic exposes
+    // a source code section so editors can highlight the file.
+    assert!(
+        err.source_code().is_some(),
+        "yaml validation error should expose source code"
+    );
+}
+
+#[test]
+fn unknown_top_level_key_in_yaml_surfaces_diagnostic() {
+    let (_dir, path) = write_config(
+        "plumb.yaml",
+        "\
+viewports:
+  mobile:
+    width: 320
+    height: 568
+bogus_top_level: true
+",
+    );
+
+    let err = load(&path);
+    assert!(
+        matches!(err, ConfigError::Parse { .. }),
+        "expected Parse, got {err:?}"
+    );
+    assert!(
+        err.source_code().is_some(),
+        "yaml parse error should expose source code"
+    );
+}

--- a/crates/plumb-config/tests/validation_errors.rs
+++ b/crates/plumb-config/tests/validation_errors.rs
@@ -5,10 +5,7 @@
 //! miette `Diagnostic` with a non-empty source span pointing at the
 //! offending line.
 
-// Helpers deliberately use `expect`/`expect_err` to surface failures
-// loudly. The crate's `clippy.toml` allows this in tests, but
-// integration-test helpers don't carry the `#[test]` proximity that
-// clippy looks for, so we opt them in explicitly.
+// allow expect_used — integration-test helpers lack #[test] proximity that clippy needs.
 #![allow(clippy::expect_used)]
 
 use std::path::Path;


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #22

## Summary

- Add `ConfigError::Validation` carrying `NamedSource` + `SourceSpan` so post-deserialization issues (currently bad palette hex values) reach the user with a label that points at the offending line.
- Wire `source_code` and `span` on figment-driven YAML/JSON parse errors via a key-search heuristic; previously they were `None`.
- Walk `toml::de::DeTable`'s spanned representation to resolve arbitrary dotted paths to byte offsets, so unknown-key, wrong-type, and bad-value diagnostics highlight the offending value precisely.
- Validate `[color.tokens]` entries against `#rgb`, `#rgba`, `#rrggbb`, and `#rrggbbaa` after deserialization. The walk uses `IndexMap` order so the same input always surfaces the same diagnostic.

## Crates touched

- [ ] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [x] `plumb-config`
- [ ] `plumb-mcp`
- [ ] `plumb-cli`
- [ ] `xtask`
- [ ] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [ ] Dependency added / bumped (cargo-deny must still pass)
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

`ConfigError::Validation` is the new public variant. Its docstring covers each field; `load`'s `# Errors` section was extended to mention it. No JSON Schema impact (the `Config` data shape is unchanged).

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

The two `#![allow(clippy::redundant_pub_crate)]` attributes (in `span.rs` and `validate.rs`) match the workspace convention already used in `plumb-core::rules::util`. The `#![allow(clippy::expect_used)]` in the new integration test is documented in-file: integration-test helpers don't carry the `#[test]` proximity that clippy's `allow-expect-in-tests` looks for.

## Test plan

- [x] `just validate` passes locally
- [x] `cargo xtask pre-release` passes (if rule or schema changed)
- [x] `just determinism-check` passes (3× byte-diff clean) — covered by `just validate`
- [x] `cargo deny check` passes — covered by `just validate`
- [x] New/changed behavior has a test (unit, golden snapshot, or integration)

New tests in `crates/plumb-config/tests/validation_errors.rs` cover the four documented failure classes plus YAML smoke tests for both Parse and Validation variants. New unit tests in `validate.rs` cover hex-shape acceptance/rejection. New unit tests in `span.rs` cover the TOML walk and the YAML key-search fallback.

## Documentation

- [x] Rustdoc added for every new public item
- [x] `# Errors` section on every new public fallible fn
- [ ] `docs/src/` updated when user-visible behavior changed
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [ ] Humanizer skill run on docs changes

No user-visible behavior outside of richer diagnostics on existing failure paths; release-please will pick this up at release time.

## Breaking change?

- [x] No
- [ ] Yes — describe migration path

`ConfigError` is `#[non_exhaustive]`, so adding the `Validation` variant is non-breaking. Existing matches on `Parse` continue to compile and behave identically.

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/<primary>-<type>-<slug>` — `codex/22-feat-config-miette-validation`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [ ] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

- Issue #21 is enriching `ColorSpec`/`RadiusSpec`/`AlignmentSpec`/`A11ySpec` shapes in parallel. This PR deliberately stays out of `crates/plumb-core/src/config.rs` data shapes; only `plumb-config` (the loader) is touched.
- TOML span recovery uses `toml::de::DeTable::parse`, which keeps spans on every key and value through the recursive `DeValue` tree. That avoids the `untagged` enum buffering issue that broke an earlier `Spanned<Value>` approach.
- YAML and JSON span recovery is best-effort: a key-search heuristic finds the leaf segment and spans the rest of its line. The integration tests reflect this — YAML asserts `source_code()` is present rather than asserting on a specific span.