### PR TITLE
fix(ci): make phase 3 gate environment reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ From the first release onward, this file is maintained automatically by [`releas
 
 - Repository hooks now enforce the talking-stick workflow for agent-driven changes.
 - Initial workspace scaffold, tooling, and walking skeleton.
-- `requirements-dev.txt`, `scripts/check-phase3-gate-env.sh`, and `just phase3-gate-env` now codify the Python (`PyYAML`, `jsonschema`) and Chrome/Chromium prerequisites for the Phase 3 MCP gate.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - `plumb mcp` `lint_url` now accepts an optional `detail` argument. The default `compact` mode preserves the existing MCP payload, while `detail: "full"` returns the canonical full JSON envelope and rejects structured payloads above 50 KB.
 - `plumb mcp` now exposes a `plumb://config` resource that returns the resolved `plumb.toml` for the server working directory as JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 - Repository hooks now enforce the talking-stick workflow for agent-driven changes.
 - Initial workspace scaffold, tooling, and walking skeleton.
+- `requirements-dev.txt`, `scripts/check-phase3-gate-env.sh`, and `just phase3-gate-env` now codify the Python (`PyYAML`, `jsonschema`) and Chrome/Chromium prerequisites for the Phase 3 MCP gate.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - `plumb mcp` `lint_url` now accepts an optional `detail` argument. The default `compact` mode preserves the existing MCP payload, while `detail: "full"` returns the canonical full JSON envelope and rejects structured payloads above 50 KB.
 - `plumb mcp` now exposes a `plumb://config` resource that returns the resolved `plumb.toml` for the server working directory as JSON.

--- a/docs/runbooks/phase-3-gate.md
+++ b/docs/runbooks/phase-3-gate.md
@@ -1,5 +1,8 @@
 # Phase 3 gate
 
+Internal runbook only. This file is not part of the mdBook site, and
+`just phase3-gate-env` is a manual preflight check rather than a CI job.
+
 This gate closes Phase 3. Do not mark the phase done until every item
 below is captured in the PR or issue thread.
 

--- a/docs/runbooks/phase-3-gate.md
+++ b/docs/runbooks/phase-3-gate.md
@@ -1,0 +1,97 @@
+# Phase 3 gate
+
+This gate closes Phase 3. Do not mark the phase done until every item
+below is captured in the PR or issue thread.
+
+## Required evidence
+
+Record the command and the result for each check:
+
+1. Environment check:
+
+   ```bash
+   just phase3-gate-env
+   ```
+
+2. Full validation:
+
+   ```bash
+   just validate
+   ```
+
+3. Real MCP client session against the live site:
+
+   - Start the server:
+
+     ```bash
+     cargo run --quiet -p plumb-cli -- mcp
+     ```
+
+   - From a real MCP client such as Claude Code or Cursor, call:
+     - `lint_url` with `url=https://plumb.aramhammoudeh.com`
+     - `explain_rule` for at least one built-in rule returned by `lint_url`
+     - `list_rules`
+   - Record the client name, the exact URL, and whether each call
+     succeeded.
+
+4. Rules index sync:
+
+   ```bash
+   cargo xtask sync-rules-index
+   ```
+
+5. Pre-release checks:
+
+   ```bash
+   cargo xtask pre-release
+   ```
+
+## What to attach
+
+- The `just phase3-gate-env` output, or the exact missing dependency or
+  browser error if the environment is incomplete.
+- The `just validate` result.
+- MCP client evidence that shows `lint_url`, `explain_rule`, and
+  `list_rules` all worked against
+  `https://plumb.aramhammoudeh.com`.
+- Confirmation that `cargo xtask sync-rules-index` passed.
+- Confirmation that `cargo xtask pre-release` passed.
+
+## Troubleshooting
+
+### Missing Python packages
+
+Install the dev dependencies with the same interpreter Plumb uses for
+runbook tooling:
+
+```bash
+python3 -m pip install --requirement requirements-dev.txt
+```
+
+If you are working in a virtual environment, activate it first.
+
+On Debian or Ubuntu, `python3 -m venv` may require `python3-venv`.
+Installing `python3-yaml` and `python3-jsonschema` also satisfies the
+import check if you prefer distro packages.
+
+### Chrome or Chromium not found
+
+Plumb does not install a browser for you. Install one of these binaries:
+
+- `google-chrome`
+- `google-chrome-stable`
+- `chromium`
+- `chromium-browser`
+
+Common install commands:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install chromium-browser
+
+# Fedora
+sudo dnf install chromium
+
+# macOS
+brew install --cask google-chrome
+```

--- a/justfile
+++ b/justfile
@@ -14,7 +14,8 @@ default:
     @just --list --unsorted
 
 # One-time developer setup. Installs git hooks and Python deps, then verifies
-# the toolchain and phase-3 gate environment.
+# the base Rust toolchain. Run `just phase3-gate-env` for the full Phase 3
+# browser gate.
 setup:
     @echo "▸ Installing git hooks via lefthook…"
     @command -v lefthook >/dev/null 2>&1 || { echo "✖ lefthook not installed. See CONTRIBUTING.md."; exit 1; }
@@ -37,20 +38,8 @@ setup:
     @echo "▸ Verifying Rust toolchain…"
     @rustc --version
     @cargo --version
-    @echo "▸ Checking Chrome/Chromium requirement for Phase 3…"
-    @if command -v google-chrome >/dev/null 2>&1; then \
-        echo "▸ Browser found: $$(command -v google-chrome)"; \
-    elif command -v google-chrome-stable >/dev/null 2>&1; then \
-        echo "▸ Browser found: $$(command -v google-chrome-stable)"; \
-    elif command -v chromium >/dev/null 2>&1; then \
-        echo "▸ Browser found: $$(command -v chromium)"; \
-    elif command -v chromium-browser >/dev/null 2>&1; then \
-        echo "▸ Browser found: $$(command -v chromium-browser)"; \
-    else \
-        echo "▸ Chrome/Chromium not found."; \
-        echo "  just setup is continuing, but just phase3-gate-env still requires Chrome/Chromium for the Phase 3 gate."; \
-        echo "  Install one of: google-chrome, google-chrome-stable, chromium, chromium-browser."; \
-    fi
+    @echo "▸ Phase 3 browser gate not run during setup."
+    @echo "  Run `just phase3-gate-env` to verify Chrome/Chromium before the Phase 3 gate."
     @echo "▸ Done."
 
 # Format the workspace.

--- a/justfile
+++ b/justfile
@@ -13,14 +13,32 @@ set dotenv-load := false
 default:
     @just --list --unsorted
 
-# One-time developer setup. Installs git hooks, verifies toolchain and deps.
+# One-time developer setup. Installs git hooks and Python deps, then verifies
+# the toolchain and phase-3 gate environment.
 setup:
     @echo "▸ Installing git hooks via lefthook…"
     @command -v lefthook >/dev/null 2>&1 || { echo "✖ lefthook not installed. See CONTRIBUTING.md."; exit 1; }
     lefthook install
+    @echo "▸ Installing Python dev dependencies from requirements-dev.txt…"
+    @command -v python3 >/dev/null 2>&1 || { echo "✖ python3 not installed. See requirements-dev.txt."; exit 1; }
+    @python3 -m pip --version >/dev/null 2>&1 || { echo "✖ python3 -m pip is unavailable. Install pip for your Python 3 interpreter."; exit 1; }
+    @if [ -n "${VIRTUAL_ENV:-}" ]; then \
+        python3 -m pip install --requirement requirements-dev.txt; \
+    elif python3 -m pip install --dry-run --user --requirement requirements-dev.txt >/dev/null 2>&1; then \
+        python3 -m pip install --user --requirement requirements-dev.txt; \
+    else \
+        echo "✖ Python dev dependencies were not installed."; \
+        echo "  This interpreter does not allow direct pip installs."; \
+        echo "  Create a virtual environment and rerun just setup:"; \
+        echo "    python3 -m venv .venv && . .venv/bin/activate"; \
+        echo "  Or install distro packages such as python3-yaml, python3-jsonschema, and python3-venv."; \
+        exit 1; \
+    fi
     @echo "▸ Verifying Rust toolchain…"
     @rustc --version
     @cargo --version
+    @echo "▸ Verifying Chrome/Chromium requirement for Phase 3…"
+    bash scripts/check-phase3-gate-env.sh
     @echo "▸ Done."
 
 # Format the workspace.
@@ -36,6 +54,10 @@ check: check-agents
 # symlinks + no drift phrases).
 check-agents:
     bash scripts/check-agents-md.sh
+
+# Verify the local environment required by the Phase 3 gate.
+phase3-gate-env:
+    bash scripts/check-phase3-gate-env.sh
 
 # Full test run.
 test:

--- a/justfile
+++ b/justfile
@@ -13,9 +13,9 @@ set dotenv-load := false
 default:
     @just --list --unsorted
 
-# One-time developer setup. Installs git hooks and Python deps, then verifies
-# the base Rust toolchain. Run `just phase3-gate-env` for the full Phase 3
-# browser gate.
+# One-time developer setup. Installs git hooks and attempts the optional
+# Phase 3 Python deps, then verifies the base Rust toolchain. Run
+# `just phase3-gate-env` for the manual Phase 3 environment preflight.
 setup:
     @echo "▸ Installing git hooks via lefthook…"
     @command -v lefthook >/dev/null 2>&1 || { echo "✖ lefthook not installed. See CONTRIBUTING.md."; exit 1; }
@@ -25,21 +25,23 @@ setup:
     @python3 -m pip --version >/dev/null 2>&1 || { echo "✖ python3 -m pip is unavailable. Install pip for your Python 3 interpreter."; exit 1; }
     @if [ -n "${VIRTUAL_ENV:-}" ]; then \
         python3 -m pip install --requirement requirements-dev.txt; \
-    elif python3 -m pip install --dry-run --user --requirement requirements-dev.txt >/dev/null 2>&1; then \
-        python3 -m pip install --user --requirement requirements-dev.txt; \
     else \
-        echo "✖ Python dev dependencies were not installed."; \
-        echo "  This interpreter does not allow direct pip installs."; \
-        echo "  Create a virtual environment and rerun just setup:"; \
-        echo "    python3 -m venv .venv && . .venv/bin/activate"; \
-        echo "  Or install distro packages such as python3-yaml, python3-jsonschema, and python3-venv."; \
-        exit 1; \
+        if python3 -m pip install --user --requirement requirements-dev.txt; then \
+            :; \
+        else \
+            echo "⚠ Python dev dependencies were not installed."; \
+            echo "  Continue if you only need the Rust toolchain."; \
+            echo "  For Phase 3 tooling, create a virtual environment and rerun just setup:"; \
+            echo "    python3 -m venv .venv && . .venv/bin/activate"; \
+            echo "  Or install distro packages such as python3-yaml, python3-jsonschema, and python3-venv."; \
+            echo "  Then run just phase3-gate-env before working on the Phase 3 gate."; \
+        fi; \
     fi
     @echo "▸ Verifying Rust toolchain…"
     @rustc --version
     @cargo --version
-    @echo "▸ Phase 3 browser gate not run during setup."
-    @echo "  Run `just phase3-gate-env` to verify Chrome/Chromium before the Phase 3 gate."
+    @echo "▸ Phase 3 environment preflight not run during setup."
+    @echo '  Run `just phase3-gate-env` to verify the Python imports and Chrome/Chromium before the Phase 3 gate.'
     @echo "▸ Done."
 
 # Format the workspace.

--- a/justfile
+++ b/justfile
@@ -37,8 +37,20 @@ setup:
     @echo "▸ Verifying Rust toolchain…"
     @rustc --version
     @cargo --version
-    @echo "▸ Verifying Chrome/Chromium requirement for Phase 3…"
-    bash scripts/check-phase3-gate-env.sh
+    @echo "▸ Checking Chrome/Chromium requirement for Phase 3…"
+    @if command -v google-chrome >/dev/null 2>&1; then \
+        echo "▸ Browser found: $$(command -v google-chrome)"; \
+    elif command -v google-chrome-stable >/dev/null 2>&1; then \
+        echo "▸ Browser found: $$(command -v google-chrome-stable)"; \
+    elif command -v chromium >/dev/null 2>&1; then \
+        echo "▸ Browser found: $$(command -v chromium)"; \
+    elif command -v chromium-browser >/dev/null 2>&1; then \
+        echo "▸ Browser found: $$(command -v chromium-browser)"; \
+    else \
+        echo "▸ Chrome/Chromium not found."; \
+        echo "  just setup is continuing, but just phase3-gate-env still requires Chrome/Chromium for the Phase 3 gate."; \
+        echo "  Install one of: google-chrome, google-chrome-stable, chromium, chromium-browser."; \
+    fi
     @echo "▸ Done."
 
 # Format the workspace.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+PyYAML
+jsonschema

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-PyYAML
-jsonschema
+PyYAML>=6,<7
+jsonschema>=4,<5

--- a/scripts/check-phase3-gate-env.sh
+++ b/scripts/check-phase3-gate-env.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+PYTHON_BIN="${PYTHON:-python3}"
+
+echo "▸ Checking Python interpreter..."
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    cat <<EOF >&2
+✖ Python 3 interpreter not found: $PYTHON_BIN
+
+Install Python 3, then install the phase-3 dev dependencies:
+  python3 -m pip install --requirement requirements-dev.txt
+EOF
+    exit 1
+fi
+
+missing_python_deps="$(
+    "$PYTHON_BIN" - <<'PY'
+import importlib.util
+
+missing = []
+for module_name, package_name in (("yaml", "PyYAML"), ("jsonschema", "jsonschema")):
+    if importlib.util.find_spec(module_name) is None:
+        missing.append(package_name)
+
+print("\n".join(missing))
+PY
+)"
+
+if [ -n "$missing_python_deps" ]; then
+    cat <<EOF >&2
+✖ Missing Python dev dependencies:
+$missing_python_deps
+
+Install them with:
+  python3 -m pip install --requirement requirements-dev.txt
+EOF
+    exit 1
+fi
+echo "▸ Python imports OK: yaml, jsonschema"
+
+echo "▸ Checking Chrome/Chromium availability..."
+browser_candidates=(
+    "google-chrome"
+    "google-chrome-stable"
+    "chromium"
+    "chromium-browser"
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    "/c/Program Files/Google/Chrome/Application/chrome.exe"
+    "/c/Program Files/Chromium/Application/chrome.exe"
+    "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+    "/mnt/c/Program Files/Chromium/Application/chrome.exe"
+)
+
+browser_path=""
+for candidate in "${browser_candidates[@]}"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        browser_path="$(command -v "$candidate")"
+        break
+    fi
+
+    if [ -x "$candidate" ]; then
+        browser_path="$candidate"
+        break
+    fi
+done
+
+if [ -z "$browser_path" ]; then
+    cat <<'EOF' >&2
+✖ Chrome/Chromium not found.
+
+Install one of these binaries so Phase 3 MCP checks can lint real URLs:
+  - google-chrome
+  - google-chrome-stable
+  - chromium
+  - chromium-browser
+
+Common install commands:
+  Debian/Ubuntu: sudo apt-get install chromium-browser
+  Fedora: sudo dnf install chromium
+  macOS (Homebrew): brew install --cask google-chrome
+
+Plumb does not install Chrome/Chromium for you.
+EOF
+    exit 1
+fi
+
+echo "▸ Browser found: $browser_path"
+echo "▸ Phase 3 gate environment OK."


### PR DESCRIPTION
Refs #34

## Summary

- add `requirements-dev.txt` for the Phase 3 Python dev dependencies (`PyYAML`, `jsonschema`)
- add `scripts/check-phase3-gate-env.sh` and `just phase3-gate-env` as a manual Phase 3 environment preflight for Python imports plus Chrome/Chromium availability
- make `just setup` attempt the Phase 3 Python dependency install, warn on PEP 668 / pip install failures, and continue with Rust toolchain setup
- add `docs/runbooks/phase-3-gate.md` with the required gate evidence, concise troubleshooting guidance, and an explicit note that it is an internal runbook outside mdBook

## Validation

- `just --list --unsorted`
  - passed
- `cargo fmt --check`
  - passed
- `bash -n scripts/check-phase3-gate-env.sh`
  - passed
- `just setup`
  - failed before the Python step because `lefthook` is not installed in this container (`✖ lefthook not installed. See CONTRIBUTING.md.`)
- `PATH="<tmp-stub>:$PATH" just setup`
  - passed with a stub `lefthook` so the Python step could be exercised; `python3 -m pip install --user --requirement requirements-dev.txt` failed with `externally-managed-environment` on this PEP 668 interpreter, `just setup` printed the warning/help text, then continued and completed successfully
- `just phase3-gate-env`
  - failed as expected on missing Python deps in the base interpreter (`PyYAML`, `jsonschema`); this remains the hard Phase 3 preflight gate

## Expected local blockers

- `lefthook` is not installed in this container, so the real `just setup` stops before the optional Python install step
- the base Python 3 environment is externally managed (PEP 668), so `python3 -m pip install --user --requirement requirements-dev.txt` is rejected unless a virtual environment or distro packages are used
- Chrome/Chromium is not installed in this container
