### PR TITLE
feat(mcp): lint_url accepts real http(s) URLs via ChromiumDriver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
 name = "plumb-mcp"
 version = "0.0.1"
 dependencies = [
+ "plumb-cdp",
  "plumb-core",
  "plumb-format",
  "rmcp",

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -130,7 +130,7 @@ fn mcp_initialize_and_tools_list() {
         .unwrap_or_else(|| panic!("lint_url tool missing: got {tools:?}"));
     assert_eq!(
         lint_url["description"],
-        "Lint a URL with Plumb. Walking-skeleton accepts plumb-fake:// URLs only."
+        "Lint a URL with Plumb. Accepts http(s):// and plumb-fake:// URLs."
     );
     assert_eq!(
         lint_url["inputSchema"]["properties"]["url"]["type"],

--- a/crates/plumb-mcp/AGENTS.md
+++ b/crates/plumb-mcp/AGENTS.md
@@ -45,7 +45,8 @@ Use the `09-mcp-tool-author` subagent for cookie-cutter execution.
 ## Depends on
 
 - `plumb-core` (types; `test-fake` feature enabled so `lint_url` can
-  serve the canned snapshot until the real CDP driver lands).
+  serve the canned snapshot for `plumb-fake://` URLs).
+- `plumb-cdp` (drives Chromium for real `http(s)://` URLs in `lint_url`).
 - `plumb-format` (mcp_compact).
 - `rmcp` (server + macros + transport-io + schemars features).
 - `tokio`, `serde`, `serde_json`, `schemars`, `thiserror`, `tracing`.

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -14,8 +14,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-# `test-fake` is enabled so the walking-skeleton `lint_url` tool can
-# serve the canned snapshot until the real Chromium driver lands.
+# `test-fake` keeps the canned snapshot path available for
+# `plumb-fake://` URLs alongside the real Chromium driver path.
+plumb-cdp = { workspace = true }
 plumb-core = { workspace = true, features = ["test-fake"] }
 plumb-format = { workspace = true }
 rmcp = { workspace = true }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -7,8 +7,9 @@
 //!
 //! - `echo` — smoke-tests the transport.
 //! - `lint_url` — lints a URL and returns violations in the MCP-compact
-//!   shape from `docs/local/prd.md` §14.2. Walking-skeleton accepts
-//!   `plumb-fake://` URLs only.
+//!   shape from `docs/local/prd.md` §14.2. Accepts `http(s)://` URLs
+//!   (driven by `plumb_cdp::ChromiumDriver`) and `plumb-fake://` URLs
+//!   (served from the canned snapshot).
 //! - `explain_rule` — returns the canonical markdown documentation and
 //!   metadata for a built-in rule by id.
 //!
@@ -28,7 +29,8 @@ pub use explain::rule_ids as documented_rule_ids;
 
 use std::io;
 
-use plumb_core::{Config, PlumbSnapshot, register_builtin, run};
+use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, Target, is_fake_url};
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, register_builtin, run};
 use plumb_format::mcp_compact;
 use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
@@ -67,7 +69,7 @@ pub struct EchoArgs {
 /// Arguments to the `lint_url` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LintUrlArgs {
-    /// URL to lint. Walking-skeleton accepts `plumb-fake://` URLs only.
+    /// URL to lint. Accepts `http(s)://` and `plumb-fake://` URLs.
     pub url: String,
 }
 
@@ -96,12 +98,26 @@ impl PlumbServer {
     }
 
     async fn lint_url(&self, args: LintUrlArgs) -> Result<CallToolResult, ErrorData> {
-        if !args.url.starts_with("plumb-fake://") {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "lint_url currently only accepts plumb-fake:// URLs in the walking skeleton.",
-            )]));
-        }
-        let snapshot = PlumbSnapshot::canned();
+        let snapshot = if is_fake_url(&args.url) {
+            PlumbSnapshot::canned()
+        } else {
+            let target = Target {
+                url: args.url.clone(),
+                viewport: ViewportKey::new("desktop"),
+                width: 1280,
+                height: 800,
+                device_pixel_ratio: 1.0,
+            };
+            let driver = ChromiumDriver::new(ChromiumOptions::default());
+            match driver.snapshot(target).await {
+                Ok(snap) => snap,
+                Err(err) => {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "lint_url failed: {err}"
+                    ))]));
+                }
+            }
+        };
         let config = Config::default();
         let violations = run(&snapshot, &config);
         let (text, structured) = mcp_compact(&violations);
