### PR TITLE
fix(cdp): scale FakeDriver viewport rects to configured target

### DIFF
--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -368,6 +368,12 @@ async fn inject_animation_killer(page: &Page) -> Result<(), CdpError> {
 /// Deterministic fake driver. Recognizes `plumb-fake://hello` and returns
 /// [`PlumbSnapshot::canned`]. Used by the walking-skeleton CLI and by
 /// downstream tests.
+///
+/// Viewport-aware end-to-end: the returned snapshot's viewport name,
+/// width, and height match the target, and any per-node rect that
+/// covered the canned viewport is rescaled to the target dimensions
+/// so that hand-testing multi-viewport behavior produces the expected
+/// rects rather than the canned 1280x800 ones.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FakeDriver;
 
@@ -376,9 +382,25 @@ impl BrowserDriver for FakeDriver {
     async fn snapshot(&self, target: Target) -> Result<PlumbSnapshot, CdpError> {
         if target.url == "plumb-fake://hello" {
             let mut snap = PlumbSnapshot::canned();
+            // Capture the canned viewport bounds before overwriting so
+            // we can rewrite any node rect that covered the full
+            // canned viewport to the target's dimensions.
+            let canned_w = snap.viewport_width;
+            let canned_h = snap.viewport_height;
             snap.viewport = target.viewport.clone();
             snap.viewport_width = target.width;
             snap.viewport_height = target.height;
+            for node in &mut snap.nodes {
+                if let Some(rect) = node.rect.as_mut()
+                    && rect.x == 0
+                    && rect.y == 0
+                    && rect.width == canned_w
+                    && rect.height == canned_h
+                {
+                    rect.width = target.width;
+                    rect.height = target.height;
+                }
+            }
             Ok(snap)
         } else {
             Err(CdpError::UnknownFakeUrl(target.url))

--- a/crates/plumb-cdp/tests/snapshot_all_default.rs
+++ b/crates/plumb-cdp/tests/snapshot_all_default.rs
@@ -37,3 +37,51 @@ async fn fake_driver_snapshot_all_preserves_target_order_and_viewport() -> Resul
 
     Ok(())
 }
+
+/// Regression for #121: the canned snapshot's html/body rects are
+/// viewport-sized, so when a non-default viewport is requested the
+/// fake driver MUST rewrite those rects to match the target's
+/// width/height — otherwise hand-testing multi-viewport behavior
+/// against `plumb-fake://` reports desktop rects on mobile.
+#[tokio::test]
+async fn fake_driver_rewrites_viewport_sized_rects_to_target() -> Result<(), CdpError> {
+    let driver = FakeDriver;
+    let snap = driver.snapshot(target("mobile", 375, 667)).await?;
+
+    assert_eq!(snap.viewport_width, 375);
+    assert_eq!(snap.viewport_height, 667);
+
+    let html = snap
+        .nodes
+        .iter()
+        .find(|n| n.tag == "html")
+        .expect("canned snapshot has an <html> root");
+    let html_rect = html.rect.expect("html node has a rect");
+    assert_eq!(html_rect.x, 0);
+    assert_eq!(html_rect.y, 0);
+    assert_eq!(
+        html_rect.width, 375,
+        "html rect width follows target viewport"
+    );
+    assert_eq!(
+        html_rect.height, 667,
+        "html rect height follows target viewport"
+    );
+
+    let body = snap
+        .nodes
+        .iter()
+        .find(|n| n.tag == "body")
+        .expect("canned snapshot has a <body>");
+    let body_rect = body.rect.expect("body node has a rect");
+    assert_eq!(
+        body_rect.width, 375,
+        "body rect width follows target viewport"
+    );
+    assert_eq!(
+        body_rect.height, 667,
+        "body rect height follows target viewport"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `FakeDriver::snapshot` already retargeted `viewport`/`viewport_width`/`viewport_height` per request, but the per-node `rect` values from `PlumbSnapshot::canned()` (html and body) stayed at the canned `1280×800`. Multi-viewport runs against `plumb-fake://hello` therefore reported `mobile` viewports with `desktop` rects.
- After this change, any node whose rect equals the canned viewport bounds `(0, 0, canned_w, canned_h)` is rewritten to the requested target's `width`/`height`. Captured before the field assignments so there are no magic numbers.
- New regression test in `crates/plumb-cdp/tests/snapshot_all_default.rs::fake_driver_rewrites_viewport_sized_rects_to_target` requests `mobile` 375×667 and asserts both html and body rects come back at 375×667.

## Test plan

- [x] `cargo test -p plumb-cdp --test snapshot_all_default` — both tests pass
- [x] `cargo test -p plumb-cdp` — crate suite passes
- [x] `cargo test --workspace` — workspace passes
- [x] `cargo clippy -p plumb-cdp --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)