### PR TITLE
feat(core): rule color/palette-conformance

### DIFF
--- a/crates/plumb-core/src/rules/color/mod.rs
+++ b/crates/plumb-core/src/rules/color/mod.rs
@@ -1,0 +1,27 @@
+//! Color rules.
+//!
+//! Currently:
+//!
+//! - [`palette_conformance`] — flag computed colors that aren't on the
+//!   configured palette, measured by CIEDE2000 (ΔE00) in CIE Lab space.
+
+pub mod palette_conformance;
+
+/// Computed-style properties this category inspects.
+///
+/// Order is the deterministic emission order: a single offending node
+/// can produce one violation per property, sorted alphabetically by
+/// property name within the rule's loop. The engine's outer
+/// `(rule_id, viewport, selector, dom_order)` sort then re-orders
+/// across nodes and rules — within a `(rule_id, selector)` pair the
+/// emission order is preserved by the stable sort, so two violations
+/// on the same node read in property order.
+pub(crate) const COLOR_PROPERTIES: &[&str] = &[
+    "background-color",
+    "border-bottom-color",
+    "border-left-color",
+    "border-right-color",
+    "border-top-color",
+    "color",
+    "outline-color",
+];

--- a/crates/plumb-core/src/rules/color/palette_conformance.rs
+++ b/crates/plumb-core/src/rules/color/palette_conformance.rs
@@ -149,7 +149,14 @@ impl Rule for PaletteConformance {
                             token = entry.name,
                             hex = entry.hex,
                         ),
-                        confidence: Confidence::Medium,
+                        confidence: if (parsed.a - 1.0).abs() < f32::EPSILON {
+                            Confidence::Medium
+                        } else {
+                            // Translucent source: the nearest token was picked against
+                            // the composited appearance, so swapping the literal value
+                            // changes more than the rendered color.
+                            Confidence::Low
+                        },
                     }),
                     doc_url: "https://plumb.aramhammoudeh.com/rules/color-palette-conformance"
                         .to_owned(),

