### PR TITLE
test: v3.1.1 talking-stick ignoreOtherMentions proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 - v3 autonomous full-flow proof
 - v3 ACP-allowed proof
+- v3.1.1 ignoreOtherMentions proof
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.


### PR DESCRIPTION
Closes #151

## Verification
- `git diff --stat`
- `git diff -- CHANGELOG.md`
- Confirmed `- v3.1.1 ignoreOtherMentions proof` appears exactly once under `## [Unreleased]` / `### Added`
- Confirmed no released changelog sections were changed (`released_section_headings=0` in this worktree)