### PR TITLE
feat(mcp): expose resolved config resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ From the first release onward, this file is maintained automatically by [`releas
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - `plumb mcp` `lint_url` now accepts an optional `detail` argument. The default `compact` mode preserves the existing MCP payload, while `detail: "full"` returns the canonical full JSON envelope and rejects structured payloads above 50 KB.
+- `plumb mcp` now exposes a `plumb://config` resource that returns the resolved `plumb.toml` for the server working directory as JSON.
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.
 - Rule `spacing/scale-conformance`: flags the same property set when values aren't members of `spacing.scale`.
 - Rule `type/scale-conformance`: flags `font-size` values that aren't members of `type.scale`.

--- a/crates/plumb-cli/src/commands/mcp.rs
+++ b/crates/plumb-cli/src/commands/mcp.rs
@@ -1,11 +1,13 @@
 //! `plumb mcp` — serve MCP on stdio.
 
+use std::env;
 use std::process::ExitCode;
 
 use anyhow::Result;
 
 pub async fn run() -> Result<ExitCode> {
     tracing::info!("starting mcp stdio server");
-    plumb_mcp::run_stdio().await?;
+    let cwd = env::current_dir()?;
+    plumb_mcp::run_stdio(cwd).await?;
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -18,10 +18,7 @@ fn send_and_read(requests: Vec<Value>) -> Vec<Value> {
     send_and_read_in_dir(requests, None::<&Path>)
 }
 
-fn send_and_read_in_dir(
-    requests: Vec<Value>,
-    working_dir: Option<impl AsRef<Path>>,
-) -> Vec<Value> {
+fn send_and_read_in_dir(requests: Vec<Value>, working_dir: Option<impl AsRef<Path>>) -> Vec<Value> {
     let mut command = Command::new(bin());
     command
         .arg("mcp")
@@ -32,9 +29,7 @@ fn send_and_read_in_dir(
         command.current_dir(working_dir);
     }
 
-    let mut child = command
-        .spawn()
-        .expect("spawn plumb mcp");
+    let mut child = command.spawn().expect("spawn plumb mcp");
 
     let stdin = child.stdin.take().expect("stdin");
     let stdout = child.stdout.take().expect("stdout");

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
 
 use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -14,11 +15,24 @@ fn bin() -> std::path::PathBuf {
 }
 
 fn send_and_read(requests: Vec<Value>) -> Vec<Value> {
-    let mut child = Command::new(bin())
+    send_and_read_in_dir(requests, None::<&Path>)
+}
+
+fn send_and_read_in_dir(
+    requests: Vec<Value>,
+    working_dir: Option<impl AsRef<Path>>,
+) -> Vec<Value> {
+    let mut command = Command::new(bin());
+    command
         .arg("mcp")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(working_dir) = working_dir {
+        command.current_dir(working_dir);
+    }
+
+    let mut child = command
         .spawn()
         .expect("spawn plumb mcp");
 
@@ -100,6 +114,26 @@ fn lint_url_request(id: u32, url: &str, detail: Option<&str>) -> Value {
     })
 }
 
+fn assert_get_config_schema(tool: &Value) {
+    assert_eq!(
+        tool["description"],
+        "Return the resolved plumb.toml for a working directory as JSON. Memoized per (path, mtime)."
+    );
+    assert_eq!(
+        tool["inputSchema"]["properties"]["working_dir"]["type"],
+        "string"
+    );
+}
+
+fn assert_config_resource(resource: &Value) {
+    assert_eq!(resource["name"], "resolved_config");
+    assert_eq!(resource["mimeType"], "application/json");
+    assert_eq!(
+        resource["description"],
+        "Resolved plumb.toml for the server working directory as JSON."
+    );
+}
+
 #[test]
 fn mcp_initialize_and_tools_list() {
     let tools_list = json!({
@@ -107,10 +141,16 @@ fn mcp_initialize_and_tools_list() {
         "id": 2,
         "method": "tools/list"
     });
+    let resources_list = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "resources/list"
+    });
     let responses = send_and_read(vec![
         init_request(1),
         initialized_notification(),
         tools_list,
+        resources_list,
     ]);
     assert!(!responses.is_empty(), "expected responses, got none");
 
@@ -178,14 +218,20 @@ fn mcp_initialize_and_tools_list() {
         .iter()
         .find(|tool| tool["name"] == "get_config")
         .unwrap_or_else(|| panic!("get_config tool missing: got {tools:?}"));
-    assert_eq!(
-        get_config["description"],
-        "Return the resolved plumb.toml for a working directory as JSON. Memoized per (path, mtime)."
-    );
-    assert_eq!(
-        get_config["inputSchema"]["properties"]["working_dir"]["type"],
-        "string"
-    );
+    assert_get_config_schema(get_config);
+
+    let resources_resp = responses
+        .iter()
+        .find(|r| r["id"] == 3)
+        .unwrap_or_else(|| panic!("resources/list response missing: got {responses:?}"));
+    let resources = resources_resp["result"]["resources"]
+        .as_array()
+        .expect("resources array");
+    let config = resources
+        .iter()
+        .find(|resource| resource["uri"] == "plumb://config")
+        .unwrap_or_else(|| panic!("plumb://config resource missing: got {resources:?}"));
+    assert_config_resource(config);
 }
 
 #[test]
@@ -361,6 +407,57 @@ fn mcp_get_config_returns_default_when_no_file() {
     assert!(
         structured["config"]["viewports"].is_object(),
         "default config must include viewports map: {structured:?}"
+    );
+}
+
+#[test]
+fn mcp_read_config_resource_returns_resolved_config_json() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("plumb.toml");
+    std::fs::write(
+        &config_path,
+        "[viewports.desktop]\nwidth = 1440\nheight = 900\ndevice_pixel_ratio = 2.0\n",
+    )
+    .expect("write plumb.toml");
+
+    let read_config = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "resources/read",
+        "params": { "uri": "plumb://config" }
+    });
+    let responses = send_and_read_in_dir(
+        vec![init_request(1), initialized_notification(), read_config],
+        Some(tmp.path()),
+    );
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("resources/read response missing: got {responses:?}"));
+
+    let contents = resp["result"]["contents"]
+        .as_array()
+        .expect("contents array");
+    assert_eq!(contents.len(), 1, "expected one resource payload: {resp:?}");
+
+    let content = &contents[0];
+    assert_eq!(content["uri"], "plumb://config");
+    assert_eq!(content["mimeType"], "application/json");
+
+    let text = content["text"].as_str().expect("resource text");
+    let structured: Value = serde_json::from_str(text).expect("resource text must be JSON");
+    assert_eq!(structured["source"].as_str(), Some("file"));
+    assert_eq!(
+        structured["path"].as_str(),
+        Some(config_path.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        structured["config"]["viewports"]["desktop"]["width"].as_u64(),
+        Some(1440)
+    );
+    assert_eq!(
+        structured["config"]["viewports"]["desktop"]["device_pixel_ratio"].as_f64(),
+        Some(2.0)
     );
 }
 

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -442,10 +442,18 @@ fn mcp_read_config_resource_returns_resolved_config_json() {
     let text = content["text"].as_str().expect("resource text");
     let structured: Value = serde_json::from_str(text).expect("resource text must be JSON");
     assert_eq!(structured["source"].as_str(), Some("file"));
-    assert_eq!(
-        structured["path"].as_str(),
-        Some(config_path.to_string_lossy().as_ref())
+    let resource_path = Path::new(
+        structured["path"]
+            .as_str()
+            .expect("resource path must be a string"),
     );
+    let expected_path = config_path
+        .canonicalize()
+        .expect("canonicalize config path");
+    let actual_path = resource_path
+        .canonicalize()
+        .expect("canonicalize resource path");
+    assert_eq!(actual_path, expected_path);
     assert_eq!(
         structured["config"]["viewports"]["desktop"]["width"].as_u64(),
         Some(1440)
@@ -453,6 +461,38 @@ fn mcp_read_config_resource_returns_resolved_config_json() {
     assert_eq!(
         structured["config"]["viewports"]["desktop"]["device_pixel_ratio"].as_f64(),
         Some(2.0)
+    );
+}
+
+#[test]
+fn mcp_read_unknown_resource_returns_jsonrpc_error() {
+    let read_config = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "resources/read",
+        "params": { "uri": "plumb://bogus" }
+    });
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        read_config,
+    ]);
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("resources/read error response missing: got {responses:?}"));
+
+    assert!(
+        resp.get("result").is_none(),
+        "unknown resource must not return a result payload: {resp:?}"
+    );
+    assert_eq!(resp["error"]["code"].as_i64(), Some(-32002));
+    let message = resp["error"]["message"]
+        .as_str()
+        .expect("error message must be a string");
+    assert!(
+        message.contains("unknown resource: plumb://bogus"),
+        "unexpected error message: {message}"
     );
 }
 

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -127,8 +127,9 @@ pub struct GetConfigArgs {
 /// browser handle. The browser is warmed lazily on the first non-fake
 /// `lint_url` call and reused for the rest of the session — see
 /// [`PersistentBrowser`] for the per-call incognito-context invariant.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct PlumbServer {
+    cwd: PathBuf,
     config_cache: Arc<Mutex<HashMap<PathBuf, ConfigCacheEntry>>>,
     browser: Arc<OnceCell<PersistentBrowser>>,
 }
