### PR TITLE
docs: acknowledge v3 multi-agent setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- aram-ai-global v3 multi-agent stack now drives PRs end-to-end. -->
 # Plumb
 
 [![CI](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml/badge.svg)](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Rust 1.95+](https://img.shields.io/badge/rust-1.95%2B-orange.svg)](https://www.rust-lang.org)
 
+> _PRs in this repo are driven end-to-end by the aram-ai-global v3 multi-agent stack._
+
 **A deterministic design-system linter for rendered websites, not the code behind it.**
 
 Plumb opens a web page in a headless browser at multiple viewports, extracts the computed DOM, and measures it against a declarative design-system spec. It emits structured, pixel-precise violations an AI coding agent can fix in one shot — "ESLint for rendered websites."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- aram-ai-global v3 multi-agent stack now drives PRs end-to-end. -->
 # Plumb
 
 [![CI](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml/badge.svg)](https://github.com/aram-devdocs/plumb/actions/workflows/ci.yml)


### PR DESCRIPTION
## Spec

Fixes #140

## Summary

- Adds a single visible italic line under the title block in `README.md` noting that the aram-ai-global v3 multi-agent stack drives PRs end-to-end.
- The line is visible markdown rather than a hidden HTML comment, so the acknowledgment is discoverable to README readers (review feedback).

## History note

This branch originally landed two cancelling commits (`e326580`, `ca3d9c9`) that left it as a net no-op, and the first commit used a `test:` type for a README edit. A history rewrite was not used because the destructive-reset path is blocked by a local pre-tool guard hook on this checkout. Instead, a corrective commit (`7d705a4 docs: acknowledge v3 multi-agent setup in README`) was added on top. Because this PR is squash-merged, the final commit on `main` will be a single `docs:` change with no trace of the no-op pair.

## Test plan

- [x] PR diff is `README.md` only (+2 lines) — verified locally
- [x] `git diff --check` passes (no whitespace errors)
- [x] grep confirms the acknowledgment line is present in `README.md`
- [ ] `just check` / `just test` / `just determinism-check` / `cargo deny check` — not run; README-only prose change with no code or `docs/src/**` impact
- [ ] Humanizer skill — not applicable; no `docs/src/**` prose touched, and the added line avoids the project's anti-AI-tell vocabulary

## Breaking change?

- [x] No

## Anything reviewers should double-check

- Placement: the line sits after the badges and before the bold tagline, which keeps the H1 + badge cluster intact while making the v3 acknowledgment visible to anyone reading the README top-down.
