### PR TITLE
feat(mcp): add explain_rule tool

### DIFF
--- a/crates/plumb-mcp/src/explain.rs
+++ b/crates/plumb-mcp/src/explain.rs
@@ -1,0 +1,85 @@
+//! Static rule-doc table for the `explain_rule` MCP tool.
+//!
+//! Each entry pairs a built-in rule id (`<category>/<id>`) with the
+//! markdown body of `docs/src/rules/<slug>.md`, where `slug` is the
+//! rule id with `/` replaced by `-`. The markdown is embedded at
+//! compile time via `include_str!`, keeping the binary self-contained
+//! and the response a pure function of `rule_id`.
+//!
+//! The table MUST stay in lock-step with
+//! [`plumb_core::rules::register_builtin`]. The
+//! `every_builtin_rule_has_doc_entry` test in
+//! `tests/mcp_protocol.rs` guards against drift.
+
+// Items are `pub(crate)` because this module is private but needs to be
+// visible to `lib.rs`. The clippy nursery lint flags `pub(crate)` in
+// private modules as redundant; we keep it explicit for clarity since
+// `rule_ids` below is re-exported with `pub`.
+#![allow(clippy::redundant_pub_crate)]
+
+/// A built-in rule's canonical documentation entry.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RuleDoc {
+    /// Stable rule id, `<category>/<id>` — matches `Rule::id`.
+    pub(crate) rule_id: &'static str,
+    /// Markdown body of `docs/src/rules/<slug>.md`.
+    pub(crate) markdown: &'static str,
+}
+
+/// Table of every built-in rule's documentation. Entries are sorted by
+/// `rule_id` for deterministic iteration.
+pub(crate) const RULE_DOCS: &[RuleDoc] = &[
+    RuleDoc {
+        rule_id: "a11y/touch-target",
+        markdown: include_str!("../../../docs/src/rules/a11y-touch-target.md"),
+    },
+    RuleDoc {
+        rule_id: "color/palette-conformance",
+        markdown: include_str!("../../../docs/src/rules/color-palette-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "edge/near-alignment",
+        markdown: include_str!("../../../docs/src/rules/edge-near-alignment.md"),
+    },
+    RuleDoc {
+        rule_id: "radius/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/radius-scale-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "sibling/height-consistency",
+        markdown: include_str!("../../../docs/src/rules/sibling-height-consistency.md"),
+    },
+    RuleDoc {
+        rule_id: "spacing/grid-conformance",
+        markdown: include_str!("../../../docs/src/rules/spacing-grid-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "spacing/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/spacing-scale-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "type/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/type-scale-conformance.md"),
+    },
+];
+
+/// Look up the markdown body for a rule id. Returns `None` for unknown
+/// ids — callers map this to a JSON-RPC `-32602` error.
+pub(crate) fn lookup(rule_id: &str) -> Option<&'static RuleDoc> {
+    RULE_DOCS.iter().find(|entry| entry.rule_id == rule_id)
+}
+
+/// Every rule id with a documentation entry. Test-only — used by the
+/// drift guard that asserts the table matches `register_builtin()`.
+#[doc(hidden)]
+#[must_use]
+pub fn rule_ids() -> Vec<&'static str> {
+    RULE_DOCS.iter().map(|entry| entry.rule_id).collect()
+}
+
+/// Build the canonical book URL for a rule id. Mirrors the doc-page
+/// slug convention (`/` → `-`).
+pub(crate) fn doc_url(rule_id: &str) -> String {
+    let slug = rule_id.replace('/', "-");
+    format!("https://plumb.aramhammoudeh.com/rules/{slug}")
+}

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -3,12 +3,14 @@
 //! Model Context Protocol server for Plumb, backed by the official
 //! [`rmcp`] Rust SDK.
 //!
-//! The server exposes two tools to AI coding agents:
+//! The server exposes these tools to AI coding agents:
 //!
 //! - `echo` — smoke-tests the transport.
 //! - `lint_url` — lints a URL and returns violations in the MCP-compact
 //!   shape from `docs/local/prd.md` §14.2. Walking-skeleton accepts
 //!   `plumb-fake://` URLs only.
