### PR TITLE
feat(mcp): get_config tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
 name = "plumb-mcp"
 version = "0.0.1"
 dependencies = [
+ "plumb-config",
  "plumb-core",
  "plumb-format",
  "rmcp",

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -110,6 +110,7 @@ fn mcp_initialize_and_tools_list() {
     let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(names.contains(&"echo"));
     assert!(names.contains(&"lint_url"));
+    assert!(names.contains(&"get_config"));
 
     let echo = tools
         .iter()
@@ -134,6 +135,19 @@ fn mcp_initialize_and_tools_list() {
     );
     assert_eq!(
         lint_url["inputSchema"]["properties"]["url"]["type"],
+        "string"
+    );
+
+    let get_config = tools
+        .iter()
+        .find(|tool| tool["name"] == "get_config")
+        .unwrap_or_else(|| panic!("get_config tool missing: got {tools:?}"));
+    assert_eq!(
+        get_config["description"],
+        "Return the resolved plumb.toml for a working directory as JSON. Memoized per (path, mtime)."
+    );
+    assert_eq!(
+        get_config["inputSchema"]["properties"]["working_dir"]["type"],
         "string"
     );
 }
@@ -190,5 +204,43 @@ fn mcp_lint_url_returns_structured_content() {
     assert_eq!(
         structured["violations"][0]["rule_id"].as_str(),
         Some("spacing/grid-conformance")
+    );
+}
+
+#[test]
+fn mcp_get_config_returns_default_when_no_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let working_dir = tmp.path().to_string_lossy().into_owned();
+
+    let get_config = json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "get_config", "arguments": { "working_dir": working_dir } }
+    });
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        get_config,
+    ]);
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("get_config response missing: got {responses:?}"));
+    let result = &resp["result"];
+    assert_eq!(result["isError"].as_bool(), Some(false));
+
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    assert!(text.contains("no plumb.toml"), "unexpected text: {text}");
+
+    let structured = result["structuredContent"]
+        .as_object()
+        .expect("structuredContent object");
+    assert_eq!(structured["source"].as_str(), Some("default"));
+    assert!(
+        structured["config"].is_object(),
+        "config field must be an object: {structured:?}"
+    );
+    assert!(
+        structured["config"]["viewports"].is_object(),
+        "default config must include viewports map: {structured:?}"
     );
 }

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -17,6 +17,7 @@ categories.workspace = true
 # `test-fake` is enabled so the walking-skeleton `lint_url` tool can
 # serve the canned snapshot until the real Chromium driver lands.
 plumb-core = { workspace = true, features = ["test-fake"] }
+plumb-config = { workspace = true }
 plumb-format = { workspace = true }
 rmcp = { workspace = true }
 tokio = { workspace = true }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -11,6 +11,8 @@
 //!   `plumb-fake://` URLs only.
 //! - `explain_rule` — returns the canonical markdown documentation and
 //!   metadata for a built-in rule by id.
+//! - `get_config` — resolves `plumb.toml` for a given working directory
+//!   and returns the [`Config`] as JSON. Memoized per `(path, mtime)`.
 //!
 //! The [`PlumbServer`] type implements [`rmcp::ServerHandler`] directly.
 //! Extend it by adding a tool descriptor to `list_tools` and a matching
@@ -26,8 +28,13 @@ mod explain;
 #[doc(hidden)]
 pub use explain::rule_ids as documented_rule_ids;
 
+use std::collections::HashMap;
 use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
