### PR TITLE
test: v3 ACP-allowed proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- v3 ACP-allowed proof
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.


### PR DESCRIPTION
Fixes #146

## Summary
One-line CHANGELOG.md addition under Unreleased / Added — proof that the v3 visible-flow lands diffs end-to-end with acpx.permissionMode=approve-all + Codex sandbox=danger-full-access.

## Test plan
- [x] CHANGELOG.md has new bullet under ## [Unreleased] / ### Added
- [x] No other files changed