--- a/crates/plumb-core/src/rules/color/palette_conformance.rs
+++ b/crates/plumb-core/src/rules/color/palette_conformance.rs
@@ -1,0 +1,368 @@
+//! `color/palette-conformance` — flag computed colors that aren't on
+//! the configured palette, measured by CIEDE2000 (ΔE00) in CIE Lab.
+//!
+//! Per acceptance criteria of the rule:
+//!
+//! - The palette is parsed once per `check` call, never per node.
+//! - Colors with non-1.0 alpha are composited over the closest opaque
+//!   ancestor `background-color` (defaulting to white) before the ΔE
+//!   measurement, so a translucent overlay is judged against what the
+//!   user actually sees.
+//! - Properties iterated: `color`, `background-color`, the four
+//!   `border-*-color` longhands, and `outline-color`. One violation
+//!   per `(node, property)` pair.
+
+use indexmap::IndexMap;
+use palette::IntoColor;
+use palette::color_difference::Ciede2000;
+use palette::white_point::D65;
+use palette::{Lab, LinSrgb, Srgb};
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::rules::color::COLOR_PROPERTIES;
+use crate::rules::util::{CssColor, parse_css_color};
+use crate::snapshot::{SnapshotCtx, SnapshotNode};
+
+/// Background assumed when no opaque ancestor declares a
+/// `background-color`. Matches the User Agent default for HTML.
+const DEFAULT_BACKGROUND: CssColor = CssColor {
+    r: 1.0,
+    g: 1.0,
+    b: 1.0,
+    a: 1.0,
+};
+
+/// One palette token, pre-converted to CIE Lab (D65) for ΔE00.
+struct PaletteEntry {
+    name: String,
+    hex: String,
+    lab: Lab<D65, f32>,
+}
+
+/// Flags computed colors whose CIEDE2000 distance to every palette
+/// token exceeds `color.delta_e_tolerance`.
+#[derive(Debug, Clone, Copy)]
+pub struct PaletteConformance;
+
+impl Rule for PaletteConformance {
+    fn id(&self) -> &'static str {
+        "color/palette-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags computed colors that aren't on `color.tokens` (CIEDE2000)."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let palette = build_palette(config);
+        if palette.is_empty() {
+            // Empty palette is a no-op. Without an allow-list, flagging
+            // every color would be noise.
+            return;
+        }
+        let tolerance = config.color.delta_e_tolerance;
+        if !tolerance.is_finite() || tolerance < 0.0 {
+            // Defensive: the schema enforces a non-negative tolerance,
+            // but a malformed runtime config shouldn't panic. Skip.
+            return;
+        }
+
+        let snapshot = ctx.snapshot();
+        let parents = parent_index(snapshot);
+
+        for node in ctx.nodes() {
+            for prop in COLOR_PROPERTIES {
+                let Some(raw) = node.computed_styles.get(*prop) else {
+                    continue;
+                };
+                let Some(parsed) = parse_css_color(raw) else {
+                    continue;
+                };
+                if parsed.a <= 0.0 {
+                    // `transparent` and zero-alpha values have no
+                    // visible color — skip rather than match against
+                    // the default background.
+                    continue;
+                }
+                let effective = if (parsed.a - 1.0).abs() < f32::EPSILON {
+                    parsed
+                } else {
+                    let backdrop = resolve_backdrop(snapshot, &parents, node);
+                    composite_over(parsed, backdrop)
+                };
+                let candidate_lab: Lab<D65, f32> = srgb_to_lab(effective.into_srgb());
+
+                let Some(nearest) = nearest_palette_entry(&palette, candidate_lab) else {
+                    continue;
+                };
+                if f64::from(nearest.delta) <= f64::from(tolerance) {
+                    continue;
+                }
+
+                let entry = &palette[nearest.index];
+                let mut metadata = IndexMap::new();
+                metadata.insert((*prop).to_owned(), serde_json::Value::String(raw.clone()));
+                metadata.insert(
+                    "nearest_token".to_owned(),
+                    serde_json::Value::String(entry.name.clone()),
+                );
+                metadata.insert(
+                    "nearest_token_hex".to_owned(),
+                    serde_json::Value::String(entry.hex.clone()),
+                );
+                metadata.insert(
+                    "delta_e".to_owned(),
+                    delta_e_metadata(nearest.delta).unwrap_or(serde_json::Value::Null),
+                );
+                metadata.insert(
+                    "delta_e_tolerance".to_owned(),
+                    delta_e_metadata(tolerance).unwrap_or(serde_json::Value::Null),
+                );
+
+                sink.push(Violation {
+                    rule_id: self.id().to_owned(),
+                    severity: self.default_severity(),
+                    message: format!(
+                        "`{selector}` has off-palette {prop} {raw}; nearest token is `{token}` ({hex}).",
+                        selector = node.selector,
+                        token = entry.name,
+                        hex = entry.hex,
+                    ),
+                    selector: node.selector.clone(),
+                    viewport: ctx.snapshot().viewport.clone(),
+                    rect: ctx.rect_for(node.dom_order),
+                    dom_order: node.dom_order,
+                    fix: Some(Fix {
+                        kind: FixKind::CssPropertyReplace {
+                            property: (*prop).to_owned(),
+                            from: raw.clone(),
+                            to: entry.hex.clone(),
+                        },
+                        description: format!(
+                            "Snap `{prop}` to the nearest palette token `{token}` ({hex}).",
+                            token = entry.name,
+                            hex = entry.hex,
+                        ),
+                        confidence: Confidence::Medium,
+                    }),
+                    doc_url: "https://plumb.aramhammoudeh.com/rules/color-palette-conformance"
+                        .to_owned(),
+                    metadata,
+                });
+            }
+        }
+    }
+}
+
+fn build_palette(config: &Config) -> Vec<PaletteEntry> {
+    let mut out = Vec::with_capacity(config.color.tokens.len());
+    for (name, hex) in &config.color.tokens {
+        let Some(parsed) = parse_css_color(hex) else {
+            // Tokens that aren't parseable hex are skipped silently
+            // rather than panicking. The config-loader is the right
+            // place to validate; the rule MUST stay pure.
+            continue;
+        };
+        if parsed.a <= 0.0 {
+            continue;
+        }
+        let lab = srgb_to_lab(parsed.into_srgb());
+        out.push(PaletteEntry {
+            name: name.clone(),
+            hex: hex.clone(),
+            lab,
+        });
+    }
+    out
+}
+
+fn srgb_to_lab(rgb: Srgb<f32>) -> Lab<D65, f32> {
+    // `palette` chains the conversion through `LinSrgb` and `Xyz`.
+    // Going through `LinSrgb` explicitly keeps the gamma-decode step
+    // visible at the call site — composite math runs in linear space,
+    // ΔE math in Lab.
+    let linear: LinSrgb<f32> = rgb.into_linear();
+    linear.into_color()
+}
+
+struct Nearest {
+    index: usize,
+    delta: f32,
+}
+
+fn nearest_palette_entry(palette: &[PaletteEntry], candidate: Lab<D65, f32>) -> Option<Nearest> {
+    let mut best: Option<Nearest> = None;
+    for (idx, entry) in palette.iter().enumerate() {
+        let delta = candidate.difference(entry.lab);
+        match best.as_mut() {
+            None => best = Some(Nearest { index: idx, delta }),
+            Some(current) => {
+                // Strictly less keeps the first-seen tie-winner
+                // (deterministic given `IndexMap` insertion order).
+                if delta < current.delta {
+                    current.index = idx;
+                    current.delta = delta;
+                }
+            }
+        }
+    }
+    best
+}
+
+fn delta_e_metadata(value: f32) -> Option<serde_json::Value> {
+    let rounded = (f64::from(value) * 1000.0).round() / 1000.0;
+    serde_json::Number::from_f64(rounded).map(serde_json::Value::Number)
+}
+
+fn parent_index(snapshot: &crate::snapshot::PlumbSnapshot) -> IndexMap<u64, u64> {
+    snapshot
+        .nodes
+        .iter()
+        .filter_map(|n| n.parent.map(|p| (n.dom_order, p)))
+        .collect()
+}
+
+fn node_by_dom_order(
+    snapshot: &crate::snapshot::PlumbSnapshot,
+    dom_order: u64,
+) -> Option<&SnapshotNode> {
+    snapshot.nodes.iter().find(|n| n.dom_order == dom_order)
+}
+
+fn resolve_backdrop(
+    snapshot: &crate::snapshot::PlumbSnapshot,
+    parents: &IndexMap<u64, u64>,
+    start: &SnapshotNode,
+) -> CssColor {
+    // Walk up the DOM ancestor chain looking for the closest
+    // `background-color` with full alpha. If we never find one, fall
+    // back to the UA default (white). The walk MUST start at the
+    // parent — the start node's own colour is what we're judging.
+    let mut current = parents.get(&start.dom_order).copied();
+    while let Some(dom_order) = current {
+        let Some(node) = node_by_dom_order(snapshot, dom_order) else {
+            break;
+        };
+        if let Some(bg) = node
+            .computed_styles
+            .get("background-color")
+            .and_then(|raw| parse_css_color(raw))
+            && (bg.a - 1.0).abs() < f32::EPSILON
+        {
+            return bg;
+        }
+        current = parents.get(&dom_order).copied();
+    }
+    DEFAULT_BACKGROUND
+}
+
+fn composite_over(src: CssColor, dst: CssColor) -> CssColor {
+    // Standard "source over" Porter–Duff in linear-light space, which
+    // is the only physically correct compositing space for sRGB
+    // alpha blending. Convert sRGB → linear, blend, convert back.
+    let s_lin: LinSrgb<f32> = Srgb::new(src.r, src.g, src.b).into_linear();
+    let d_lin: LinSrgb<f32> = Srgb::new(dst.r, dst.g, dst.b).into_linear();
+    let alpha = src.a;
+    let inv = 1.0 - alpha;
+    // Pre-multiplied "over": `out = s*alpha + d*(1-alpha)` (assuming
+    // the destination is fully opaque, which `resolve_backdrop`
+    // guarantees by walking until alpha == 1.0 or hitting white).
+    let blended = LinSrgb::new(
+        s_lin.red.mul_add(alpha, d_lin.red * inv),
+        s_lin.green.mul_add(alpha, d_lin.green * inv),
+        s_lin.blue.mul_add(alpha, d_lin.blue * inv),
+    );
+    let out: Srgb<f32> = Srgb::from_linear(blended);
+    CssColor {
+        r: out.red,
+        g: out.green,
+        b: out.blue,
+        a: 1.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_BACKGROUND, build_palette, composite_over, nearest_palette_entry, srgb_to_lab,
+    };
+    use crate::config::{ColorSpec, Config};
+    use crate::rules::util::{CssColor, parse_css_color};
+    use indexmap::IndexMap;
+
+    #[test]
+    fn build_palette_skips_unparseable_tokens() {
+        let mut tokens = IndexMap::new();
+        tokens.insert("primary".into(), "#0b7285".into());
+        tokens.insert("garbage".into(), "not-a-color".into());
+        let config = Config {
+            color: ColorSpec {
+                tokens,
+                delta_e_tolerance: 2.0,
+            },
+            ..Config::default()
+        };
+        let palette = build_palette(&config);
+        assert_eq!(palette.len(), 1);
+        assert_eq!(palette[0].name, "primary");
+    }
+
+    #[test]
+    fn nearest_palette_entry_picks_minimum_delta() {
+        let mut tokens = IndexMap::new();
+        tokens.insert("white".into(), "#ffffff".into());
+        tokens.insert("black".into(), "#000000".into());
+        tokens.insert("primary".into(), "#0b7285".into());
+        let config = Config {
+            color: ColorSpec {
+                tokens,
+                delta_e_tolerance: 2.0,
+            },
+            ..Config::default()
+        };
+        let palette = build_palette(&config);
+
+        // A near-black candidate.
+        let cand = parse_css_color("#020202").expect("parse near-black");
+        let lab = srgb_to_lab(cand.into_srgb());
+        let nearest = nearest_palette_entry(&palette, lab).expect("non-empty palette");
+        assert_eq!(palette[nearest.index].name, "black");
+    }
+
+    #[test]
+    fn composite_over_respects_alpha_zero_and_one() {
+        let red = parse_css_color("rgba(255, 0, 0, 1.0)").expect("opaque red");
+        let composited = composite_over(red, DEFAULT_BACKGROUND);
+        // Fully opaque source must come back unchanged.
+        assert!((composited.r - 1.0).abs() < 1e-4);
+        assert!((composited.g - 0.0).abs() < 1e-4);
+        assert!((composited.b - 0.0).abs() < 1e-4);
+        assert!((composited.a - 1.0).abs() < 1e-4);
+
+        // Translucent black over white must land near 50% gray in
+        // linear space — visibly mid-gray after gamma encode.
+        let half_black = parse_css_color("rgba(0, 0, 0, 0.5)").expect("translucent black");
+        let mid = composite_over(half_black, DEFAULT_BACKGROUND);
+        assert!(mid.r > 0.5 && mid.r < 0.85);
+    }
+
+    #[test]
+    fn composite_over_zero_alpha_returns_destination() {
+        let zero = CssColor {
+            r: 0.2,
+            g: 0.2,
+            b: 0.2,
+            a: 0.0,
+        };
+        let result = composite_over(zero, DEFAULT_BACKGROUND);
+        assert!((result.r - 1.0).abs() < 1e-4);
+        assert!((result.g - 1.0).abs() < 1e-4);
+        assert!((result.b - 1.0).abs() < 1e-4);
+    }
+}

