### PR TITLE
test: v3 autonomous full-flow proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- v3 autonomous full-flow proof
 - v3 ACP-allowed proof
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.


### PR DESCRIPTION
Closes #148

Verification:
- `git diff --stat` shows `CHANGELOG.md | 1 +`.
- `git diff -- CHANGELOG.md` shows only the new `- v3 autonomous full-flow proof` bullet under `## [Unreleased]`.
- Confirmed the new bullet appears exactly once under `Unreleased` and no released changelog sections changed.