+use plumb_config::ConfigError;
 use plumb_core::{Config, PlumbSnapshot, register_builtin, run};
 use plumb_format::mcp_compact;
 use rmcp::{
@@ -78,17 +85,32 @@ pub struct ExplainRuleArgs {
     pub rule_id: String,
 }
 
-/// The Plumb MCP server. Cheap to construct.
+/// Arguments to the `get_config` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetConfigArgs {
+    /// Absolute path to the working directory containing `plumb.toml`.
+    /// The tool resolves `<working_dir>/plumb.toml` deterministically;
+    /// it never reads the process current directory.
+    pub working_dir: String,
+}
+
+/// The Plumb MCP server. Cheap to construct; `Clone` shares the memo cache.
 #[derive(Clone, Default)]
 pub struct PlumbServer {
-    _private: (),
+    config_cache: Arc<Mutex<HashMap<PathBuf, ConfigCacheEntry>>>,
+}
+
+#[derive(Clone)]
+struct ConfigCacheEntry {
+    mtime: SystemTime,
+    value: serde_json::Value,
 }
 
 impl PlumbServer {
     /// Construct a new server.
     #[must_use]
     pub fn new() -> Self {
-        Self { _private: () }
+        Self::default()
     }
 
     async fn echo(&self, args: EchoArgs) -> Result<CallToolResult, ErrorData> {
@@ -159,6 +181,105 @@ impl PlumbServer {
         result.structured_content = Some(structured);
         Ok(result)
     }
+
+    /// Resolve `<working_dir>/plumb.toml` and return the resolved [`Config`]
+    /// as JSON.
+    ///
+    /// The result is memoized per `(path, mtime)`. A subsequent call with
+    /// the same `working_dir` returns the cached JSON until the underlying
+    /// file is modified.
+    ///
+    /// When no `plumb.toml` exists at the requested path, the tool returns
+    /// the result of [`Config::default`] with `source = "default"`. This
+    /// keeps a fresh checkout usable without scaffolding a config file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorData::invalid_params`] if `working_dir` is empty or
+    /// not absolute, and [`ErrorData::internal_error`] when reading or
+    /// parsing an existing `plumb.toml` fails.
+    pub async fn get_config(&self, args: GetConfigArgs) -> Result<CallToolResult, ErrorData> {
+        if args.working_dir.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "working_dir must not be empty".to_string(),
+                None,
+            ));
+        }
+        let working_dir = PathBuf::from(&args.working_dir);
+        if !working_dir.is_absolute() {
+            return Err(ErrorData::invalid_params(
+                format!("working_dir must be absolute: {}", args.working_dir),
+                None,
+            ));
+        }
+
+        let config_path = working_dir.join("plumb.toml");
+
+        let (structured, summary) = if config_path.exists() {
+            let mtime = std::fs::metadata(&config_path)
+                .and_then(|m| m.modified())
+                .map_err(|err| {
+                    ErrorData::internal_error(
+                        format!("stat {}: {err}", config_path.display()),
+                        None,
+                    )
+                })?;
+
+            if let Some(entry) = self.cache_lookup(&config_path, mtime)? {
+                let summary = format!("plumb.toml @ {} (cached)", config_path.display());
+                (entry, summary)
+            } else {
+                let config =
+                    plumb_config::load(&config_path).map_err(|err| map_config_error(&err))?;
+                let value = serialize_config(&config, &config_path, ConfigSource::File)?;
+                self.cache_store(&config_path, mtime, value.clone())?;
+                let summary = format!("plumb.toml @ {}", config_path.display());
+                (value, summary)
+            }
+        } else {
+            let value = serialize_config(&Config::default(), &config_path, ConfigSource::Default)?;
+            let summary = format!(
+                "no plumb.toml at {} — returning Config::default()",
+                config_path.display()
+            );
+            (value, summary)
+        };
+
+        let mut result = CallToolResult::success(vec![Content::text(summary)]);
+        result.structured_content = Some(structured);
+        Ok(result)
+    }
+
+    fn cache_lookup(
+        &self,
+        path: &Path,
+        mtime: SystemTime,
+    ) -> Result<Option<serde_json::Value>, ErrorData> {
+        let hit = self
+            .config_cache
+            .lock()
+            .map_err(|err| {
+                ErrorData::internal_error(format!("config cache poisoned: {err}"), None)
+            })?
+            .get(path)
+            .and_then(|entry| (entry.mtime == mtime).then(|| entry.value.clone()));
+        Ok(hit)
+    }
+
+    fn cache_store(
+        &self,
+        path: &Path,
+        mtime: SystemTime,
+        value: serde_json::Value,
+    ) -> Result<(), ErrorData> {
+        self.config_cache
+            .lock()
+            .map_err(|err| {
+                ErrorData::internal_error(format!("config cache poisoned: {err}"), None)
+            })?
+            .insert(path.to_path_buf(), ConfigCacheEntry { mtime, value });
+        Ok(())
+    }
 }
 
 impl ServerHandler for PlumbServer {
@@ -169,7 +290,8 @@ impl ServerHandler for PlumbServer {
         info.server_info = Implementation::new("plumb", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
             "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
-             use `explain_rule` for canonical rule documentation; use `echo` to smoke-test the \
+             use `explain_rule` for canonical rule documentation; use `get_config` to fetch the \
+             resolved `plumb.toml` for a working directory; use `echo` to smoke-test the \
              transport."
                 .into(),
         );
@@ -186,6 +308,7 @@ impl ServerHandler for PlumbServer {
             "echo" => self.echo(parse_tool_args(arguments)?).await,
             "lint_url" => self.lint_url(parse_tool_args(arguments)?).await,
             "explain_rule" => self.explain_rule(parse_tool_args(arguments)?).await,
+            "get_config" => self.get_config(parse_tool_args(arguments)?).await,
             unknown => Err(ErrorData::invalid_params(
                 format!("unknown tool: {unknown}"),
                 None,
@@ -207,6 +330,10 @@ impl ServerHandler for PlumbServer {
             tool_descriptor::<ExplainRuleArgs>(
                 "explain_rule",
                 "Return canonical documentation and metadata for a Plumb rule by id.",
+            ),
+            tool_descriptor::<GetConfigArgs>(
+                "get_config",
+                "Return the resolved plumb.toml for a working directory as JSON. Memoized per (path, mtime).",
             ),
         ];
         std::future::ready(Ok(ListToolsResult::with_all_items(tools)))
@@ -230,6 +357,39 @@ where
     T: JsonSchema + 'static,
 {
     Tool::new(name, description, schema_for_type::<T>())
+}
+
+#[derive(Copy, Clone)]
+enum ConfigSource {
+    Default,
+    File,
+}
+
+impl ConfigSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::File => "file",
+        }
+    }
+}
+
+fn serialize_config(
+    config: &Config,
+    path: &Path,
+    source: ConfigSource,
+) -> Result<serde_json::Value, ErrorData> {
+    let inner = serde_json::to_value(config)
+        .map_err(|err| ErrorData::internal_error(format!("serialize config: {err}"), None))?;
+    Ok(serde_json::json!({
+        "config": inner,
+        "source": source.as_str(),
+        "path": path.display().to_string(),
+    }))
+}
+
+fn map_config_error(err: &ConfigError) -> ErrorData {
+    ErrorData::internal_error(format!("load plumb.toml: {err}"), None)
 }
 
 /// Run the MCP server on stdin/stdout until EOF.

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -39,6 +39,7 @@ For local development against a source checkout:
 | `echo` | Smoke-test the transport. Echoes the `message` arg back. |
 | `lint_url` | Lint a URL. Accepts `plumb-fake://hello` only until the Chromium driver lands. |
 | `explain_rule` | Return canonical documentation and metadata for a Plumb rule by id. Args: `{ "rule_id": "<category>/<id>" }`. |
+| `get_config` | Return resolved `plumb.toml` for a working directory as JSON. Memoized per `(path, mtime)`. |
 
 The response shape follows the MCP `content` + `structuredContent`
 convention:


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #37

## Summary

- New `get_config` MCP tool returns the resolved `plumb.toml` for a caller-supplied working directory as JSON-serialized [`Config`].
- Memoized per `(path, mtime)` via an `Arc<Mutex<HashMap<PathBuf, ConfigCacheEntry>>>` shared across `Clone` instances of `PlumbServer`. Cache is internal-only — never iterated, so the determinism rule banning `HashMap` in observable output is preserved.
- When no `plumb.toml` exists at the requested path, the tool returns `Config::default()` with `source = "default"` so a fresh checkout still gets a usable answer.

## Crates touched

- [ ] `plumb-core`
- [ ] `plumb-format`
- [ ] `plumb-cdp`
- [ ] `plumb-config`
- [x] `plumb-mcp`
- [x] `plumb-cli` (test only)
- [ ] `xtask`
- [x] `docs/`
- [ ] `.agents/` or `.claude/`
- [ ] `.github/`

## System impact

- [x] New public API item (`PlumbServer::get_config`, `GetConfigArgs`) — rustdoc + `# Errors` section included.
- [x] New MCP tool — `tools/list` entry + happy-path protocol test added.
- [ ] New rule
- [ ] CDP / browser surface change
- [ ] Config schema change
- [x] Dependency added — `plumb-mcp` now depends on `plumb-config` (which depends only on `plumb-core`; layering preserved).
- [x] Determinism invariant touched — see Architectural compliance below for the analysis.

## Architectural compliance

- [x] Layer discipline: `plumb-mcp` → `plumb-config` → `plumb-core` is allowed; no cycles, no `unsafe` introduced, no `println!` outside `plumb-cli`.
- [x] Error shape: `ErrorData::invalid_params` for empty / non-absolute `working_dir`; `ErrorData::internal_error` for stat / parse / serialize / poisoned-mutex paths. No `anyhow` added.
- [x] No new `unwrap`/`expect`/`panic!` in library crates — every `Mutex::lock` and `serde_json::to_value` is mapped to a typed error.
- [x] No new `SystemTime::now` / `Instant::now`. `metadata.modified()` is a filesystem read used only for cache-equality, not a clock read.
- [x] No new `HashMap` in observable output. The internal cache is never iterated; output ordering of the JSON config comes from `Config`'s `IndexMap` fields.
- [x] No new `#[allow(...)]` attributes added.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p plumb-mcp -p plumb-cli --all-targets --all-features -- -D warnings` clean.
- [x] `cargo nextest run -p plumb-mcp -p plumb-cli` — 58/58 pass, including the new `mcp_get_config_returns_default_when_no_file` protocol test and the extended `mcp_initialize_and_tools_list` assertion.
- [ ] `just validate` — will run as part of CI / final test gate; not yet executed locally (skeleton milestone).
- [ ] `cargo xtask pre-release` — N/A (no rule or schema change).
- [ ] `just determinism-check` — will run in CI.
- [ ] `cargo deny check` — will run in CI (one new internal dep edge: `plumb-mcp` → `plumb-config`).

## Documentation

- [x] Rustdoc on `GetConfigArgs` and `PlumbServer::get_config`, including a `# Errors` section.
- [ ] `# Errors` section on every new public fallible fn — covered.
- [x] `docs/src/mcp.md` tool table extended.
- [ ] CHANGELOG — release-please will pick up the `feat(mcp):` Conventional Commits.
- [ ] Humanizer skill — ran mentally over the one-line docs row; no marketing prose introduced.

## Breaking change?

- [x] No
- [ ] Yes

## Checklist

- [x] Conventional Commits title.
- [x] Branch name: `codex/37-feat-mcp-get-config`.
- [ ] All review gates passed — running after this PR opens (skeleton milestone).
- [ ] `/gh-review --local-diff main...HEAD` — will run after this initial PR is up so reviewers see the same scope as CI.

## Reviewer notes

- The `working_dir` argument is required and must be absolute. This avoids reading process state (current dir / env) inside a tool call and keeps `get_config` deterministic.
- The cache is keyed by `PathBuf`, so two distinct working directories cohabit. There is no eviction yet; an MCP session lives for a CLI run, so the cache stays small in practice.
- `source = "default"` is surfaced explicitly so an agent can distinguish "no config exists" from "config exists and happens to match defaults" without a separate probe.
- This is the **initial PR / skeleton milestone**. The remaining review gates (spec / quality / architecture / test / security-auditor) will run on the open PR. Follow-up commits will address any blocker findings before merge.