--- a/crates/plumb-core/src/rules/mod.rs
+++ b/crates/plumb-core/src/rules/mod.rs
@@ -8,6 +8,7 @@
 //! 3. Add a golden snapshot test under `tests/`.
 //! 4. Document it at `docs/src/rules/<rule-id>.md`.
 
+pub mod color;
 pub mod spacing;
 pub mod type_;
 
@@ -46,6 +47,7 @@ pub trait Rule: Send + Sync {
 #[must_use]
 pub fn register_builtin() -> Vec<Box<dyn Rule>> {
     vec![
+        Box::new(color::palette_conformance::PaletteConformance),
         Box::new(spacing::grid_conformance::GridConformance),
         Box::new(spacing::scale_conformance::ScaleConformance),
         Box::new(type_::scale_conformance::ScaleConformance),

--- a/crates/plumb-core/src/rules/util.rs
+++ b/crates/plumb-core/src/rules/util.rs
@@ -304,7 +304,7 @@ pub(crate) fn nearest_in_scale(value: f64, scale: &[u32]) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{nearest_in_scale, nearest_multiple, parse_px};
+    use super::{nearest_in_scale, nearest_multiple, parse_css_color, parse_px};
 
     #[test]
     fn parse_px_accepts_supported_shapes() {
@@ -377,5 +377,76 @@ mod tests {
     #[test]
     fn nearest_in_scale_returns_none_for_empty_scale() {
         assert_eq!(nearest_in_scale(13.0, &[]), None);
+    }
+
+    #[test]
+    fn parse_css_color_expands_3_digit_hex() {
+        let c = parse_css_color("#fff").expect("hex-3 parses");
+        assert!((c.r - 1.0).abs() < 1e-6);
+        assert!((c.g - 1.0).abs() < 1e-6);
+        assert!((c.b - 1.0).abs() < 1e-6);
+        assert!((c.a - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_expands_4_digit_hex_with_alpha() {
+        let c = parse_css_color("#f00a").expect("hex-4 parses");
+        assert!((c.r - 1.0).abs() < 1e-6);
+        assert!((c.g - 0.0).abs() < 1e-6);
+        assert!((c.b - 0.0).abs() < 1e-6);
+        // 0xaa / 0xff = 170/255
+        assert!((c.a - (170.0 / 255.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_accepts_8_digit_hex_with_alpha() {
+        let c = parse_css_color("#ff00ff80").expect("hex-8 parses");
+        assert!((c.r - 1.0).abs() < 1e-6);
+        assert!((c.g - 0.0).abs() < 1e-6);
+        assert!((c.b - 1.0).abs() < 1e-6);
+        // 0x80 / 0xff
+        assert!((c.a - (128.0 / 255.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_handles_percentage_channels() {
+        let c = parse_css_color("rgb(50%, 50%, 50%)").expect("percentage rgb parses");
+        assert!((c.r - 0.5).abs() < 1e-2);
+        assert!((c.g - 0.5).abs() < 1e-2);
+        assert!((c.b - 0.5).abs() < 1e-2);
+        assert!((c.a - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_handles_rgba_with_fractional_alpha() {
+        let c = parse_css_color("rgba(255, 0, 0, 0.5)").expect("rgba parses");
+        assert!((c.r - 1.0).abs() < 1e-6);
+        assert!((c.g - 0.0).abs() < 1e-6);
+        assert!((c.b - 0.0).abs() < 1e-6);
+        assert!((c.a - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_handles_whitespace_separated_rgb() {
+        // CSS Color 4: rgb(r g b)
+        let c = parse_css_color("rgb(255 0 0)").expect("space-separated rgb parses");
+        assert!((c.r - 1.0).abs() < 1e-6);
+        assert!((c.g - 0.0).abs() < 1e-6);
+        assert!((c.b - 0.0).abs() < 1e-6);
+        assert!((c.a - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_returns_transparent_for_keyword() {
+        let c = parse_css_color("transparent").expect("transparent parses");
+        assert!((c.a - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_css_color_rejects_malformed_input() {
+        assert!(parse_css_color("#ff").is_none());
+        assert!(parse_css_color("rgb(1, 2)").is_none());
+        assert!(parse_css_color("not-a-color").is_none());
+        assert!(parse_css_color("").is_none());
     }
 }

--- a/crates/plumb-core/src/rules/util.rs
+++ b/crates/plumb-core/src/rules/util.rs
@@ -1,13 +1,204 @@
 //! Internal helpers shared by the built-in rules.
 //!
 //! Rules in `plumb-core` are pure functions of `(snapshot, config)`. The
-//! shared helpers here encapsulate CSS-pixel parsing and discrete-scale
-//! lookup so rule modules stay focused on their domain logic.
+//! shared helpers here encapsulate CSS-pixel parsing, CSS-color parsing,
+//! and discrete-scale lookup so rule modules stay focused on their
+//! domain logic.
 //!
 //! All helpers are `pub(crate)` — they are an implementation detail of
 //! the rule modules, not a stable surface.
 
 #![allow(clippy::redundant_pub_crate)]
+
+use palette::Srgb;
+use std::str::FromStr;
+
+/// Parsed CSS color in the (gamma-encoded) sRGB color space.
+///
+/// Components are non-linear sRGB in `[0.0, 1.0]`, matching the
+/// encoding of `palette::Srgb<f32>`. Alpha is in `[0.0, 1.0]`, with
+/// `1.0` meaning fully opaque.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CssColor {
+    /// sRGB red, gamma-encoded, `[0.0, 1.0]`.
+    pub(crate) r: f32,
+    /// sRGB green, gamma-encoded, `[0.0, 1.0]`.
+    pub(crate) g: f32,
+    /// sRGB blue, gamma-encoded, `[0.0, 1.0]`.
+    pub(crate) b: f32,
+    /// Alpha channel, `[0.0, 1.0]`.
+    pub(crate) a: f32,
+}
+
+impl CssColor {
+    /// Build from byte (0..=255) channels and an alpha in `[0.0, 1.0]`.
+    fn from_rgb_u8_alpha(r: u8, g: u8, b: u8, a: f32) -> Self {
+        Self {
+            r: f32::from(r) / 255.0,
+            g: f32::from(g) / 255.0,
+            b: f32::from(b) / 255.0,
+            a,
+        }
+    }
+
+    /// View as a `palette::Srgb<f32>` (alpha discarded).
+    pub(crate) fn into_srgb(self) -> Srgb<f32> {
+        Srgb::new(self.r, self.g, self.b)
+    }
+}
+
+/// Parse the CSS color shapes that `getComputedStyle` ever returns
+/// after Chromium's normalization, plus a few hand-friendly forms used
+/// by Plumb config tokens.
+///
+/// Accepted shapes:
+///
+/// - `"transparent"` — returns alpha == 0 (caller MUST skip).
+/// - `"#rgb"`, `"#rrggbb"`, `"#rgba"`, `"#rrggbbaa"` — hex with
+///   optional alpha.
+/// - `"rgb(r, g, b)"` — decimal channels, no alpha (`a = 1.0`).
+/// - `"rgba(r, g, b, a)"` — decimal channels and alpha in `[0, 1]`.
+///
+/// Whitespace is tolerated. Anything else (named colors other than
+/// `transparent`, `hsl()`, `hsla()`, `color()`, etc.) returns `None`
+/// so the caller can skip silently. Chromium's resolved-style output
+/// for any color other than `transparent` is `rgb(...)` or `rgba(...)`,
+/// so this covers every snapshot value Plumb sees in practice; the
+/// hex paths handle palette tokens defined in `plumb.toml`.
+#[must_use]
+pub(crate) fn parse_css_color(s: &str) -> Option<CssColor> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.eq_ignore_ascii_case("transparent") {
+        return Some(CssColor {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0.0,
+        });
+    }
+    if trimmed.starts_with('#') {
+        return parse_hex(trimmed);
+    }
+    if let Some(rest) = strip_ci_prefix(trimmed, "rgba") {
+        return parse_rgb_functional(rest);
+    }
+    if let Some(rest) = strip_ci_prefix(trimmed, "rgb") {
+        return parse_rgb_functional(rest);
+    }
+    None
+}
+
+fn strip_ci_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    let plen = prefix.len();
+    if s.len() < plen {
+        return None;
+    }
+    let (head, tail) = s.split_at(plen);
+    if head.eq_ignore_ascii_case(prefix) {
+        Some(tail)
+    } else {
+        None
+    }
+}
+
+fn parse_hex(input: &str) -> Option<CssColor> {
+    // Route by hex length — `palette::Srgb::<u8>::from_str` covers the
+    // 3 / 6 cases. The 4 / 8 (with alpha) shapes need a hand-rolled
+    // split because palette's `Rgba` FromStr is generic over `Alpha`.
+    let hex = input.strip_prefix('#').unwrap_or(input);
+    match hex.len() {
+        3 | 6 => {
+            let rgb: Srgb<u8> = Srgb::from_str(input).ok()?;
+            Some(CssColor::from_rgb_u8_alpha(
+                rgb.red, rgb.green, rgb.blue, 1.0,
+            ))
+        }
+        4 => {
+            let red = u8::from_str_radix(&hex[0..1], 16).ok()?;
+            let green = u8::from_str_radix(&hex[1..2], 16).ok()?;
+            let blue = u8::from_str_radix(&hex[2..3], 16).ok()?;
+            let alpha = u8::from_str_radix(&hex[3..4], 16).ok()?;
+            Some(CssColor::from_rgb_u8_alpha(
+                red * 17,
+                green * 17,
+                blue * 17,
+                f32::from(alpha * 17) / 255.0,
+            ))
+        }
+        8 => {
+            let red = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let green = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let blue = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            let alpha = u8::from_str_radix(&hex[6..8], 16).ok()?;
+            Some(CssColor::from_rgb_u8_alpha(
+                red,
+                green,
+                blue,
+                f32::from(alpha) / 255.0,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn parse_rgb_functional(input: &str) -> Option<CssColor> {
+    let trimmed = input.trim();
+    let inner = trimmed.strip_prefix('(')?.strip_suffix(')')?.trim();
+    // Tolerate both comma and whitespace separation. Chromium emits
+    // `rgb(255, 0, 0)` with commas; CSS Color 4 also allows
+    // `rgb(255 0 0)`. Splitting on either keeps the parser usable
+    // for hand-written palette config.
+    let parts: Vec<&str> = if inner.contains(',') {
+        inner.split(',').map(str::trim).collect()
+    } else {
+        inner.split_whitespace().collect()
+    };
+
+    let (red_s, green_s, blue_s, alpha_s) = match parts.as_slice() {
+        [r, g, b] => (*r, *g, *b, None),
+        [r, g, b, a] => (*r, *g, *b, Some(*a)),
+        _ => return None,
+    };
+    let alpha = match alpha_s {
+        Some(token) => parse_alpha(token)?,
+        // The function name (`rgb` vs `rgba`) does not constrain the
+        // channel count — `rgba(r, g, b)` is silently treated as
+        // opaque. Chromium normalizes both to the same shape.
+        None => 1.0,
+    };
+    let red = parse_channel(red_s)?;
+    let green = parse_channel(green_s)?;
+    let blue = parse_channel(blue_s)?;
+    Some(CssColor::from_rgb_u8_alpha(red, green, blue, alpha))
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn parse_channel(s: &str) -> Option<u8> {
+    let trimmed = s.trim();
+    if let Some(pct) = trimmed.strip_suffix('%') {
+        let v = pct.trim().parse::<f32>().ok()?;
+        let scaled = (v / 100.0).clamp(0.0, 1.0) * 255.0;
+        // Clamp keeps the cast safe; `round` is half-away-from-zero.
+        return Some(scaled.round().clamp(0.0, 255.0) as u8);
+    }
+    let v = trimmed.parse::<f32>().ok()?;
+    // Accept fractional channel values (CSS Color 4) by rounding to
+    // the nearest integer.
+    Some(v.round().clamp(0.0, 255.0) as u8)
+}
+
+fn parse_alpha(s: &str) -> Option<f32> {
+    let trimmed = s.trim();
+    if let Some(pct) = trimmed.strip_suffix('%') {
+        let v = pct.trim().parse::<f32>().ok()?;
+        return Some((v / 100.0).clamp(0.0, 1.0));
+    }
+    let v = trimmed.parse::<f32>().ok()?;
+    Some(v.clamp(0.0, 1.0))
+}
 
 /// Parse a CSS pixel value into an `f64`.
 ///

--- a/crates/plumb-core/tests/golden_color_palette_conformance.rs
+++ b/crates/plumb-core/tests/golden_color_palette_conformance.rs
@@ -1,0 +1,208 @@
+//! Golden snapshot for the `color/palette-conformance` rule.
+//!
+//! Hand-built fixture covering the four behaviours that matter:
+//!
+//! 1. A node whose `color` matches a palette token exactly — no
+//!    violation.
+//! 2. A node whose `color` is off-palette by less than the
+//!    `delta_e_tolerance` — no violation.
+//! 3. A node whose `color` is off-palette by more than the tolerance
+//!    — one violation.
+//! 4. A node with `color: rgba(...)` carrying alpha < 1 over a
+//!    fully-opaque ancestor `background-color`. The composited
+//!    foreground sits well outside the palette, so one violation
+//!    fires and the violation message references the original raw
+//!    value (not the composited result).
+
+use indexmap::IndexMap;
+use plumb_core::config::{ColorSpec, Config};
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let exact_match = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("color", "rgb(11, 114, 133)")],
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
+    );
+
+    // Within tolerance: a slight nudge away from #0b7285.
+    let within_tolerance = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("color", "rgb(12, 115, 134)")],
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
+    );
+
+    // Way off-palette: bright pink against a teal/black/white palette.
+    let off_palette = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[("color", "rgb(255, 0, 153)")],
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
+    );
+
+    // Translucent foreground over an opaque ancestor `background-color`.
+    // The body's `background-color: #ffffff` is the resolved backdrop.
+    // `rgba(0, 0, 0, 0.4)` blended over white lands near a mid-gray
+    // that's > 2 ΔE00 from any palette token.
+    let translucent = node(
+        5,
+        "html > body > div:nth-child(4)",
+        &[("color", "rgba(0, 0, 0, 0.4)")],
+        Some(Rect {
+            x: 0,
+            y: 72,
+            width: 200,
+            height: 24,
+        }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://color-palette".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![
+            root_html(),
+            body_node(),
+            exact_match,
+            within_tolerance,
+            off_palette,
+            translucent,
+        ],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    let mut styles = IndexMap::new();
+    // The body declares a fully-opaque white background, so the
+    // alpha-blending path in `palette-conformance` resolves the
+    // backdrop to `#ffffff` for translucent descendants.
+    styles.insert("background-color".into(), "rgb(255, 255, 255)".into());
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: styles,
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: Some(0),
+        children: vec![2, 3, 4, 5],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    let mut tokens = IndexMap::new();
+    tokens.insert("white".into(), "#ffffff".into());
+    tokens.insert("black".into(), "#000000".into());
+    tokens.insert("primary".into(), "#0b7285".into());
+    Config {
+        color: ColorSpec {
+            tokens,
+            delta_e_tolerance: 2.0,
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn color_palette_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "color/palette-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("color_palette_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn color_palette_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}
+
+#[test]
+fn color_palette_conformance_skips_when_palette_empty() {
+    let snapshot = fixture_snapshot();
+    let config = Config::default();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "color/palette-conformance")
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "expected zero violations with empty palette, got {violations:?}"
+    );
+}

--- a/crates/plumb-core/tests/snapshots/golden_color_palette_conformance__color_palette_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_color_palette_conformance__color_palette_conformance.snap
@@ -57,7 +57,7 @@ expression: json
         "to": "#ffffff"
       },
       "description": "Snap `color` to the nearest palette token `white` (#ffffff).",
-      "confidence": "medium"
+      "confidence": "low"
     },
     "doc_url": "https://plumb.aramhammoudeh.com/rules/color-palette-conformance",
     "metadata": {

--- a/crates/plumb-core/tests/snapshots/golden_color_palette_conformance__color_palette_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_color_palette_conformance__color_palette_conformance.snap
@@ -1,0 +1,71 @@
+---
+source: crates/plumb-core/tests/golden_color_palette_conformance.rs
+assertion_line: 180
+expression: json
+---
+[
+  {
+    "rule_id": "color/palette-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(3)` has off-palette color rgb(255, 0, 153); nearest token is `white` (#ffffff).",
+    "selector": "html > body > div:nth-child(3)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 48,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 4,
+    "fix": {
+      "kind": {
+        "kind": "css_property_replace",
+        "property": "color",
+        "from": "rgb(255, 0, 153)",
+        "to": "#ffffff"
+      },
+      "description": "Snap `color` to the nearest palette token `white` (#ffffff).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-palette-conformance",
+    "metadata": {
+      "color": "rgb(255, 0, 153)",
+      "nearest_token": "white",
+      "nearest_token_hex": "#ffffff",
+      "delta_e": 43.071,
+      "delta_e_tolerance": 2.0
+    }
+  },
+  {
+    "rule_id": "color/palette-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(4)` has off-palette color rgba(0, 0, 0, 0.4); nearest token is `white` (#ffffff).",
+    "selector": "html > body > div:nth-child(4)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 72,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 5,
+    "fix": {
+      "kind": {
+        "kind": "css_property_replace",
+        "property": "color",
+        "from": "rgba(0, 0, 0, 0.4)",
+        "to": "#ffffff"
+      },
+      "description": "Snap `color` to the nearest palette token `white` (#ffffff).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-palette-conformance",
+    "metadata": {
+      "color": "rgba(0, 0, 0, 0.4)",
+      "nearest_token": "white",
+      "nearest_token_hex": "#ffffff",
+      "delta_e": 11.28,
+      "delta_e_tolerance": 2.0
+    }
+  }
+]

--- a/docs/src/rules/color-palette-conformance.md
+++ b/docs/src/rules/color-palette-conformance.md
@@ -1,0 +1,145 @@
+# color/palette-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads each of these computed
+styles and parses the value as a CSS color:
+
+- `color`
+- `background-color`
+- `border-top-color`, `border-right-color`, `border-bottom-color`, `border-left-color`
+- `outline-color`
+
+Each parsed color is converted to CIE Lab (D65) and compared against
+every entry in `color.tokens` via CIEDE2000 (ΔE00). A property fires
+a violation when the smallest distance to any token exceeds
+`color.delta_e_tolerance` (default `2.0`).
+
+The rule MUST skip a property when:
+
+- the value parses as `transparent` or has alpha `0`;
+- the value is not one of the supported shapes — `rgb(...)`,
+  `rgba(...)`, `#rgb`, `#rrggbb`, `#rgba`, `#rrggbbaa` (HSL, named
+  colors other than `transparent`, and `color()` resolve through
+  Chromium to one of these in real snapshots);
+- or `color.tokens` is empty (the rule is a no-op in that case
+  rather than flagging every color as off-palette).
+
+For colors with `0 < alpha < 1`, the rule walks up the DOM ancestor
+chain looking for the closest `background-color` with `alpha == 1.0`
+and composites the foreground over it (Porter–Duff "source over" in
+linear-light sRGB). When no fully-opaque ancestor declares a
+`background-color`, the rule defaults to `#ffffff` — the User Agent
+default. The composited result is the value used for the ΔE00
+measurement, so a translucent overlay is judged against what the
+user actually sees.
+
+At most one violation is emitted per `(node, property)` pair.
+
+## Why it matters
+
+A palette is the design system's vocabulary for color. Off-palette
+values introduce vocabulary the system did not sanction — a slightly
+warmer red here, a slightly grayer text color there — and the
+cumulative drift erodes the system's identity. CIEDE2000 is the
+standard perceptual color-difference metric: a tolerance of `2.0` is
+the "just noticeable difference" threshold for trained observers, so
+a violation reads as "a designer would see this is not the right
+color."
+
+The rule's blended-background semantics matter for translucent UI
+chrome — a half-opaque "muted" foreground that lands on a dark
+background renders very differently from the same color on white,
+and the rule judges it where it actually lives in the rendered tree.
+
+## Example violation
+
+```json
+{
+  "rule_id": "color/palette-conformance",
+  "severity": "warning",
+  "message": "`html > body > div:nth-child(3)` has off-palette color rgb(255, 0, 153); nearest token is `white` (#ffffff).",
+  "selector": "html > body > div:nth-child(3)",
+  "viewport": "desktop",
+  "dom_order": 4,
+  "fix": {
+    "kind": {
+      "kind": "css_property_replace",
+      "property": "color",
+      "from": "rgb(255, 0, 153)",
+      "to": "#ffffff"
+    },
+    "description": "Snap `color` to the nearest palette token `white` (#ffffff).",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/color-palette-conformance",
+  "metadata": {
+    "color": "rgb(255, 0, 153)",
+    "nearest_token": "white",
+    "nearest_token_hex": "#ffffff",
+    "delta_e": 43.071,
+    "delta_e_tolerance": 2.0
+  }
+}
+```
+
+The `metadata` block carries the ΔE00 value, the active tolerance,
+and the nearest token's name and hex so downstream tooling can
+render a richer suggestion than the bare `Fix` payload.
+
+## Configuration
+
+`color.tokens` is the list of allowed colors as `name → hex` pairs.
+Slash-delimited names (`"bg/canvas"`) act as informal namespaces.
+Default is empty (the rule is a no-op).
+
+`color.delta_e_tolerance` controls how strict the match is. Default
+is `2.0`. Lower values are stricter; values above `5.0` admit colors
+that most designers would call "different."
+
+```toml
+[color]
+delta_e_tolerance = 2.0
+
+[color.tokens]
+"bg/canvas" = "#ffffff"
+"fg/primary" = "#0b7285"
+"fg/muted" = "#495057"
+```
+
+The rule converts every token to CIE Lab once per `check` call
+(never per node) and picks the nearest token by smallest CIEDE2000
+distance when emitting a fix. Ties resolve to the first-declared
+token (deterministic given `IndexMap` insertion order).
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."color/palette-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."color/palette-conformance"]
+severity = "info"
+```
+
+`RuleOverride` accepts both `enabled` (default `true`) and an
+optional `severity` of `info`, `warning`, or `error`. Severity
+remapping is applied at the formatter layer.
+
+## See also
+
+- [`spacing/scale-conformance`](./spacing-scale-conformance.md) — the
+  same allow-list shape applied to the spacing scale.
+- [`type/scale-conformance`](./type-scale-conformance.md) — the same
+  shape for `font-size`.
+- PRD §11.3 — color rules and the token model.


### PR DESCRIPTION
## Target branch

- [x] This PR targets `main`

## Spec

Fixes #23

## Summary

- Adds the `color/palette-conformance` built-in rule. Flags computed colors whose CIEDE2000 distance to every entry in `color.tokens` exceeds `color.delta_e_tolerance` (default `2.0`).
- Translucent colors are composited over the closest opaque ancestor `background-color` (default `#ffffff`) in linear sRGB before the ΔE measurement, so overlays are judged where they actually render.
- Palette is converted to CIE Lab once per `check` call (never per node) and cached as `Vec<PaletteEntry>`.

## Crates touched

- [x] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [ ] `plumb-config`
- [ ] `plumb-mcp`
- [ ] `plumb-cli`
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [ ] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [x] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [ ] Dependency added / bumped (cargo-deny must still pass)
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

The rule reuses `Config::color` (`tokens` + `delta_e_tolerance`), which already shipped with PR #109; no schema change required.

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `just validate` passes locally
- [x] `cargo xtask pre-release` passes (4 built-in rules; all have docs pages)
- [x] `just determinism-check` passes (3× byte-diff clean)
- [x] `cargo deny check` passes
- [x] New/changed behavior has a test — unit tests in `palette_conformance.rs::tests`, golden snapshot in `tests/golden_color_palette_conformance.rs`

## Documentation

- [x] Rustdoc added for every new public item (`PaletteConformance`)
- [ ] `# Errors` section on every new public fallible fn (no new fallible fn)
- [ ] `docs/src/` updated when user-visible behavior changed
- [x] `docs/src/rules/<category>-<id>.md` written for new rules
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [x] Humanizer skill run on docs changes (avoided AI-tell phrasing in `color-palette-conformance.md`)

## Breaking change?

- [x] No
- [ ] Yes — describe migration path

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/<primary>-<type>-<slug>`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [ ] `/gh-review --local-diff main...HEAD` run locally

## Implementation notes

**ΔE00 implementation choice.** `palette` 0.7 only implements `Ciede2000` for `Lab<D65, _>` and `Lch<D65, _>`; the `Oklab` type carries `EuclideanDistance` only. Per the spec's "use what palette exposes" hint, I converted candidates and tokens through `LinSrgb → Xyz → Lab(D65)` and used `Ciede2000::difference` for ΔE00. Math runs on `f32` to keep the conversion path light.

**Backdrop fallback.** `resolve_backdrop` walks `parent_dom_order` until it finds an ancestor with `background-color` and `alpha == 1.0`. If the walk never finds one (or hits the root), the rule defaults to `CssColor { r: 1.0, g: 1.0, b: 1.0, a: 1.0 }` — the User Agent default. The walk starts at `start.parent`, never the start node, since the start node's own color is what's being judged.

**Compositing.** Standard "source over" Porter–Duff in linear-light sRGB. The ancestor walk guarantees the destination has `alpha == 1.0`, so the simplified `out = src.a * src + (1 - src.a) * dst` form is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)