### PR TITLE
test(cli): regression for #121 — FakeDriver mobile rect in JSON output

### DIFF
--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -363,3 +363,31 @@ fn lint_with_selector_matching_nothing_exits_input_error() -> Result<(), Box<dyn
         .stderr(contains("matched no elements"));
     Ok(())
 }
+
+/// End-to-end regression for #121: when `plumb lint plumb-fake://hello
+/// --format json --viewport mobile` runs against a multi-viewport
+/// config, the JSON `rect` field MUST carry the mobile dimensions, not
+/// the canned desktop ones. Before #125 this would emit `1280x800`
+/// even for the mobile target.
+#[test]
+fn lint_fake_url_json_rect_matches_requested_viewport() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = workspace_with_two_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--viewport",
+            "mobile",
+            "--format",
+            "json",
+        ])
+        .current_dir(workspace.path())
+        .assert()
+        .code(3)
+        .stdout(contains("\"viewport\": \"mobile\""))
+        .stdout(contains("\"width\": 375"))
+        .stdout(contains("\"height\": 812"))
+        .stdout(contains("\"width\": 1280").not())
+        .stdout(contains("\"height\": 800").not());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

End-to-end CLI regression test for issue #121. PR #125 fixed the
`FakeDriver` so multi-viewport runs against `plumb-fake://hello` no
longer emit the canned desktop rect for the mobile viewport. The fix
is unit-tested at the `FakeDriver::snapshot` layer
(`crates/plumb-cdp/tests/snapshot_all_default.rs::fake_driver_rewrites_viewport_sized_rects_to_target`).
The original issue, however, was reported at the CLI layer — `plumb
lint plumb-fake://hello --format json` showing `1280x800` rects under
a mobile viewport. This PR adds the matching CLI-level assertion so
the regression is guarded at the level the issue was reported.

## Why this exists (audit follow-up)

PR #125 merged with the `Claude review` check **failed** because the
review action hit its SDK turn limit (`Reached maximum number of
turns (20)`), an infrastructure failure rather than a review finding.
All other gates (tests, fmt, clippy, determinism, coverage, MSRV,
cargo-deny, three-OS test matrix) passed. There is therefore no
recorded approval verdict on #125, only passing real CI. This PR
closes the acceptance-criteria validation gap so the fix is covered
end-to-end.

## What the test asserts

`plumb lint plumb-fake://hello --viewport mobile --format json` against
a `[viewports.mobile] width=375 height=812` config MUST:

- exit `3` (warning-only)
- emit `"viewport": "mobile"`
- emit `"width": 375` / `"height": 812` in the rect block
- NOT emit `"width": 1280` or `"height": 800` (the pre-#125 bug)

## Test plan

- [x] `cargo test -p plumb-cli --test cli_integration` — all 22 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p plumb-cli --all-targets -- -D warnings` — clean
- [ ] CI green

Refs #121.