### PR TITLE
feat(format): add deterministic stats output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ From the first release onward, this file is maintained automatically by [`releas
 ### Added
 
 - SARIF output now includes built-in rule metadata, canonical rule `helpUri` links, and Code Scanning-compatible result locations.
+- Pretty and JSON formatter output now include deterministic stats with severity counts, viewport count, rule count, and a content-hashed run id. Pretty output now groups violations by viewport, then rule, then selector.
 - Repository hooks now enforce the talking-stick workflow for agent-driven changes.
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,7 @@ dependencies = [
 name = "plumb-format"
 version = "0.0.1"
 dependencies = [
+ "indexmap",
  "insta",
  "plumb-core",
  "serde",

--- a/crates/plumb-format/Cargo.toml
+++ b/crates/plumb-format/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 plumb-core = { workspace = true, features = ["test-fake"] }
+indexmap = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 
 [lints]

--- a/crates/plumb-format/src/lib.rs
+++ b/crates/plumb-format/src/lib.rs
@@ -19,6 +19,7 @@
 #![deny(missing_docs)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+use std::collections::BTreeSet;
 use std::fmt::Write as _;
 
 use plumb_core::{RuleMetadata, Severity, Violation};
@@ -40,27 +41,61 @@ const PLUMB_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// No ANSI escapes — coloring is a CLI concern, not a library concern.
 #[must_use]
 pub fn pretty(violations: &[Violation]) -> String {
-    if violations.is_empty() {
-        return String::from("No violations.\n");
-    }
+    let sorted = pretty_sorted(violations);
+    let run_id = match run_id_for_sorted(&sorted) {
+        Ok(run_id) => run_id,
+        // `Violation` is JSON-serializable by construction, so this
+        // branch should be unreachable in practice. Keep the pretty
+        // formatter infallible and deterministic anyway.
+        Err(_) => String::from("sha256:unavailable"),
+    };
+
     let mut out = String::new();
-    for v in violations {
-        let _ = writeln!(
-            out,
-            "{level:>7} {rule}\n         at {selector} [{viewport}]\n         {msg}",
-            level = v.severity.label(),
-            rule = v.rule_id,
-            selector = v.selector,
-            viewport = v.viewport.as_str(),
-            msg = v.message,
-        );
-        if let Some(fix) = &v.fix {
-            let _ = writeln!(out, "         fix: {}", fix.description);
+
+    if sorted.is_empty() {
+        out.push_str("No violations.\n");
+    } else {
+        let mut current_viewport: Option<&str> = None;
+        let mut current_rule: Option<&str> = None;
+        let mut current_selector: Option<&str> = None;
+
+        for violation in &sorted {
+            let viewport = violation.viewport.as_str();
+            if current_viewport != Some(viewport) {
+                if current_viewport.is_some() {
+                    out.push('\n');
+                }
+                let _ = writeln!(out, "{viewport}");
+                current_viewport = Some(viewport);
+                current_rule = None;
+                current_selector = None;
+            }
+
+            if current_rule != Some(violation.rule_id.as_str()) {
+                let _ = writeln!(out, "  {}", violation.rule_id);
+                current_rule = Some(violation.rule_id.as_str());
+                current_selector = None;
+            }
+
+            if current_selector != Some(violation.selector.as_str()) {
+                let _ = writeln!(out, "    {}", violation.selector);
+                current_selector = Some(violation.selector.as_str());
+            }
+
+            let _ = writeln!(
+                out,
+                "      {}: {}",
+                violation.severity.label(),
+                violation.message
+            );
+            if let Some(fix) = &violation.fix {
+                let _ = writeln!(out, "      fix: {}", fix.description);
+            }
+            let _ = writeln!(out, "      docs: {}", violation.doc_url);
         }
-        let _ = writeln!(out, "         docs: {}\n", v.doc_url);
     }
-    out.push_str(&summary_line(violations));
-    out.push('\n');
+
+    append_pretty_stats(&mut out, violations, &run_id);
     out
 }
 
@@ -107,11 +142,10 @@ pub fn pretty(violations: &[Violation]) -> String {
 /// happens when a `Violation::metadata` contains a non-JSON-representable
 /// value.
 pub fn json(violations: &[Violation]) -> Result<String, serde_json::Error> {
-    let mut sorted: Vec<&Violation> = violations.iter().collect();
-    sorted.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+    let sorted = canonical_sorted(violations);
 
-    let canonical = serde_json::to_vec(&sorted)?;
-    let run_id = format!("sha256:{}", hex_digest(&canonical));
+    let run_id = run_id_for_sorted(&sorted)?;
+    let stats = stats_json(&sorted, &run_id);
 
     // Build the envelope with alphabetically ordered keys so the
     // output is stable regardless of `serde_json`'s `preserve_order`
@@ -122,7 +156,8 @@ pub fn json(violations: &[Violation]) -> Result<String, serde_json::Error> {
         Value::String(PLUMB_VERSION.to_owned()),
     );
     envelope.insert("run_id".to_owned(), Value::String(run_id));
-    envelope.insert("summary".to_owned(), counts(violations));
+    envelope.insert("stats".to_owned(), stats.clone());
+    envelope.insert("summary".to_owned(), stats["counts"].clone());
     envelope.insert("violations".to_owned(), serde_json::to_value(&sorted)?);
     serde_json::to_string_pretty(&Value::Object(envelope))
 }
@@ -320,13 +355,51 @@ pub fn mcp_compact(violations: &[Violation]) -> (String, Value) {
 
     let structured = json!({
         "violations": violations,
-        "counts": counts(violations),
+        "counts": counts_json(violations),
     });
 
     (text, structured)
 }
 
-fn counts(violations: &[Violation]) -> Value {
+#[derive(Clone, Copy)]
+struct SeverityCounts {
+    error: usize,
+    info: usize,
+    warning: usize,
+    total: usize,
+}
+
+fn canonical_sorted(violations: &[Violation]) -> Vec<&Violation> {
+    let mut sorted: Vec<&Violation> = violations.iter().collect();
+    sorted.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+    sorted
+}
+
+fn pretty_sorted(violations: &[Violation]) -> Vec<&Violation> {
+    let mut sorted: Vec<&Violation> = violations.iter().collect();
+    sorted.sort_by(|a, b| {
+        (
+            a.viewport.as_str(),
+            a.rule_id.as_str(),
+            a.selector.as_str(),
+            a.dom_order,
+        )
+            .cmp(&(
+                b.viewport.as_str(),
+                b.rule_id.as_str(),
+                b.selector.as_str(),
+                b.dom_order,
+            ))
+    });
+    sorted
+}
+
+fn run_id_for_sorted(sorted: &[&Violation]) -> Result<String, serde_json::Error> {
+    let canonical = serde_json::to_vec(sorted)?;
+    Ok(format!("sha256:{}", hex_digest(&canonical)))
+}
+
+fn counts(violations: &[Violation]) -> SeverityCounts {
     let (mut err, mut warn, mut info) = (0usize, 0usize, 0usize);
     for v in violations {
         match v.severity {
@@ -335,13 +408,48 @@ fn counts(violations: &[Violation]) -> Value {
             Severity::Info => info += 1,
         }
     }
+    SeverityCounts {
+        error: err,
+        info,
+        warning: warn,
+        total: violations.len(),
+    }
+}
+
+fn counts_json(violations: &[Violation]) -> Value {
+    let counts = counts(violations);
     // Insert in alphabetical order so the output is stable regardless
     // of `serde_json`'s `preserve_order` feature toggle.
     let mut map = serde_json::Map::new();
-    map.insert("error".to_owned(), json!(err));
-    map.insert("info".to_owned(), json!(info));
-    map.insert("total".to_owned(), json!(violations.len()));
-    map.insert("warning".to_owned(), json!(warn));
+    map.insert("error".to_owned(), json!(counts.error));
+    map.insert("info".to_owned(), json!(counts.info));
+    map.insert("total".to_owned(), json!(counts.total));
+    map.insert("warning".to_owned(), json!(counts.warning));
+    Value::Object(map)
+}
+
+fn stats_json(sorted: &[&Violation], run_id: &str) -> Value {
+    let owned: Vec<Violation> = sorted
+        .iter()
+        .map(|violation| (*violation).clone())
+        .collect();
+    let counts = counts_json(&owned);
+    let viewport_count = sorted
+        .iter()
+        .map(|violation| violation.viewport.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let rule_count = sorted
+        .iter()
+        .map(|violation| violation.rule_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+
+    let mut map = serde_json::Map::new();
+    map.insert("counts".to_owned(), counts);
+    map.insert("rule_count".to_owned(), json!(rule_count));
+    map.insert("run_id".to_owned(), Value::String(run_id.to_owned()));
+    map.insert("viewport_count".to_owned(), json!(viewport_count));
     Value::Object(map)
 }
 
@@ -349,9 +457,33 @@ fn summary_line(violations: &[Violation]) -> String {
     let c = counts(violations);
     format!(
         "{total} violations ({errors} error, {warnings} warning, {infos} info)",
-        total = c["total"],
-        errors = c["error"],
-        warnings = c["warning"],
-        infos = c["info"],
+        total = c.total,
+        errors = c.error,
+        warnings = c.warning,
+        infos = c.info,
     )
+}
+
+fn append_pretty_stats(out: &mut String, violations: &[Violation], run_id: &str) {
+    let sorted = canonical_sorted(violations);
+    let viewport_count = sorted
+        .iter()
+        .map(|violation| violation.viewport.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let rule_count = sorted
+        .iter()
+        .map(|violation| violation.rule_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str("stats\n");
+    let _ = writeln!(out, "  run_id: {run_id}");
+    let _ = writeln!(out, "  {}", summary_line(violations));
+    let _ = writeln!(out, "  viewport_count: {viewport_count}");
+    let _ = writeln!(out, "  rule_count: {rule_count}");
 }

--- a/crates/plumb-format/tests/determinism.rs
+++ b/crates/plumb-format/tests/determinism.rs
@@ -5,13 +5,70 @@
 //! suite mirrors the `just determinism-check` recipe at the formatter
 //! level — i.e. before the CLI ever wraps it.
 
-use plumb_core::{Config, PlumbSnapshot, Severity, builtin_rule_metadata, register_builtin, run};
+use indexmap::IndexMap;
+use plumb_core::{
+    Config, PlumbSnapshot, Severity, ViewportKey, Violation, builtin_rule_metadata,
+    register_builtin, run,
+};
 use plumb_format::{json, mcp_compact, pretty, sarif_with_rules};
 
 fn fixture() -> Vec<plumb_core::Violation> {
     let snapshot = PlumbSnapshot::canned();
     let config = Config::default();
     run(&snapshot, &config)
+}
+
+fn grouped_fixture() -> Vec<Violation> {
+    vec![
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Warning,
+            message: "Hero spacing drifts off the spacing grid.".to_owned(),
+            selector: "main > section.hero".to_owned(),
+            viewport: ViewportKey::new("mobile"),
+            rect: None,
+            dom_order: 8,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "a11y/touch-target".to_owned(),
+            severity: Severity::Error,
+            message: "CTA touch target is smaller than the minimum size.".to_owned(),
+            selector: "button.cta".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 3,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/a11y-touch-target".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Info,
+            message: "Nav spacing is close to the grid but still non-canonical.".to_owned(),
+            selector: "nav.primary > a".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 2,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Warning,
+            message: "Nav container gap is off-grid.".to_owned(),
+            selector: "nav.primary".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 1,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+    ]
 }
 
 /// Mirror of the SARIF severity mapping owned by the formatter.
@@ -69,11 +126,31 @@ fn json_envelope_has_required_fields() {
         assert!(summary.get(key).is_some(), "summary.{key} must be present");
     }
 
+    let stats = parsed.get("stats").expect("stats present");
+    for key in ["counts", "rule_count", "run_id", "viewport_count"] {
+        assert!(stats.get(key).is_some(), "stats.{key} must be present");
+    }
+
     let violations_value = parsed
         .get("violations")
         .and_then(serde_json::Value::as_array)
         .expect("violations array present");
     assert_eq!(violations_value.len(), violations.len());
+}
+
+#[test]
+fn json_stats_capture_distinct_rule_and_viewport_counts() {
+    let out = json(&grouped_fixture()).expect("json serialize grouped");
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("parse grouped json");
+    let stats = parsed.get("stats").expect("stats present");
+
+    assert_eq!(stats["counts"]["error"].as_u64(), Some(1));
+    assert_eq!(stats["counts"]["warning"].as_u64(), Some(2));
+    assert_eq!(stats["counts"]["info"].as_u64(), Some(1));
+    assert_eq!(stats["counts"]["total"].as_u64(), Some(4));
+    assert_eq!(stats["viewport_count"].as_u64(), Some(2));
+    assert_eq!(stats["rule_count"].as_u64(), Some(2));
+    assert_eq!(stats["run_id"], parsed["run_id"]);
 }
 
 #[test]
@@ -119,6 +196,33 @@ fn pretty_is_byte_identical_across_runs() {
     let c = pretty(&violations);
     assert_eq!(a, b);
     assert_eq!(b, c);
+}
+
+#[test]
+fn pretty_groups_by_viewport_then_rule_then_selector() {
+    let out = pretty(&grouped_fixture());
+
+    let desktop = out.find("desktop\n").expect("desktop group");
+    let mobile = out.find("mobile\n").expect("mobile group");
+    assert!(desktop < mobile, "desktop viewport group must render first");
+
+    let a11y = out.find("  a11y/touch-target\n").expect("a11y rule group");
+    let spacing = out
+        .find("  spacing/grid-conformance\n")
+        .expect("spacing rule group");
+    assert!(
+        a11y < spacing,
+        "desktop rule groups must be sorted before selector entries"
+    );
+
+    let nav = out.find("    nav.primary\n").expect("nav selector");
+    let nav_link = out
+        .find("    nav.primary > a\n")
+        .expect("nav link selector");
+    assert!(
+        nav < nav_link,
+        "selector groups must be sorted within a rule"
+    );
 }
 
 #[test]

--- a/crates/plumb-format/tests/format_snapshots.rs
+++ b/crates/plumb-format/tests/format_snapshots.rs
@@ -1,7 +1,10 @@
 //! Snapshot tests for every formatter against the canned walking-skeleton
 //! violation set.
 
-use plumb_core::{Config, PlumbSnapshot, builtin_rule_metadata, run};
+use indexmap::IndexMap;
+use plumb_core::{
+    Config, PlumbSnapshot, Severity, ViewportKey, Violation, builtin_rule_metadata, run,
+};
 use plumb_format::{json, mcp_compact, pretty, sarif_with_rules};
 
 fn fixture() -> Vec<plumb_core::Violation> {
@@ -10,15 +13,79 @@ fn fixture() -> Vec<plumb_core::Violation> {
     run(&snapshot, &config)
 }
 
+fn grouped_fixture() -> Vec<Violation> {
+    vec![
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Warning,
+            message: "Hero spacing drifts off the spacing grid.".to_owned(),
+            selector: "main > section.hero".to_owned(),
+            viewport: ViewportKey::new("mobile"),
+            rect: None,
+            dom_order: 8,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "a11y/touch-target".to_owned(),
+            severity: Severity::Error,
+            message: "CTA touch target is smaller than the minimum size.".to_owned(),
+            selector: "button.cta".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 3,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/a11y-touch-target".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Info,
+            message: "Nav spacing is close to the grid but still non-canonical.".to_owned(),
+            selector: "nav.primary > a".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 2,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+        Violation {
+            rule_id: "spacing/grid-conformance".to_owned(),
+            severity: Severity::Warning,
+            message: "Nav container gap is off-grid.".to_owned(),
+            selector: "nav.primary".to_owned(),
+            viewport: ViewportKey::new("desktop"),
+            rect: None,
+            dom_order: 1,
+            fix: None,
+            doc_url: "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance".to_owned(),
+            metadata: IndexMap::new(),
+        },
+    ]
+}
+
 #[test]
 fn pretty_snapshot() {
     insta::assert_snapshot!("pretty", pretty(&fixture()));
 }
 
 #[test]
+fn pretty_grouped_snapshot() {
+    insta::assert_snapshot!("pretty_grouped", pretty(&grouped_fixture()));
+}
+
+#[test]
 fn json_snapshot() {
     let out = json(&fixture()).expect("json serialize");
     insta::assert_snapshot!("json", out);
+}
+
+#[test]
+fn json_stats_snapshot() {
+    let out = json(&grouped_fixture()).expect("json serialize grouped");
+    insta::assert_snapshot!("json_stats", out);
 }
 
 #[test]

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
@@ -1,10 +1,22 @@
 ---
 source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 82
 expression: out
 ---
 {
   "plumb_version": "0.0.1",
   "run_id": "sha256:53a662be238be796f9a08b74adb05e4020dd3d9f653e9bf91a7fb5b1c7a274c0",
+  "stats": {
+    "counts": {
+      "error": 0,
+      "info": 0,
+      "total": 1,
+      "warning": 1
+    },
+    "rule_count": 1,
+    "run_id": "sha256:53a662be238be796f9a08b74adb05e4020dd3d9f653e9bf91a7fb5b1c7a274c0",
+    "viewport_count": 1
+  },
   "summary": {
     "error": 0,
     "info": 0,

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
@@ -1,0 +1,72 @@
+---
+source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 88
+expression: out
+---
+{
+  "plumb_version": "0.0.1",
+  "run_id": "sha256:f47589f64fe0e1ced94e916195257a272a6e8509a8ed2831c060a7398d2f86e6",
+  "stats": {
+    "counts": {
+      "error": 1,
+      "info": 1,
+      "total": 4,
+      "warning": 2
+    },
+    "rule_count": 2,
+    "run_id": "sha256:f47589f64fe0e1ced94e916195257a272a6e8509a8ed2831c060a7398d2f86e6",
+    "viewport_count": 2
+  },
+  "summary": {
+    "error": 1,
+    "info": 1,
+    "total": 4,
+    "warning": 2
+  },
+  "violations": [
+    {
+      "rule_id": "a11y/touch-target",
+      "severity": "error",
+      "message": "CTA touch target is smaller than the minimum size.",
+      "selector": "button.cta",
+      "viewport": "desktop",
+      "rect": null,
+      "dom_order": 3,
+      "fix": null,
+      "doc_url": "https://plumb.aramhammoudeh.com/rules/a11y-touch-target"
+    },
+    {
+      "rule_id": "spacing/grid-conformance",
+      "severity": "warning",
+      "message": "Nav container gap is off-grid.",
+      "selector": "nav.primary",
+      "viewport": "desktop",
+      "rect": null,
+      "dom_order": 1,
+      "fix": null,
+      "doc_url": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
+    },
+    {
+      "rule_id": "spacing/grid-conformance",
+      "severity": "info",
+      "message": "Nav spacing is close to the grid but still non-canonical.",
+      "selector": "nav.primary > a",
+      "viewport": "desktop",
+      "rect": null,
+      "dom_order": 2,
+      "fix": null,
+      "doc_url": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
+    },
+    {
+      "rule_id": "spacing/grid-conformance",
+      "severity": "warning",
+      "message": "Hero spacing drifts off the spacing grid.",
+      "selector": "main > section.hero",
+      "viewport": "mobile",
+      "rect": null,
+      "dom_order": 8,
+      "fix": null,
+      "doc_url": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
+    }
+  ]
+}

--- a/crates/plumb-format/tests/snapshots/format_snapshots__pretty.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__pretty.snap
@@ -1,11 +1,17 @@
 ---
 source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 71
 expression: pretty(&fixture())
 ---
-warning spacing/grid-conformance
-         at html > body [desktop]
-         `html > body` has off-grid padding-top 13px; expected a multiple of 4px.
-         fix: Snap `padding-top` to the nearest spacing-grid value (12px).
-         docs: https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance
+desktop
+  spacing/grid-conformance
+    html > body
+      warning: `html > body` has off-grid padding-top 13px; expected a multiple of 4px.
+      fix: Snap `padding-top` to the nearest spacing-grid value (12px).
+      docs: https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance
 
-1 violations (0 error, 1 warning, 0 info)
+stats
+  run_id: sha256:53a662be238be796f9a08b74adb05e4020dd3d9f653e9bf91a7fb5b1c7a274c0
+  1 violations (0 error, 1 warning, 0 info)
+  viewport_count: 1
+  rule_count: 1

--- a/crates/plumb-format/tests/snapshots/format_snapshots__pretty_grouped.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__pretty_grouped.snap
@@ -1,0 +1,29 @@
+---
+source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 76
+expression: pretty(&grouped_fixture())
+---
+desktop
+  a11y/touch-target
+    button.cta
+      error: CTA touch target is smaller than the minimum size.
+      docs: https://plumb.aramhammoudeh.com/rules/a11y-touch-target
+  spacing/grid-conformance
+    nav.primary
+      warning: Nav container gap is off-grid.
+      docs: https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance
+    nav.primary > a
+      info: Nav spacing is close to the grid but still non-canonical.
+      docs: https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance
+
+mobile
+  spacing/grid-conformance
+    main > section.hero
+      warning: Hero spacing drifts off the spacing grid.
+      docs: https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance
+
+stats
+  run_id: sha256:f47589f64fe0e1ced94e916195257a272a6e8509a8ed2831c060a7398d2f86e6
+  4 violations (1 error, 2 warning, 1 info)
+  viewport_count: 2
+  rule_count: 2

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -70,6 +70,6 @@ convention:
 `detail: "compact"` returns the existing token-efficient payload shown
 above. `detail: "full"` keeps the same text block and switches
 `structuredContent` to the canonical JSON envelope from `plumb lint
-<url> --format json`, including `plumb_version`, `run_id`, `summary`,
-and full per-violation fields. Full mode is rejected when the
-serialized structured payload exceeds 50 KB.
+<url> --format json`, including `plumb_version`, `run_id`, `stats`,
+`summary`, and full per-violation fields. Full mode is rejected when
+the serialized structured payload exceeds 50 KB.


### PR DESCRIPTION
Fixes #46

## Summary
- add deterministic formatter stats to pretty and JSON output, including severity counts, distinct viewport count, distinct rule count, and a content-hashed `run_id`
- group pretty output by viewport, then rule, then selector while keeping JSON ordering canonical by violation sort key
- add snapshot and determinism coverage for grouped pretty output and JSON stats, and document the expanded MCP full-detail envelope

## Tests Run
- `cargo test -p plumb-format`
- `cargo fmt --check`
- `cargo check --no-default-features`

## Coordination
- #44: stats and grouped pretty formatting stay within `plumb-format` and do not depend on SARIF internals