### PR TITLE
feat(cli): add lint output file flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- `plumb lint` now accepts `--output <path>` for writing rendered JSON or SARIF output to a file without changing the command's exit code.
 - SARIF output now includes built-in rule metadata, canonical rule `helpUri` links, and Code Scanning-compatible result locations.
 - Pretty and JSON formatter output now include deterministic stats with severity counts, viewport count, rule count, and a content-hashed run id. Pretty output now groups violations by viewport, then rule, then selector.
 - Repository hooks now enforce the talking-stick workflow for agent-driven changes.

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -49,6 +49,7 @@ pub async fn run(
     config_path: Option<PathBuf>,
     executable_path: Option<PathBuf>,
     format: OutputFormat,
+    output_path: Option<PathBuf>,
     viewports: Vec<String>,
     selector: Option<String>,
 ) -> Result<ExitCode> {
@@ -98,11 +99,17 @@ pub async fn run(
                 .context("serialize SARIF")?
         }
     };
-    // CLI is the one place writing to stdout is permitted — hence the
-    // crate-level allow(clippy::print_stdout) above.
-    #[allow(clippy::print_stdout)]
-    {
-        print!("{out}");
+
+    if let Some(path) = output_path {
+        std::fs::write(&path, out)
+            .with_context(|| format!("write lint output to {}", path.display()))?;
+    } else {
+        // CLI is the one place writing to stdout is permitted — hence the
+        // crate-level allow(clippy::print_stdout) above.
+        #[allow(clippy::print_stdout)]
+        {
+            print!("{out}");
+        }
     }
 
     Ok(exit_code_for(&violations))

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -58,6 +58,9 @@ enum Command {
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Pretty)]
         format: Format,
+        /// Write the rendered lint output to a file instead of stdout.
+        #[arg(long, value_name = "PATH")]
+        output: Option<PathBuf>,
         /// Restrict the run to the named viewports (repeatable).
         ///
         /// Defaults to every viewport configured in `plumb.toml`, or
@@ -125,6 +128,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 config,
                 executable_path,
                 format,
+                output,
                 viewports,
                 selector,
             } => {
@@ -133,6 +137,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
                     config,
                     executable_path,
                     format.into(),
+                    output,
                     viewports,
                     selector,
                 )

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -53,6 +53,92 @@ fn lint_fake_url_json_format() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn lint_fake_url_json_output_writes_exact_payload_to_file() -> Result<(), Box<dyn std::error::Error>>
+{
+    let dir = TempDir::new()?;
+    let output_path = dir.path().join("violations.json");
+
+    let expected = Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--format", "json"])
+        .output()?;
+    assert_eq!(expected.status.code(), Some(3));
+    assert!(expected.stderr.is_empty());
+
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().ok_or("non-utf8 output path")?,
+        ])
+        .assert()
+        .code(3)
+        .stdout("")
+        .stderr("");
+
+    let written = fs::read(&output_path)?;
+    assert_eq!(written, expected.stdout);
+    Ok(())
+}
+
+#[test]
+fn lint_fake_url_sarif_output_writes_exact_payload_to_file()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let output_path = dir.path().join("results.sarif");
+
+    let expected = Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--format", "sarif"])
+        .output()?;
+    assert_eq!(expected.status.code(), Some(3));
+    assert!(expected.stderr.is_empty());
+
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "sarif",
+            "--output",
+            output_path.to_str().ok_or("non-utf8 output path")?,
+        ])
+        .assert()
+        .code(3)
+        .stdout("")
+        .stderr("");
+
+    let written = fs::read(&output_path)?;
+    assert_eq!(written, expected.stdout);
+    Ok(())
+}
+
+#[test]
+fn lint_output_with_missing_parent_exits_infra_error_without_rendering_payload()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let output_path = dir.path().join("missing").join("violations.json");
+
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().ok_or("non-utf8 output path")?,
+        ])
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr(contains("write lint output to"))
+        .stderr(contains("\"rule_id\"").not())
+        .stderr(contains("spacing/grid-conformance").not());
+    Ok(())
+}
+
+#[test]
 fn lint_real_url_with_missing_executable_path_reports_chromium_hint()
 -> Result<(), Box<dyn std::error::Error>> {
     Command::cargo_bin("plumb")?

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -16,6 +16,7 @@ major version falls in Plumb's supported range (see
 | `-c`, `--config <path>` | Config file path. Defaults to `plumb.toml` in CWD. |
 | `--executable-path <path>` | Chrome or Chromium binary to use instead of auto-detection. |
 | `--format <pretty\|json\|sarif>` | Output format. Default: `pretty`. |
+| `--output <path>` | Write rendered output to a file instead of stdout. |
 | `-v`, `--verbose` | Increase log verbosity. `-vv` for trace. |
 
 Exit codes:

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -71,7 +71,7 @@ in CI — there is no clock or hash-randomized output to wash through
 For SARIF (GitHub code scanning, JetBrains, etc.):
 
 ```bash
-plumb lint https://example.com --format sarif > plumb.sarif
+plumb lint https://example.com --format sarif --output plumb.sarif
 ```
 
 ## 5. Configure a rule


### PR DESCRIPTION
## Summary
- add `--output <PATH>` to `plumb lint` and thread it through the CLI into the lint command
- keep formatter calls pure and write the exact rendered output to stdout or the requested file path
- cover JSON/SARIF output-file behavior and write failures in CLI integration tests

## Testing
- `cargo test -p plumb-cli --test cli_integration`
- `cargo check --no-default-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p plumb-cli --all-targets -- -D warnings`

Fixes #45