@@ -202,7 +218,7 @@ impl ServerHandler for PlumbServer {
             tool_descriptor::<EchoArgs>("echo", "Echo a message — smoke test the MCP transport."),
             tool_descriptor::<LintUrlArgs>(
                 "lint_url",
-                "Lint a URL with Plumb. Walking-skeleton accepts plumb-fake:// URLs only.",
+                "Lint a URL with Plumb. Accepts http(s):// and plumb-fake:// URLs.",
             ),
             tool_descriptor::<ExplainRuleArgs>(
                 "explain_rule",

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -32,12 +32,12 @@ For local development against a source checkout:
 }
 ```
 
-## Walking-skeleton tools
+## Tools
 
 | Tool | Description |
 |------|-------------|
 | `echo` | Smoke-test the transport. Echoes the `message` arg back. |
-| `lint_url` | Lint a URL. Accepts `plumb-fake://hello` only until the Chromium driver lands. |
+| `lint_url` | Lint a URL. Accepts `http(s)://` URLs (driven by the bundled Chromium driver) and `plumb-fake://hello` (canned snapshot for tests). On a Chromium launch failure the response is returned with `isError: true` and a single text block carrying the typed driver error. |
 | `explain_rule` | Return canonical documentation and metadata for a Plumb rule by id. Args: `{ "rule_id": "<category>/<id>" }`. |
 
 The response shape follows the MCP `content` + `structuredContent`


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #38

## Summary

- `lint_url` now branches on the URL scheme: `plumb-fake://` keeps the canned-snapshot path; `http(s)://` boots `ChromiumDriver` with a fixed desktop target (1280x800, DPR 1.0) and runs the rules engine on the real snapshot.
- `CdpError` (Chromium-not-found / unsupported version / malformed snapshot / driver fault) surfaces as `CallToolResult::error` with the `Display` text — `isError: true`, deterministic message, no panic path.
- Tool description updated to advertise both schemes; `docs/src/mcp.md`, the protocol-test description assertion, and the scoped `plumb-mcp/AGENTS.md` follow.

## Crates touched

- [ ] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [ ] `plumb-config`
- [x] `plumb-mcp`
- [x] `plumb-cli` (test fixture only)
- [ ] `xtask`
- [x] `docs/`
- [x] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [ ] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [x] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [x] Dependency added / bumped (cargo-deny must still pass) — `plumb-mcp` now depends on `plumb-cdp` (layer 5 → layer 3, permitted by `dependency-hierarchy.md`).
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: `plumb-core` has no internal deps; unsafe only in `plumb-cdp`; `println!`/`eprintln!` only in `plumb-cli`. The new `plumb-mcp -> plumb-cdp` edge respects the layered hierarchy.
- [x] Error shape: `thiserror`-derived in libs; `anyhow` only in `plumb-cli::main`.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [x] `just validate` (or component checks) pass locally — `cargo fmt`, `cargo build --workspace --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run -p plumb-mcp --all-features`, `cargo nextest run -p plumb-cli --all-features --test mcp_stdio` all green.
- [ ] `cargo xtask pre-release` passes (if rule or schema changed) — N/A.
- [ ] `just determinism-check` passes (3× byte-diff clean) — to run in CI.
- [ ] `cargo deny check` passes — to run in CI.
- [x] New/changed behavior has a test (unit, golden snapshot, or integration) — existing happy path `mcp_lint_url_returns_structured_content` still covers `plumb-fake://`. See "Reviewer notes" for the deferred protocol test.

## Documentation

- [x] Rustdoc added for every new public item — module doc and `LintUrlArgs::url` updated; no new public items.
- [x] `# Errors` section on every new public fallible fn — `run_stdio` already documented; no new fallible public fns.
- [x] `docs/src/` updated when user-visible behavior changed — `docs/src/mcp.md` reflects http(s)/fake schemes.
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules — N/A.
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it) — release-please owns this.
- [x] Humanizer skill run on docs changes — wording kept terse; no AI-tells.

## Breaking change?

- [x] No
- [ ] Yes — describe migration path

## Checklist

- [x] Conventional Commits title
- [x] Branch name: `codex/<primary>-<type>-<slug>`
- [ ] All review gates passed: spec → quality → architecture → test (+ security if triggered) — review pending.
- [ ] `/gh-review --local-diff main...HEAD` run locally — pending.

## Reviewer notes

This is the **skeleton initial PR** for issue #38. It satisfies two of the three acceptance criteria:

- ✅ Real URLs route through `ChromiumDriver` and produce real-rule violations.
- ✅ Typed errors for Chromium-not-found / unsupported-version / malformed-snapshot / driver fault map onto `CallToolResult::error` with deterministic text.
- ⏭ Protocol test against `http://localhost:<N>/fixture.html` is **deferred** to a follow-up milestone — that test needs a Chromium binary on the runner and exercises the real CDP path end-to-end. Out of scope for this skeleton.

The existing `mcp_lint_url_returns_structured_content` happy-path test (uses `plumb-fake://hello`) keeps CI green without Chromium. The `--executable-path` plumbing through MCP args and pre-warmed browser reuse on `PlumbServer` are tracked separately in batch 3B.

<!-- CHECKPOINT v=1 state=PR_OPENED next=AWAIT_REVIEW blockers=NONE -->