@@ -153,8 +154,12 @@ struct ResolvedConfig {
 impl PlumbServer {
     /// Construct a new server.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(cwd: PathBuf) -> Self {
+        Self {
+            cwd,
+            config_cache: Arc::default(),
+            browser: Arc::default(),
+        }
     }
 
     async fn echo(&self, args: EchoArgs) -> Result<CallToolResult, ErrorData> {
@@ -593,9 +598,7 @@ impl PlumbServer {
             ));
         }
 
-        let working_dir = std::env::current_dir()
-            .map_err(|err| ErrorData::internal_error(format!("current_dir: {err}"), None))?;
-        let resolved = self.resolve_config_for_dir(&working_dir)?;
+        let resolved = self.resolve_config_for_dir(&self.cwd)?;
         let text = serde_json::to_string(&resolved.value).map_err(|err| {
             ErrorData::internal_error(format!("serialize config resource: {err}"), None)
         })?;
@@ -671,8 +674,8 @@ fn map_config_error(err: &ConfigError) -> ErrorData {
 /// Returns [`McpError::Service`] if rmcp's service loop fails or
 /// [`PlumbServer::shutdown`] surfaces an error, and [`McpError::Io`]
 /// on transport errors.
-pub async fn run_stdio() -> Result<(), McpError> {
-    let handler = PlumbServer::new();
+pub async fn run_stdio(cwd: PathBuf) -> Result<(), McpError> {
+    let handler = PlumbServer::new(cwd);
     let service = handler
         .clone()
         .serve(stdio())

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -44,16 +44,16 @@ use plumb_format::{json as full_json, mcp_compact};
 use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
     handler::server::tool::schema_for_type,
+    model::AnnotateAble,
     model::{
         CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation, JsonObject,
-        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
-        RawResource, ReadResourceRequestParams, ReadResourceResult, ResourceContents,
-        ServerCapabilities, ServerInfo, Tool,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion, RawResource,
+        ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
+        ServerInfo, Tool,
     },
     schemars::{self, JsonSchema},
     service::RequestContext,
     transport::stdio,
-    model::AnnotateAble,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -563,10 +563,12 @@ impl ServerHandler for PlumbServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListResourcesResult, ErrorData>> + Send + '_ {
-        let resources = vec![RawResource::new(CONFIG_RESOURCE_URI, CONFIG_RESOURCE_NAME)
-            .with_description(CONFIG_RESOURCE_DESCRIPTION)
-            .with_mime_type(CONFIG_RESOURCE_MIME_TYPE)
-            .no_annotation()];
+        let resources = vec![
+            RawResource::new(CONFIG_RESOURCE_URI, CONFIG_RESOURCE_NAME)
+                .with_description(CONFIG_RESOURCE_DESCRIPTION)
+                .with_mime_type(CONFIG_RESOURCE_MIME_TYPE)
+                .no_annotation(),
+        ];
         std::future::ready(Ok(ListResourcesResult::with_all_items(resources)))
     }
 

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -46,12 +46,14 @@ use rmcp::{
     handler::server::tool::schema_for_type,
     model::{
         CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation, JsonObject,
-        ListToolsResult, PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo,
-        Tool,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
+        RawResource, ReadResourceRequestParams, ReadResourceResult, ResourceContents,
+        ServerCapabilities, ServerInfo, Tool,
     },
     schemars::{self, JsonSchema},
     service::RequestContext,
     transport::stdio,
+    model::AnnotateAble,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -131,10 +133,21 @@ pub struct PlumbServer {
     browser: Arc<OnceCell<PersistentBrowser>>,
 }
 
+const CONFIG_RESOURCE_URI: &str = "plumb://config";
+const CONFIG_RESOURCE_NAME: &str = "resolved_config";
+const CONFIG_RESOURCE_DESCRIPTION: &str =
+    "Resolved plumb.toml for the server working directory as JSON.";
+const CONFIG_RESOURCE_MIME_TYPE: &str = "application/json";
+
 #[derive(Clone)]
 struct ConfigCacheEntry {
     mtime: SystemTime,
     value: serde_json::Value,
+}
+
+struct ResolvedConfig {
+    value: serde_json::Value,
+    summary: String,
 }
 
 impl PlumbServer {
@@ -340,23 +353,34 @@ impl PlumbServer {
     /// not absolute, and [`ErrorData::internal_error`] when reading or
     /// parsing an existing `plumb.toml` fails.
     pub async fn get_config(&self, args: GetConfigArgs) -> Result<CallToolResult, ErrorData> {
-        if args.working_dir.is_empty() {
+        let resolved = self.resolve_config_for_tool(&args.working_dir)?;
+        let mut result = CallToolResult::success(vec![Content::text(resolved.summary)]);
+        result.structured_content = Some(resolved.value);
+        Ok(result)
+    }
+
+    fn resolve_config_for_tool(&self, working_dir: &str) -> Result<ResolvedConfig, ErrorData> {
+        if working_dir.is_empty() {
             return Err(ErrorData::invalid_params(
                 "working_dir must not be empty".to_string(),
                 None,
             ));
         }
-        let working_dir = PathBuf::from(&args.working_dir);
+        let working_dir = PathBuf::from(working_dir);
         if !working_dir.is_absolute() {
             return Err(ErrorData::invalid_params(
-                format!("working_dir must be absolute: {}", args.working_dir),
+                format!("working_dir must be absolute: {}", working_dir.display()),
                 None,
             ));
         }
 
+        self.resolve_config_for_dir(&working_dir)
+    }
+
+    fn resolve_config_for_dir(&self, working_dir: &Path) -> Result<ResolvedConfig, ErrorData> {
         let config_path = working_dir.join("plumb.toml");
 
-        let (structured, summary) = if config_path.exists() {
+        if config_path.exists() {
             let mtime = std::fs::metadata(&config_path)
                 .and_then(|m| m.modified())
                 .map_err(|err| {
@@ -368,14 +392,17 @@ impl PlumbServer {
 
             if let Some(entry) = self.cache_lookup(&config_path, mtime)? {
                 let summary = format!("plumb.toml @ {} (cached)", config_path.display());
-                (entry, summary)
+                Ok(ResolvedConfig {
+                    value: entry,
+                    summary,
+                })
             } else {
                 let config =
                     plumb_config::load(&config_path).map_err(|err| map_config_error(&err))?;
                 let value = serialize_config(&config, &config_path, ConfigSource::File)?;
                 self.cache_store(&config_path, mtime, value.clone())?;
                 let summary = format!("plumb.toml @ {}", config_path.display());
-                (value, summary)
+                Ok(ResolvedConfig { value, summary })
             }
         } else {
             let value = serialize_config(&Config::default(), &config_path, ConfigSource::Default)?;
@@ -383,12 +410,8 @@ impl PlumbServer {
                 "no plumb.toml at {} — returning Config::default()",
                 config_path.display()
             );
-            (value, summary)
-        };
-
-        let mut result = CallToolResult::success(vec![Content::text(summary)]);
-        result.structured_content = Some(structured);
-        Ok(result)
+            Ok(ResolvedConfig { value, summary })
+        }
     }
 
     fn cache_lookup(
@@ -473,13 +496,17 @@ impl ServerHandler for PlumbServer {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
         info.protocol_version = ProtocolVersion::V_2024_11_05;
-        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.capabilities = ServerCapabilities::builder()
+            .enable_resources()
+            .enable_tools()
+            .build();
         info.server_info = Implementation::new("plumb", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
             "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
              use `explain_rule` for canonical rule documentation; use `list_rules` to enumerate \
              every built-in rule; use `get_config` to fetch the resolved `plumb.toml` for a \
-             working directory; use `echo` to smoke-test the transport."
+             working directory; read `plumb://config` to fetch the resolved config for the \
+             server working directory; use `echo` to smoke-test the transport."
                 .into(),
         );
         info
@@ -529,6 +556,52 @@ impl ServerHandler for PlumbServer {
             ),
         ];
         std::future::ready(Ok(ListToolsResult::with_all_items(tools)))
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListResourcesResult, ErrorData>> + Send + '_ {
+        let resources = vec![RawResource::new(CONFIG_RESOURCE_URI, CONFIG_RESOURCE_NAME)
+            .with_description(CONFIG_RESOURCE_DESCRIPTION)
+            .with_mime_type(CONFIG_RESOURCE_MIME_TYPE)
+            .no_annotation()];
+        std::future::ready(Ok(ListResourcesResult::with_all_items(resources)))
+    }
+
+    fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ReadResourceResult, ErrorData>> + Send + '_ {
+        std::future::ready(self.read_resource_impl(&request))
+    }
+}
+
+impl PlumbServer {
+    fn read_resource_impl(
+        &self,
+        request: &ReadResourceRequestParams,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        if request.uri != CONFIG_RESOURCE_URI {
+            return Err(ErrorData::resource_not_found(
+                format!("unknown resource: {}", request.uri),
+                None,
+            ));
+        }
+
+        let working_dir = std::env::current_dir()
+            .map_err(|err| ErrorData::internal_error(format!("current_dir: {err}"), None))?;
+        let resolved = self.resolve_config_for_dir(&working_dir)?;
+        let text = serde_json::to_string(&resolved.value).map_err(|err| {
+            ErrorData::internal_error(format!("serialize config resource: {err}"), None)
+        })?;
+
+        Ok(ReadResourceResult::new(vec![
+            ResourceContents::text(text, CONFIG_RESOURCE_URI)
+                .with_mime_type(CONFIG_RESOURCE_MIME_TYPE),
+        ]))
     }
 }
 

--- a/crates/plumb-mcp/tests/mcp_protocol.rs
+++ b/crates/plumb-mcp/tests/mcp_protocol.rs
@@ -3,20 +3,25 @@
 //! Protocol-level tests that spawn the real `plumb mcp` subprocess and
 //! speak JSON-RPC over stdio live in `crates/plumb-cli/tests/mcp_stdio.rs`.
 //! This file exercises only what's verifiable in-process: server info,
-//! construction, default shape.
+//! construction, and default shape.
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
 
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
 use plumb_core::register_builtin;
 use plumb_mcp::{ExplainRuleArgs, LintUrlArgs, LintUrlDetail, PlumbServer, documented_rule_ids};
 use rmcp::ServerHandler;
 use rmcp::model::ErrorCode;
 
+fn server() -> PlumbServer {
+    PlumbServer::new(PathBuf::from("/"))
+}
+
 #[test]
 fn server_info_declares_plumb() {
-    let server = PlumbServer::new();
+    let server = server();
     let info = server.get_info();
     assert_eq!(info.server_info.name, "plumb");
     assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
@@ -24,7 +29,7 @@ fn server_info_declares_plumb() {
 
 #[test]
 fn server_info_declares_tool_capability() {
-    let server = PlumbServer::new();
+    let server = server();
     let info = server.get_info();
     assert!(
         info.capabilities.tools.is_some(),
@@ -34,7 +39,7 @@ fn server_info_declares_tool_capability() {
 
 #[test]
 fn server_info_declares_resource_capability() {
-    let server = PlumbServer::new();
+    let server = server();
     let info = server.get_info();
     assert!(
         info.capabilities.resources.is_some(),
@@ -44,7 +49,7 @@ fn server_info_declares_resource_capability() {
 
 #[test]
 fn server_info_includes_instructions() {
-    let server = PlumbServer::new();
+    let server = server();
     let info = server.get_info();
     assert!(
         info.instructions.is_some(),
@@ -52,15 +57,9 @@ fn server_info_includes_instructions() {
     );
 }
 
-#[test]
-fn default_is_equivalent_to_new() {
-    // Smoke-test that Default::default() constructs a usable server.
-    let _server = PlumbServer::default();
-}
-
 #[tokio::test]
 async fn explain_rule_happy_path_returns_markdown_and_metadata() {
-    let server = PlumbServer::new();
+    let server = server();
     let result = server
         .explain_rule(ExplainRuleArgs {
             rule_id: "spacing/scale-conformance".to_owned(),
@@ -115,7 +114,7 @@ async fn explain_rule_happy_path_returns_markdown_and_metadata() {
 
 #[tokio::test]
 async fn explain_rule_unknown_rule_id_returns_invalid_params() {
-    let server = PlumbServer::new();
+    let server = server();
     let error = server
         .explain_rule(ExplainRuleArgs {
             rule_id: "does/not-exist".to_owned(),
@@ -142,7 +141,7 @@ fn every_builtin_rule_has_doc_entry() {
 
 #[test]
 fn list_rules_returns_every_builtin_rule_sorted() {
-    let server = PlumbServer::new();
+    let server = server();
     let (text, structured) = server.list_rules_payload();
 
     let builtin_count = register_builtin().len();
@@ -199,7 +198,7 @@ fn list_rules_returns_every_builtin_rule_sorted() {
 /// is a no-op (no browser was launched, so there is nothing to close).
 #[tokio::test]
 async fn fake_url_lint_does_not_warm_chromium_and_shutdown_is_noop() {
-    let server = PlumbServer::new();
+    let server = server();
     let result = server
         .lint_url(LintUrlArgs {
             url: "plumb-fake://hello".to_owned(),
@@ -235,7 +234,7 @@ async fn fake_url_lint_does_not_warm_chromium_and_shutdown_is_noop() {
 /// that accidentally routes the fake scheme through Chromium.
 #[tokio::test]
 async fn many_fake_url_lints_share_one_server_without_warming_chromium() {
-    let server = PlumbServer::new();
+    let server = server();
     for _ in 0..10 {
         let result = server
             .lint_url(LintUrlArgs {

--- a/crates/plumb-mcp/tests/mcp_protocol.rs
+++ b/crates/plumb-mcp/tests/mcp_protocol.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeSet;
 
 use plumb_core::register_builtin;
-use plumb_mcp::{ExplainRuleArgs, LintUrlArgs, PlumbServer, documented_rule_ids};
+use plumb_mcp::{ExplainRuleArgs, LintUrlArgs, LintUrlDetail, PlumbServer, documented_rule_ids};
 use rmcp::ServerHandler;
 use rmcp::model::ErrorCode;
 
@@ -29,6 +29,16 @@ fn server_info_declares_tool_capability() {
     assert!(
         info.capabilities.tools.is_some(),
         "server must advertise the `tools` capability"
+    );
+}
+
+#[test]
+fn server_info_declares_resource_capability() {
+    let server = PlumbServer::new();
+    let info = server.get_info();
+    assert!(
+        info.capabilities.resources.is_some(),
+        "server must advertise the `resources` capability"
     );
 }
 
@@ -193,6 +203,7 @@ async fn fake_url_lint_does_not_warm_chromium_and_shutdown_is_noop() {
     let result = server
         .lint_url(LintUrlArgs {
             url: "plumb-fake://hello".to_owned(),
+            detail: LintUrlDetail::default(),
         })
         .await
         .expect("fake-url lint must succeed without a browser");
@@ -229,6 +240,7 @@ async fn many_fake_url_lints_share_one_server_without_warming_chromium() {
         let result = server
             .lint_url(LintUrlArgs {
                 url: "plumb-fake://hello".to_owned(),
+                detail: LintUrlDetail::default(),
             })
             .await
             .expect("fake-url lint must succeed without a browser");

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -42,6 +42,12 @@ For local development against a source checkout:
 | `list_rules` | List every built-in Plumb rule with id, default severity, and one-line summary. No args. |
 | `get_config` | Return resolved `plumb.toml` for a working directory as JSON. Memoized per `(path, mtime)`. |
 
+## Resources
+
+| Resource | Description |
+|----------|-------------|
+| `plumb://config` | Return the resolved `plumb.toml` for the MCP server's current working directory as JSON. The payload matches `get_config`'s `structuredContent` shape: `{ "config": { ... }, "source": "file" | "default", "path": "/abs/path/to/plumb.toml" }`. |
+
 The response shape follows the MCP `content` + `structuredContent`
 convention:
 


### PR DESCRIPTION
## Summary
- expose `plumb://config` as an MCP resource for the server working directory
- advertise MCP resource capability and cover the resource in protocol tests
- document the MCP resource surface and note it in the changelog

Fixes #42

## Tests Run
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features`
- `cargo test -p plumb-mcp`
- `cargo test -p plumb-cli --test mcp_stdio`