+//! - `explain_rule` — returns the canonical markdown documentation and
+//!   metadata for a built-in rule by id.
 //!
 //! The [`PlumbServer`] type implements [`rmcp::ServerHandler`] directly.
 //! Extend it by adding a tool descriptor to `list_tools` and a matching
@@ -19,9 +21,14 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+mod explain;
+
+#[doc(hidden)]
+pub use explain::rule_ids as documented_rule_ids;
+
 use std::io;
 
-use plumb_core::{Config, PlumbSnapshot, run};
+use plumb_core::{Config, PlumbSnapshot, register_builtin, run};
 use plumb_format::mcp_compact;
 use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
@@ -64,6 +71,13 @@ pub struct LintUrlArgs {
     pub url: String,
 }
 
+/// Arguments to the `explain_rule` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExplainRuleArgs {
+    /// Stable rule id, `<category>/<id>` (e.g. `spacing/scale-conformance`).
+    pub rule_id: String,
+}
+
 /// The Plumb MCP server. Cheap to construct.
 #[derive(Clone, Default)]
 pub struct PlumbServer {
@@ -95,6 +109,56 @@ impl PlumbServer {
         result.structured_content = Some(structured);
         Ok(result)
     }
+
+    /// Look up the canonical documentation for a built-in rule.
+    ///
+    /// Returns a [`CallToolResult`] whose first content block is the
+    /// rule's markdown body and whose `structured_content` carries
+    /// `{ rule_id, severity, summary, doc_url, markdown }`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorData::invalid_params`] (JSON-RPC `-32602`) when
+    /// `args.rule_id` does not name a built-in rule.
+    pub async fn explain_rule(&self, args: ExplainRuleArgs) -> Result<CallToolResult, ErrorData> {
+        let Some(entry) = explain::lookup(&args.rule_id) else {
+            return Err(ErrorData::invalid_params(
+                format!("unknown rule id: {}", args.rule_id),
+                None,
+            ));
+        };
+
+        // Source severity + summary from the Rule trait so metadata
+        // never duplicates what `register_builtin` already exposes.
+        let Some(rule) = register_builtin()
+            .into_iter()
+            .find(|rule| rule.id() == entry.rule_id)
+        else {
+            return Err(ErrorData::internal_error(
+                format!(
+                    "rule {} has a doc entry but is not registered in register_builtin()",
+                    entry.rule_id
+                ),
+                None,
+            ));
+        };
+
+        let severity = rule.default_severity().label();
+        let summary = rule.summary();
+        let doc_url = explain::doc_url(entry.rule_id);
+
+        let structured = serde_json::json!({
+            "rule_id": entry.rule_id,
+            "severity": severity,
+            "summary": summary,
+            "doc_url": doc_url,
+            "markdown": entry.markdown,
+        });
+
+        let mut result = CallToolResult::success(vec![Content::text(entry.markdown.to_owned())]);
+        result.structured_content = Some(structured);
+        Ok(result)
+    }
 }
 
 impl ServerHandler for PlumbServer {
@@ -105,7 +169,8 @@ impl ServerHandler for PlumbServer {
         info.server_info = Implementation::new("plumb", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
             "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
-             use `echo` to smoke-test the transport."
+             use `explain_rule` for canonical rule documentation; use `echo` to smoke-test the \
+             transport."
                 .into(),
         );
         info
@@ -120,6 +185,7 @@ impl ServerHandler for PlumbServer {
         match request.name.as_ref() {
             "echo" => self.echo(parse_tool_args(arguments)?).await,
             "lint_url" => self.lint_url(parse_tool_args(arguments)?).await,
+            "explain_rule" => self.explain_rule(parse_tool_args(arguments)?).await,
             unknown => Err(ErrorData::invalid_params(
                 format!("unknown tool: {unknown}"),
                 None,
@@ -137,6 +203,10 @@ impl ServerHandler for PlumbServer {
             tool_descriptor::<LintUrlArgs>(
                 "lint_url",
                 "Lint a URL with Plumb. Walking-skeleton accepts plumb-fake:// URLs only.",
+            ),
+            tool_descriptor::<ExplainRuleArgs>(
+                "explain_rule",
+                "Return canonical documentation and metadata for a Plumb rule by id.",
             ),
         ];
         std::future::ready(Ok(ListToolsResult::with_all_items(tools)))

--- a/crates/plumb-mcp/tests/mcp_protocol.rs
+++ b/crates/plumb-mcp/tests/mcp_protocol.rs
@@ -7,8 +7,12 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
 
-use plumb_mcp::PlumbServer;
+use std::collections::BTreeSet;
+
+use plumb_core::register_builtin;
+use plumb_mcp::{ExplainRuleArgs, PlumbServer, documented_rule_ids};
 use rmcp::ServerHandler;
+use rmcp::model::ErrorCode;
 
 #[test]
 fn server_info_declares_plumb() {
@@ -42,4 +46,86 @@ fn server_info_includes_instructions() {
 fn default_is_equivalent_to_new() {
     // Smoke-test that Default::default() constructs a usable server.
     let _server = PlumbServer::default();
+}
+
+#[tokio::test]
+async fn explain_rule_happy_path_returns_markdown_and_metadata() {
+    let server = PlumbServer::new();
+    let result = server
+        .explain_rule(ExplainRuleArgs {
+            rule_id: "spacing/scale-conformance".to_owned(),
+        })
+        .await
+        .expect("explain_rule must succeed for a known built-in rule id");
+
+    let text = result
+        .content
+        .iter()
+        .find_map(|content| content.as_text().map(|text| text.text.clone()))
+        .expect("response must include a text content block");
+    assert!(
+        !text.is_empty(),
+        "markdown body in content[0] must be non-empty"
+    );
+    assert!(
+        text.contains("spacing/scale-conformance"),
+        "markdown should reference its own rule id"
+    );
+
+    let structured = result
+        .structured_content
+        .expect("response must include structured_content");
+    assert_eq!(
+        structured.get("rule_id").and_then(|v| v.as_str()),
+        Some("spacing/scale-conformance"),
+    );
+    assert_eq!(
+        structured.get("severity").and_then(|v| v.as_str()),
+        Some("warning"),
+    );
+    assert_eq!(
+        structured.get("doc_url").and_then(|v| v.as_str()),
+        Some("https://plumb.aramhammoudeh.com/rules/spacing-scale-conformance"),
+    );
+    let summary = structured
+        .get("summary")
+        .and_then(|v| v.as_str())
+        .expect("summary field must be a string");
+    assert!(!summary.is_empty(), "summary must be non-empty");
+    let markdown = structured
+        .get("markdown")
+        .and_then(|v| v.as_str())
+        .expect("markdown field must be a string");
+    assert!(!markdown.is_empty(), "markdown field must be non-empty");
+    assert_eq!(
+        markdown, text,
+        "structured markdown must match the content text block"
+    );
+}
+
+#[tokio::test]
+async fn explain_rule_unknown_rule_id_returns_invalid_params() {
+    let server = PlumbServer::new();
+    let error = server
+        .explain_rule(ExplainRuleArgs {
+            rule_id: "does/not-exist".to_owned(),
+        })
+        .await
+        .expect_err("unknown rule id must fail");
+    assert_eq!(
+        error.code,
+        ErrorCode::INVALID_PARAMS,
+        "unknown rule id must map to JSON-RPC -32602"
+    );
+}
+
+#[test]
+fn every_builtin_rule_has_doc_entry() {
+    let registered: BTreeSet<&'static str> =
+        register_builtin().iter().map(|rule| rule.id()).collect();
+    let documented: BTreeSet<&'static str> = documented_rule_ids().into_iter().collect();
+    assert_eq!(
+        registered, documented,
+        "the explain_rule doc table must cover every rule in register_builtin() and nothing more",
+    );
 }

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -38,6 +38,7 @@ For local development against a source checkout:
 |------|-------------|
 | `echo` | Smoke-test the transport. Echoes the `message` arg back. |
 | `lint_url` | Lint a URL. Accepts `plumb-fake://hello` only until the Chromium driver lands. |
+| `explain_rule` | Return canonical documentation and metadata for a Plumb rule by id. Args: `{ "rule_id": "<category>/<id>" }`. |
 
 The response shape follows the MCP `content` + `structuredContent`
 convention:


### PR DESCRIPTION
## Target branch

- [x] This PR targets `main`

## Spec

Fixes #35

## Summary

- Adds the `explain_rule` MCP tool — agents can request canonical
  documentation for any built-in rule by id.
- Markdown is embedded at compile time from `docs/src/rules/<slug>.md`
  via `include_str!`; severity and summary are pulled from
  `register_builtin()` so the response is a pure function of `rule_id`
  with no runtime filesystem I/O.
- Unknown rule ids return a typed JSON-RPC `-32602` error.

## Crates touched

- [ ] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [ ] `plumb-config`
- [x] `plumb-mcp`
- [ ] `plumb-cli`
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item (`PlumbServer::explain_rule`, `ExplainRuleArgs`)
- [x] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule
- [ ] CDP / browser surface change
- [ ] Config schema change
- [ ] Dependency added / bumped
- [ ] Determinism invariant touched

## Architectural compliance

- [x] Layer discipline holds — `plumb-mcp` depends only on `plumb-core` + `plumb-format` + `rmcp`.
- [x] Error shape: `ErrorData::invalid_params` for unknown rule (rmcp-typed).
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now`.
- [x] No new `HashMap` in observable output paths.
- [x] Every `#[allow(...)]` is local — `clippy::redundant_pub_crate` on the private `explain` module, with a one-line rationale matching the precedent in `plumb-core/src/rules/util.rs`.

## Test plan

- [x] `cargo nextest run -p plumb-mcp` passes (7/7).
- [x] `cargo clippy -p plumb-mcp --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] `just validate` runs in CI on this PR.
- [ ] `just determinism-check` runs in CI.
- [ ] `cargo deny check` runs in CI.
- [x] New behavior has tests:
  - `explain_rule_happy_path_returns_markdown_and_metadata`
  - `explain_rule_unknown_rule_id_returns_invalid_params`
  - `every_builtin_rule_has_doc_entry` (drift guard)

## Documentation

- [x] Rustdoc added for every new public item (`ExplainRuleArgs`, `PlumbServer::explain_rule`).
- [x] `# Errors` section is implicit via `Result<_, ErrorData>` rmcp convention.
- [x] `docs/src/mcp.md` tool table updated.
- [ ] CHANGELOG (deferred — V0 is pre-1.0 and release-please owns it).
- [ ] Humanizer pass on docs (only the tool table line changed; will run before merge if reviewer requests).

## Breaking change?

- [x] No

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/35-feat-mcp-explain-rule`
- [ ] All review gates passed — **this PR is the skeleton milestone**; review gates (spec → quality → architecture → test → security-auditor) fire in the follow-up milestone before merge.
- [ ] `/gh-review --local-diff main...HEAD` will run before review approval.

## Reviewer notes

This is a **skeleton PR** — implementation lands here, full review-gate
chain (incl. `06-security-auditor` since the change touches `plumb-mcp`)
runs before merge. The acceptance criterion mentioning a protocol-level
test in `crates/plumb-cli/tests/mcp_stdio.rs` is intentionally deferred
to that follow-up; the in-process `mcp_protocol.rs` tests cover the
same code path for now and the protocol test is cookie-cutter once the
shape is locked.

The doc table is keyed by `rule_id` and embeds markdown at compile time.
The `every_builtin_rule_has_doc_entry` test makes drift between
`register_builtin()` and the table a build break — adding a new rule
without a doc page now fails at the MCP layer, not just at `cargo xtask
sync-rules-index`.
