### PR TITLE
docs(ci): add code scanning and reviewdog guides

### DIFF
--- a/contrib/reviewdog-plumb.yaml
+++ b/contrib/reviewdog-plumb.yaml
@@ -1,0 +1,41 @@
+runner:
+  plumb:
+    cmd: |
+      plumb lint plumb-fake://hello --format json | jq -c '
+        {
+          source: {
+            name: "plumb",
+            url: "https://plumb.aramhammoudeh.com"
+          },
+          diagnostics: [
+            .violations[] | {
+              message: (
+                .message
+                + " selector=" + (.selector // "<unknown>")
+                + " viewport=" + (.viewport // "<unknown>")
+              ),
+              location: {
+                path: "plumb-lint-target",
+                range: {
+                  start: {
+                    line: 1,
+                    column: 1
+                  }
+                }
+              },
+              severity: (
+                if .severity == "error" then "ERROR"
+                elif .severity == "warning" then "WARNING"
+                else "INFO"
+                end
+              ),
+              code: {
+                value: .rule_id,
+                url: .doc_url
+              }
+            }
+          ]
+        }
+      '
+    format: rdjson
+    name: plumb

--- a/contrib/reviewdog-plumb.yaml
+++ b/contrib/reviewdog-plumb.yaml
@@ -1,6 +1,7 @@
 runner:
   plumb:
     cmd: |
+      # Replace plumb-fake://hello with the real target URL for your project.
       plumb lint plumb-fake://hello --format json | jq -c '
         {
           source: {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,11 @@
 - [MCP server](./mcp.md)
 - [Configuration](./configuration.md)
 
+# CI
+
+- [GitHub Code Scanning](./ci/github-code-scanning.md)
+- [reviewdog](./ci/reviewdog.md)
+
 # Rules
 
 - [Overview](./rules/overview.md)

--- a/docs/src/ci/github-code-scanning.md
+++ b/docs/src/ci/github-code-scanning.md
@@ -1,0 +1,80 @@
+# GitHub Code Scanning
+
+GitHub Code Scanning consumes SARIF. Plumb already emits SARIF, so the
+workflow is:
+
+1. Run Plumb with `--format sarif --output plumb.sarif`.
+2. Upload that file with `github/codeql-action/upload-sarif@v3`.
+3. Fail the job after the upload if Plumb reported violations.
+
+The important detail is step ordering. `plumb lint` returns a nonzero
+exit code when it finds violations, but you still want the SARIF upload
+step to run so the findings show up in GitHub's Security tab.
+
+## Minimal workflow
+
+```yaml
+name: plumb-code-scanning
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  plumb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Plumb
+        run: cargo install --git https://github.com/aram-devdocs/plumb plumb
+
+      - name: Run Plumb
+        id: plumb
+        shell: bash
+        run: |
+          set +e
+          plumb lint https://example.com --format sarif --output plumb.sarif
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: plumb.sarif
+
+      - name: Fail if Plumb reported violations
+        if: steps.plumb.outputs.exit_code != '0'
+        run: exit "${{ steps.plumb.outputs.exit_code }}"
+```
+
+## Why the extra step exists
+
+If you let `plumb lint` fail the job directly, GitHub skips the SARIF
+upload and you lose the code scanning result. Capturing the exit code in
+one step and failing later keeps both behaviors:
+
+- the SARIF file is uploaded every time;
+- the workflow still ends nonzero when Plumb reports violations.
+
+`continue-on-error: true` on the Plumb step is also fine. The example
+above uses explicit exit-code capture because it makes the control flow
+obvious in the YAML.
+
+## Notes
+
+- `security-events: write` is required for `upload-sarif`.
+- `github/codeql-action/upload-sarif@v3` only uploads the report. It
+  does not decide whether your lint step should pass.
+- Plumb writes the SARIF file directly with:
+
+```bash
+plumb lint https://example.com --format sarif --output plumb.sarif
+```

--- a/docs/src/ci/github-code-scanning.md
+++ b/docs/src/ci/github-code-scanning.md
@@ -7,7 +7,7 @@ workflow is:
 2. Upload that file with `github/codeql-action/upload-sarif@v3`.
 3. Fail the job after the upload if Plumb reported violations.
 
-The important detail is step ordering. `plumb lint` returns a nonzero
+The detail that matters is step ordering. `plumb lint` returns a nonzero
 exit code when it finds violations, but you still want the SARIF upload
 step to run so the findings show up in GitHub's Security tab.
 

--- a/docs/src/ci/reviewdog.md
+++ b/docs/src/ci/reviewdog.md
@@ -1,0 +1,128 @@
+# reviewdog
+
+Plumb does not ship a built-in reviewdog formatter. The integration
+here converts `plumb lint --format json` output to reviewdog's
+`rdjson` format with `jq`.
+
+The committed runner config lives at `contrib/reviewdog-plumb.yaml`.
+
+## What the config does
+
+Plumb reports findings against a rendered target, not a source file in
+your repository. reviewdog expects file-based diagnostics. The config
+committed in `contrib/reviewdog-plumb.yaml` does four things:
+
+- running `plumb lint plumb-fake://hello --format json`;
+- converting `.violations[]` to `rdjson`;
+- attaching each diagnostic to the synthetic path
+  `plumb-lint-target:1:1`;
+- keeping the rule id, docs URL, selector, viewport, and message.
+
+That makes the output usable for reviewdog reporters such as
+`local`, `github-check`, and `github-annotations`. It is a transport
+layer, not source mapping.
+
+## Local run
+
+```bash
+reviewdog \
+  -conf=contrib/reviewdog-plumb.yaml \
+  -runners=plumb \
+  -reporter=local \
+  -filter-mode=nofilter
+```
+
+## GitHub Actions example
+
+```yaml
+name: plumb-reviewdog
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  plumb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Plumb
+        run: cargo install --git https://github.com/aram-devdocs/plumb plumb
+
+      - uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Run reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewdog \
+            -conf=contrib/reviewdog-plumb.yaml \
+            -runners=plumb \
+            -reporter=github-check \
+            -filter-mode=nofilter
+```
+
+## The JSON pipeline
+
+The runner config uses this exact pipeline:
+
+```bash
+plumb lint plumb-fake://hello --format json | jq -c '
+  {
+    source: {
+      name: "plumb",
+      url: "https://plumb.aramhammoudeh.com"
+    },
+    diagnostics: [
+      .violations[] | {
+        message: (
+          .message
+          + " selector=" + (.selector // "<unknown>")
+          + " viewport=" + (.viewport // "<unknown>")
+        ),
+        location: {
+          path: "plumb-lint-target",
+          range: {
+            start: {
+              line: 1,
+              column: 1
+            }
+          }
+        },
+        severity: (
+          if .severity == "error" then "ERROR"
+          elif .severity == "warning" then "WARNING"
+          else "INFO"
+          end
+        ),
+        code: {
+          value: .rule_id,
+          url: .doc_url
+        }
+      }
+    ]
+  }
+'
+```
+
+On the current `plumb-fake://hello` fixture, `plumb lint` exits `3`
+because it found a warning. The config still works because the runner
+command is a plain shell pipeline, so the pipeline exit status comes
+from `jq`, which exits `0` after producing valid `rdjson`. If you wrap
+the same pipeline in a shell that enables `pipefail`, capture or ignore
+Plumb's exit code yourself before handing the transformed JSON to
+reviewdog.
+
+## Limits
+
+- The synthetic `plumb-lint-target` path is intentional. Plumb is
+  linting rendered output, so there is no source file or source line to
+  report.
+- If you need GitHub Security alerts, use the SARIF workflow from
+  [GitHub Code Scanning](./github-code-scanning.md) instead.

--- a/docs/src/ci/reviewdog.md
+++ b/docs/src/ci/reviewdog.md
@@ -5,6 +5,8 @@ here converts `plumb lint --format json` output to reviewdog's
 `rdjson` format with `jq`.
 
 The committed runner config lives at `contrib/reviewdog-plumb.yaml`.
+Copy that file from the Plumb repo into your own project before using
+`-conf=contrib/reviewdog-plumb.yaml`.
 
 ## What the config does
 
@@ -12,7 +14,8 @@ Plumb reports findings against a rendered target, not a source file in
 your repository. reviewdog expects file-based diagnostics. The config
 committed in `contrib/reviewdog-plumb.yaml` does four things:
 
-- running `plumb lint plumb-fake://hello --format json`;
+- running `plumb lint plumb-fake://hello --format json` (replace
+  `plumb-fake://hello` with the URL you want to lint);
 - converting `.violations[]` to `rdjson`;
 - attaching each diagnostic to the synthetic path
   `plumb-lint-target:1:1`;
@@ -23,6 +26,10 @@ That makes the output usable for reviewdog reporters such as
 layer, not source mapping.
 
 ## Local run
+
+Before running this, copy `contrib/reviewdog-plumb.yaml` from this repo
+into your project's `contrib/` directory. Then edit the copied file and
+replace `plumb-fake://hello` with the real target URL.
 
 ```bash
 reviewdog \
@@ -70,7 +77,8 @@ jobs:
 
 ## The JSON pipeline
 
-The runner config uses this exact pipeline:
+The runner config uses this exact pipeline. Replace `plumb-fake://hello`
+with the real target URL in your copied config.
 
 ```bash
 plumb lint plumb-fake://hello --format json | jq -c '


### PR DESCRIPTION
Fixes #47
Fixes #48

## Summary
- add `docs/src/ci/github-code-scanning.md` with the required flow: run `plumb lint --format sarif --output plumb.sarif`, then upload with `github/codeql-action/upload-sarif@v3`
- document `security-events: write` and keeping SARIF upload running after findings before failing from the captured Plumb exit code
- add `docs/src/ci/reviewdog.md` plus committed `contrib/reviewdog-plumb.yaml` that converts real `plumb lint --format json` output to reviewdog `rdjson` with `jq`
- link both CI pages from `docs/src/SUMMARY.md`

## Validation
- Humanizer run: scanned both new CI docs and `contrib/reviewdog-plumb.yaml` against `.agents/skills/humanizer/SKILL.md` vocabulary; only `important` was flagged and rewritten to `detail that matters`; rerun produced no matches
- Reviewdog config pipeline tested against real `plumb lint plumb-fake://hello --format json` via the built `plumb` binary and committed jq transform: produced rdjson with source `plumb`, 1 diagnostic, path `plumb-lint-target`, severity `WARNING`
- `git diff --check origin/main...HEAD`
- Scope check: changed only `docs/src/ci/github-code-scanning.md`, `docs/src/ci/reviewdog.md`, `contrib/reviewdog-plumb.yaml`, and `docs/src/SUMMARY.md`

## Notes
- No CI workflows, formatter changes, release docs, or Pages docs are included.
