### PR TITLE
docs: retarget phase 1 acceptance criterion to checked-in fixture

### DIFF
--- a/docs/runbooks/phase-1-spec.yaml
+++ b/docs/runbooks/phase-1-spec.yaml
@@ -19,7 +19,7 @@ parent:
     extension follows: Rule trait + golden test + docs page +
     register_builtin; Chromium launch + DOMSnapshot + viewport multi-run.
   acceptance_criteria:
-    - "`plumb lint https://plumb.aramhammoudeh.com --format json` renders a real page via Chromium and emits ≥1 violation from a real rule."
+    - "`plumb lint file://$REPO/crates/plumb-cdp/tests/fixtures/static_page.html --format json` (with `$REPO` resolved to an absolute path) renders the checked-in fixture via Chromium and emits ≥1 violation from a real rule. The fixture's `padding:13px` on `<body>` is off-grid against the default `spacing.base_unit = 4`, so `spacing/grid-conformance` fires deterministically. (Phase 6 (#56) will additionally enable `https://plumb.aramhammoudeh.com` as an acceptance target once the docs site ships.)"
     - "3x byte-diff determinism check holds on the new rules (`just determinism-check`)."
     - "`cargo xtask pre-release` green — rule docs in sync, schema current."
     - "All 9 child PRs merged."
@@ -188,8 +188,11 @@ batches:
 
 phase_gate:
   criterion: |
-    `just validate` green AND `plumb lint https://plumb.aramhammoudeh.com --format json`
-    renders a real page via Chromium and emits ≥1 violation from a real
-    rule AND `just determinism-check` passes on the new rules AND
+    `just validate` green AND `plumb lint file://$REPO/crates/plumb-cdp/tests/fixtures/static_page.html --format json`
+    (with `$REPO` resolved to an absolute path) renders the checked-in
+    fixture via Chromium and emits ≥1 violation from a real rule AND
+    `just determinism-check` passes on the new rules AND
     `cargo xtask pre-release` passes (rule docs in sync, schema current).
+    The docs-site URL `https://plumb.aramhammoudeh.com` becomes an
+    additional valid target in Phase 6 (#56) once the site ships.
   unblocks: "phase-2"


### PR DESCRIPTION
## Summary

Closes #120 — the phase 1 acceptance criterion in `docs/runbooks/phase-1-spec.yaml` pre-conditioned on `https://plumb.aramhammoudeh.com` resolving, but the docs site is a phase 6 deliverable (#56). Anyone re-running the gate today gets a Chromium navigation error instead of a clean rule violation.

## Fix

Replace the URL in both the parent-issue acceptance criterion and the phase-gate criterion with a `file://` reference to the existing checked-in fixture at `crates/plumb-cdp/tests/fixtures/static_page.html`.

## Why this fixture

- **Self-contained.** No network dependency, no third-party uptime risk.
- **Already exercise-tested.** `chromium_driver_captures_static_fixture` in `crates/plumb-cdp/tests/driver_contract.rs` (gated behind the `e2e-chromium` feature) already drives Chromium against this exact path.
- **Deterministically triggers a real rule.** `body { padding: 13px }` is off-grid for the default `spacing.base_unit = 4`, so `spacing/grid-conformance` fires every run.
- **Forward-compatible.** The phase-gate text notes that `https://plumb.aramhammoudeh.com` becomes an additional valid acceptance target once phase 6 (#56) ships.

This matches option 3 from the issue ("checked-in HTML fixture served via `file://`"), which the issue author flagged as the lowest-friction option.

## What's NOT changed

- Other repo-wide references to `plumb.aramhammoudeh.com` (rule `doc_url` strings, SARIF `informationUri`, `Cargo.toml` homepage, README install link, schema `$id`s, phase-3/phase-6/roadmap specs). These are aspirational, will resolve when phase 6 ships, and are not what #120 is reporting.
- `crates/plumb-cli/tests/cli_integration.rs:61` and `crates/plumb-cdp/tests/driver_contract.rs:68` reference the URL but never resolve it (the former asserts the Chromium-not-found error path; the latter asserts `is_fake_url` returns `false`). Both stay correct under any URL choice.

## Test plan

- [x] `cargo xtask validate-runbooks` — 8 specs valid.
- [x] `just validate` — all gates pass (fmt + clippy `-D warnings` + nextest + cargo deny + audit).
- [ ] CI green on the PR.
- [ ] Claude code reviewer verdict: APPROVE.

## Layer / determinism / scope

- **Crates touched:** none (docs-only — `docs/runbooks/phase-1-spec.yaml`).
- **Layer discipline:** N/A.
- **Determinism:** N/A (no engine output changed).
- **Security:** N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
