### PR TITLE
feat(mcp): add lint_url full detail mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ From the first release onward, this file is maintained automatically by [`releas
 - Repository hooks now enforce the talking-stick workflow for agent-driven changes.
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
+- `plumb mcp` `lint_url` now accepts an optional `detail` argument. The default `compact` mode preserves the existing MCP payload, while `detail: "full"` returns the canonical full JSON envelope and rejects structured payloads above 50 KB.
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.
 - Rule `spacing/scale-conformance`: flags the same property set when values aren't members of `spacing.scale`.
 - Rule `type/scale-conformance`: flags `font-size` values that aren't members of `type.scale`.

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -302,6 +302,31 @@ fn mcp_lint_url_full_returns_json_envelope() {
 }
 
 #[test]
+fn mcp_lint_url_invalid_detail_returns_jsonrpc_error() {
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        lint_url_request(2, "plumb-fake://hello", Some("bogus")),
+    ]);
+    let lint_resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("invalid-detail response missing: got {responses:?}"));
+    let error = lint_resp["error"].as_object().expect("error object");
+
+    assert_eq!(error["code"].as_i64(), Some(-32602));
+    let message = error["message"].as_str().expect("error message");
+    assert!(
+        message.contains("failed to deserialize tool arguments"),
+        "unexpected error message: {message}"
+    );
+    assert!(
+        message.contains("unknown variant `bogus`, expected `compact` or `full`"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
 fn mcp_get_config_returns_default_when_no_file() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let working_dir = tmp.path().to_string_lossy().into_owned();

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -86,6 +86,20 @@ fn initialized_notification() -> Value {
     })
 }
 
+fn lint_url_request(id: u32, url: &str, detail: Option<&str>) -> Value {
+    let mut arguments = json!({ "url": url });
+    if let Some(detail) = detail {
+        arguments["detail"] = Value::String(detail.to_owned());
+    }
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": "lint_url", "arguments": arguments }
+    })
+}
+
 #[test]
 fn mcp_initialize_and_tools_list() {
     let tools_list = json!({
@@ -139,6 +153,26 @@ fn mcp_initialize_and_tools_list() {
         lint_url["inputSchema"]["properties"]["url"]["type"],
         "string"
     );
+    assert!(
+        lint_url["inputSchema"]["properties"]["detail"].is_object(),
+        "lint_url detail property missing from schema: {lint_url:?}"
+    );
+    assert_eq!(
+        lint_url["inputSchema"]["required"].as_array(),
+        Some(&vec![Value::String("url".to_owned())]),
+        "lint_url must require only url: {lint_url:?}"
+    );
+    let detail_variants: Vec<&str> = lint_url["inputSchema"]["$defs"]["LintUrlDetail"]["oneOf"]
+        .as_array()
+        .expect("detail oneOf variants")
+        .iter()
+        .map(|variant| variant["const"].as_str().expect("detail variant const"))
+        .collect();
+    assert_eq!(
+        detail_variants,
+        vec!["compact", "full"],
+        "lint_url detail enum must expose compact/full: {lint_url:?}"
+    );
 
     let get_config = tools
         .iter()
@@ -173,10 +207,7 @@ fn mcp_echo_round_trip() {
 
 #[test]
 fn mcp_lint_url_returns_structured_content() {
-    let lint_url = json!({
-        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-        "params": { "name": "lint_url", "arguments": { "url": "plumb-fake://hello" } }
-    });
+    let lint_url = lint_url_request(2, "plumb-fake://hello", None);
     let responses = send_and_read(vec![init_request(1), initialized_notification(), lint_url]);
     let lint_resp = responses
         .iter()
@@ -206,6 +237,67 @@ fn mcp_lint_url_returns_structured_content() {
     assert_eq!(
         structured["violations"][0]["rule_id"].as_str(),
         Some("spacing/grid-conformance")
+    );
+}
+
+#[test]
+fn mcp_lint_url_explicit_compact_matches_default() {
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        lint_url_request(2, "plumb-fake://hello", None),
+        lint_url_request(3, "plumb-fake://hello", Some("compact")),
+    ]);
+    let default_resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("default lint_url response missing: got {responses:?}"));
+    let compact_resp = responses
+        .iter()
+        .find(|r| r["id"] == 3)
+        .unwrap_or_else(|| panic!("compact lint_url response missing: got {responses:?}"));
+
+    assert_eq!(default_resp["result"], compact_resp["result"]);
+}
+
+#[test]
+fn mcp_lint_url_full_returns_json_envelope() {
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        lint_url_request(2, "plumb-fake://hello", Some("full")),
+    ]);
+    let lint_resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("full lint_url response missing: got {responses:?}"));
+    let result = &lint_resp["result"];
+
+    assert_eq!(result["isError"].as_bool(), Some(false));
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .expect("text content")
+            .contains("warning spacing/grid-conformance @ html > body [desktop]")
+    );
+
+    let structured = result["structuredContent"]
+        .as_object()
+        .expect("structuredContent object");
+    assert_eq!(
+        structured["plumb_version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+    assert!(
+        structured["run_id"]
+            .as_str()
+            .expect("run_id string")
+            .starts_with("sha256:")
+    );
+    assert_eq!(structured["summary"]["total"].as_u64(), Some(1));
+    assert_eq!(
+        structured["violations"][0]["doc_url"].as_str(),
+        Some("https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance")
     );
 }
 

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -39,8 +39,8 @@ use std::time::SystemTime;
 
 use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, Target, is_fake_url};
 use plumb_config::ConfigError;
-use plumb_core::{Config, PlumbSnapshot, ViewportKey, register_builtin, run};
-use plumb_format::mcp_compact;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, Violation, register_builtin, run};
+use plumb_format::{json as full_json, mcp_compact};
 use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
     handler::server::tool::schema_for_type,
@@ -81,6 +81,20 @@ pub struct EchoArgs {
 pub struct LintUrlArgs {
     /// URL to lint. Accepts `http(s)://` and `plumb-fake://` URLs.
     pub url: String,
+    /// Response detail level. Defaults to the compact MCP payload.
+    #[serde(default)]
+    pub detail: LintUrlDetail,
+}
+
+/// Structured response detail level for `lint_url`.
+#[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LintUrlDetail {
+    /// Current token-efficient MCP payload.
+    #[default]
+    Compact,
+    /// Canonical full JSON envelope with complete per-violation fields.
+    Full,
 }
 
 /// Arguments to the `explain_rule` tool.
@@ -150,10 +164,7 @@ impl PlumbServer {
         };
         let config = Config::default();
         let violations = run(&snapshot, &config);
-        let (text, structured) = mcp_compact(&violations);
-        let mut result = CallToolResult::success(vec![Content::text(text)]);
-        result.structured_content = Some(structured);
-        Ok(result)
+        build_lint_url_result(&violations, args.detail)
     }
 
     /// Look up the canonical documentation for a built-in rule.
@@ -360,6 +371,57 @@ impl PlumbServer {
     }
 }
 
+const LINT_URL_FULL_RESPONSE_CAP_BYTES: usize = 50 * 1024;
+
+fn build_lint_url_result(
+    violations: &[Violation],
+    detail: LintUrlDetail,
+) -> Result<CallToolResult, ErrorData> {
+    let (text, compact_structured) = mcp_compact(violations);
+    let structured = match detail {
+        LintUrlDetail::Compact => compact_structured,
+        LintUrlDetail::Full => build_full_lint_payload(violations)?,
+    };
+
+    let mut result = CallToolResult::success(vec![Content::text(text)]);
+    result.structured_content = Some(structured);
+    Ok(result)
+}
+
+fn build_full_lint_payload(violations: &[Violation]) -> Result<Value, ErrorData> {
+    let payload = full_json(violations).map_err(|err| {
+        ErrorData::internal_error(format!("serialize full lint payload: {err}"), None)
+    })?;
+    let structured: Value = serde_json::from_str(&payload).map_err(|err| {
+        ErrorData::internal_error(format!("parse full lint payload: {err}"), None)
+    })?;
+    enforce_response_cap(
+        &structured,
+        LINT_URL_FULL_RESPONSE_CAP_BYTES,
+        "lint_url detail=full payload exceeds 50 KB response cap",
+    )?;
+    Ok(structured)
+}
+
+fn enforce_response_cap(
+    structured: &Value,
+    limit_bytes: usize,
+    error_message: &'static str,
+) -> Result<(), ErrorData> {
+    let payload_len = serde_json::to_vec(structured)
+        .map_err(|err| {
+            ErrorData::internal_error(format!("serialize lint payload size: {err}"), None)
+        })?
+        .len();
+    if payload_len > limit_bytes {
+        return Err(ErrorData::invalid_params(
+            format!("{error_message} ({payload_len} bytes)"),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 impl ServerHandler for PlumbServer {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
@@ -492,4 +554,75 @@ pub async fn run_stdio() -> Result<(), McpError> {
         .await
         .map_err(|e| McpError::Service(e.to_string()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use plumb_core::Severity;
+    use rmcp::model::ErrorCode;
+
+    use super::*;
+
+    fn violation_with_message(message_len: usize, dom_order: u64) -> Violation {
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Warning,
+            message: "x".repeat(message_len),
+            selector: "html > body".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn full_lint_payload_includes_json_envelope() {
+        let structured =
+            build_full_lint_payload(&[violation_with_message(32, 1)]).expect("full payload");
+
+        assert_eq!(
+            structured["plumb_version"].as_str(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(structured["summary"]["total"].as_u64(), Some(1));
+        assert!(
+            structured["run_id"]
+                .as_str()
+                .expect("run_id")
+                .starts_with("sha256:")
+        );
+    }
+
+    #[test]
+    fn full_lint_payload_rejects_payloads_above_cap() {
+        let violations: Vec<Violation> = (0_u64..32)
+            .map(|dom_order| violation_with_message(2_000, dom_order))
+            .collect();
+
+        let err = build_full_lint_payload(&violations).expect_err("payload must exceed 50 KB");
+        assert!(
+            err.to_string()
+                .contains("detail=full payload exceeds 50 KB response cap"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_lint_url_result_rejects_full_payloads_above_cap() {
+        let violations: Vec<Violation> = (0_u64..32)
+            .map(|dom_order| violation_with_message(2_000, dom_order))
+            .collect();
+
+        let err = build_lint_url_result(&violations, LintUrlDetail::Full)
+            .expect_err("full mode must reject payloads above the response cap");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.to_string()
+                .contains("detail=full payload exceeds 50 KB response cap"),
+            "unexpected error: {err:?}"
+        );
+    }
 }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -392,29 +392,24 @@ fn build_full_lint_payload(violations: &[Violation]) -> Result<Value, ErrorData>
     let payload = full_json(violations).map_err(|err| {
         ErrorData::internal_error(format!("serialize full lint payload: {err}"), None)
     })?;
-    let structured: Value = serde_json::from_str(&payload).map_err(|err| {
-        ErrorData::internal_error(format!("parse full lint payload: {err}"), None)
-    })?;
     enforce_response_cap(
-        &structured,
+        payload.len(),
         LINT_URL_FULL_RESPONSE_CAP_BYTES,
         "lint_url detail=full payload exceeds 50 KB response cap",
     )?;
+    let structured: Value = serde_json::from_str(&payload).map_err(|err| {
+        ErrorData::internal_error(format!("parse full lint payload: {err}"), None)
+    })?;
     Ok(structured)
 }
 
 fn enforce_response_cap(
-    structured: &Value,
+    payload_len: usize,
     limit_bytes: usize,
     error_message: &'static str,
 ) -> Result<(), ErrorData> {
-    let payload_len = serde_json::to_vec(structured)
-        .map_err(|err| {
-            ErrorData::internal_error(format!("serialize lint payload size: {err}"), None)
-        })?
-        .len();
     if payload_len > limit_bytes {
-        return Err(ErrorData::invalid_params(
+        return Err(ErrorData::internal_error(
             format!("{error_message} ({payload_len} bytes)"),
             None,
         ));
@@ -574,7 +569,7 @@ mod tests {
             dom_order,
             fix: None,
             doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
-            metadata: Default::default(),
+            metadata: std::iter::empty().collect(),
         }
     }
 
@@ -618,7 +613,7 @@ mod tests {
 
         let err = build_lint_url_result(&violations, LintUrlDetail::Full)
             .expect_err("full mode must reject payloads above the response cap");
-        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(
             err.to_string()
                 .contains("detail=full payload exceeds 50 KB response cap"),

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -37,7 +37,7 @@ For local development against a source checkout:
 | Tool | Description |
 |------|-------------|
 | `echo` | Smoke-test the transport. Echoes the `message` arg back. |
-| `lint_url` | Lint a URL. Accepts `http(s)://` URLs (driven by the bundled Chromium driver) and `plumb-fake://hello` (canned snapshot for tests). On a Chromium launch failure the response is returned with `isError: true` and a single text block carrying the typed driver error. |
+| `lint_url` | Lint a URL. Args: `{ "url": "...", "detail": "compact" | "full" }`, where `detail` is optional and defaults to `compact`. Accepts `http(s)://` URLs (driven by the bundled Chromium driver) and `plumb-fake://hello` (canned snapshot for tests). On a Chromium launch failure the response is returned with `isError: true` and a single text block carrying the typed driver error. |
 | `explain_rule` | Return canonical documentation and metadata for a Plumb rule by id. Args: `{ "rule_id": "<category>/<id>" }`. |
 | `list_rules` | List every built-in Plumb rule with id, default severity, and one-line summary. No args. |
 | `get_config` | Return resolved `plumb.toml` for a working directory as JSON. Memoized per `(path, mtime)`. |
@@ -60,3 +60,10 @@ convention:
   }
 }
 ```
+
+`detail: "compact"` returns the existing token-efficient payload shown
+above. `detail: "full"` keeps the same text block and switches
+`structuredContent` to the canonical JSON envelope from `plumb lint
+<url> --format json`, including `plumb_version`, `run_id`, `summary`,
+and full per-violation fields. Full mode is rejected when the
+serialized structured payload exceeds 50 KB.


### PR DESCRIPTION
Fixes #40

## Summary
- Adds optional `detail` argument to `lint_url`, defaulting to compact output.
- Adds `detail: "full"` structured content using deterministic full JSON violation payloads.
- Enforces the 50 KB response cap for full-detail payloads and documents the new option.

## Validation
- `cargo test -p plumb-mcp` — passed
- `cargo test -p plumb-cli --test mcp_stdio` — passed
- `cargo check --no-default-features` — passed

## Note
The original remote branch `gh-issue-40-lint-url-detail-full` already existed at divergent commit `61ea2e5`; this PR uses `gh-issue-40-lint-url-detail-full-09a39d0` to avoid force-pushing over it.
