### PR TITLE
chore(ci): harden crates.io publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,25 +34,37 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    environment: crates-io
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo publish (bottom-up)
+      - name: Publish crates (bottom-up dependency order)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
-          # Publish in dependency order. `cargo publish --dry-run` first
-          # on each so an upload failure doesn't leave a half-released state.
-          for crate in plumb-core plumb-format plumb-cdp plumb-config plumb-mcp plumb-cli; do
-            echo "▸ publishing $crate"
-            ( cd "crates/$crate" && cargo publish --dry-run )
-          done
-          for crate in plumb-core plumb-format plumb-cdp plumb-config plumb-mcp plumb-cli; do
-            ( cd "crates/$crate" && cargo publish )
-            # Wait for the index to catch up so the next crate's dep resolves.
-            sleep 30
+          # Bottom-up publish order matching the dependency hierarchy:
+          #   core (no internal deps)
+          #   → format (core)
+          #   → cdp (core)
+          #   → config (core)
+          #   → mcp (core, format, cdp, config)
+          #   → cli (all)
+          CRATES=(plumb-core plumb-format plumb-cdp plumb-config plumb-mcp plumb-cli)
+          for crate in "${CRATES[@]}"; do
+            echo "::group::Publishing $crate"
+            echo "▸ dry-run $crate"
+            cargo publish -p "$crate" --dry-run --locked
+            echo "▸ publish $crate"
+            cargo publish -p "$crate" --locked
+            echo "::endgroup::"
+            # Wait for the crates.io index to sync so the next crate's
+            # dependency on this one resolves.
+            if [ "$crate" != "plumb-cli" ]; then
+              echo "⏳ waiting 30s for index sync…"
+              sleep 30
+            fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- Per-crate README files and package metadata for crates.io publishing.
+- `release-please.yml` crates-io publish job now uses bottom-up interleaved dry-run + publish, `--locked`, GitHub environment protection, and `::group::` log folding.
+
 - `plumb lint` now accepts `--output <path>` for writing rendered JSON or SARIF output to a file without changing the command's exit code.
 - SARIF output now includes built-in rule metadata, canonical rule `helpUri` links, and Code Scanning-compatible result locations.
 - Pretty and JSON formatter output now include deterministic stats with severity counts, viewport count, rule count, and a content-hashed run id. Pretty output now groups violations by viewport, then rule, then selector.

--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -9,9 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [features]
 default = []

--- a/crates/plumb-cdp/README.md
+++ b/crates/plumb-cdp/README.md
@@ -1,0 +1,20 @@
+# plumb-cdp
+
+Chromium DevTools Protocol driver for [Plumb](https://plumb.aramhammoudeh.com) —
+renders pages to `PlumbSnapshot`.
+
+This crate drives a headless Chromium instance via CDP to capture the
+computed DOM at one or more viewports. It is the only crate in the Plumb
+workspace permitted to use `unsafe` code.
+
+## Key types
+
+- `BrowserDriver` — trait abstracting snapshot capture.
+- `ChromiumDriver` — real Chromium driver (requires a local Chromium binary).
+- `FakeDriver` — deterministic in-memory driver for `plumb-fake://` URLs.
+- `PersistentBrowser` — reusable browser session for MCP server use.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-cli/Cargo.toml
+++ b/crates/plumb-cli/Cargo.toml
@@ -9,9 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [[bin]]
 name = "plumb"

--- a/crates/plumb-cli/README.md
+++ b/crates/plumb-cli/README.md
@@ -1,0 +1,34 @@
+# plumb-cli
+
+The `plumb` command-line interface — a deterministic design-system linter
+for rendered websites.
+
+This crate builds the `plumb` binary. For library usage, depend on
+[`plumb-core`](https://crates.io/crates/plumb-core) instead.
+
+## Usage
+
+```bash
+# Lint a URL at default viewports
+plumb lint https://example.com
+
+# Output as SARIF for GitHub Code Scanning
+plumb lint https://example.com --format sarif
+
+# Start the MCP server for AI agents
+plumb mcp
+
+# Explain a rule
+plumb explain spacing/scale-conformance
+```
+
+## Install
+
+```bash
+cargo install plumb-cli
+```
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-config/Cargo.toml
+++ b/crates/plumb-config/Cargo.toml
@@ -9,9 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [dependencies]
 plumb-core = { workspace = true }

--- a/crates/plumb-config/README.md
+++ b/crates/plumb-config/README.md
@@ -1,0 +1,19 @@
+# plumb-config
+
+Config loading and JSON Schema emission for [Plumb](https://plumb.aramhammoudeh.com).
+
+Loads `plumb.toml` (or `.json` / `.yaml`) via
+[figment](https://docs.rs/figment) and emits the canonical JSON Schema
+via [schemars](https://docs.rs/schemars). Supports DTCG token files and
+Tailwind CSS config as design-token sources.
+
+## Public API
+
+- `load` — resolve and merge config from disk.
+- `emit_schema` — generate the JSON Schema for `plumb.toml`.
+- `ConfigError` — typed error enum for config failures.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-core/Cargo.toml
+++ b/crates/plumb-core/Cargo.toml
@@ -9,9 +9,11 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+# Keep agent instructions and symlinks out of the crates.io tarball.
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [features]
 # Exposes deterministic test fixtures and an in-memory `canned()` constructor.

--- a/crates/plumb-core/README.md
+++ b/crates/plumb-core/README.md
@@ -1,0 +1,23 @@
+# plumb-core
+
+Deterministic design-system linter — rule engine and core types.
+
+`plumb-core` is the foundation of the [Plumb](https://plumb.aramhammoudeh.com)
+workspace. It defines the `Rule` trait, the violation model, the
+`PlumbSnapshot` representation, and the config schema. All output is
+byte-identical across runs by design.
+
+## Crate highlights
+
+- **Rule engine** — register rules, run them against a snapshot, collect
+  sorted violations.
+- **Snapshot types** — `PlumbSnapshot`, `SnapshotCtx`, `ElementNode`,
+  `ComputedStyles`, viewport definitions.
+- **Config** — `Config` struct with `serde` + `schemars` support.
+- **No I/O, no async, no wall-clock** — pure functions of
+  `(snapshot, config)`.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-format/Cargo.toml
+++ b/crates/plumb-format/Cargo.toml
@@ -9,9 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [dependencies]
 plumb-core = { workspace = true }

--- a/crates/plumb-format/README.md
+++ b/crates/plumb-format/README.md
@@ -1,0 +1,21 @@
+# plumb-format
+
+Output formatters for [Plumb](https://plumb.aramhammoudeh.com) violations —
+pretty, JSON, SARIF, and MCP-compact.
+
+Each formatter is a pure function: violations in, formatted string out.
+No filesystem, no network, no wall-clock — deterministic by construction.
+
+## Formats
+
+| Format | Function | Use case |
+|--------|----------|----------|
+| Pretty | `pretty` | Human-readable terminal output |
+| JSON | `json` | Machine-readable, CI integrations |
+| SARIF | `sarif` | GitHub Code Scanning, IDE extensions |
+| MCP-compact | `mcp_compact` | Token-efficient AI agent responses |
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -9,9 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
 
 [dependencies]
 # `test-fake` keeps the canned snapshot path available for

--- a/crates/plumb-mcp/README.md
+++ b/crates/plumb-mcp/README.md
@@ -1,0 +1,21 @@
+# plumb-mcp
+
+Model Context Protocol server for [Plumb](https://plumb.aramhammoudeh.com).
+
+Exposes Plumb's linting capabilities over stdio using the
+[MCP](https://modelcontextprotocol.io) protocol, so AI coding agents
+(Claude Code, Cursor, Codex, Windsurf) can lint rendered pages and
+retrieve rule explanations programmatically.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `lint_url` | Lint a URL and return compact violations |
+| `explain_rule` | Return the docs page for a rule |
+| `echo` | Health-check / connectivity test |
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.


### PR DESCRIPTION
## Summary

Closes #50 — wire `release-please` + `cargo publish` to publish all 6 workspace crates to crates.io on tag push.

- **Per-crate README.md** files with crate-specific descriptions for crates.io display (replaces inherited root README).
- **Package hygiene**: exclude `AGENTS.md`/`CLAUDE.md` from published tarballs; override workspace `readme` inheritance so each crate resolves its own `README.md`.
- **Workflow fix**: interleave dry-run + publish per crate in dependency order instead of running all dry-runs first (dependent crates fail dry-run before their deps are published).
- **Workflow hardening**: `--locked` flag, `environment: crates-io` protection, `::group::` log folding, `cargo publish -p <crate>` from workspace root.

## Dry-run evidence

| Crate | `cargo publish --dry-run` | `cargo package --list` | Notes |
|-------|---------------------------|------------------------|-------|
| plumb-core | PASS | PASS (48 files, 209 KiB) | No internal deps — full dry-run succeeds |
| plumb-format | blocked | PASS (17 files) | Blocked on `plumb-core` not yet on crates.io |
| plumb-cdp | blocked | PASS (12 files) | Blocked on `plumb-core` not yet on crates.io |
| plumb-config | blocked | PASS (24 files) | Blocked on `plumb-core` not yet on crates.io |
| plumb-mcp | blocked | PASS (8 files) | Blocked on internal deps not yet on crates.io |
| plumb-cli | blocked | PASS (16 files) | Blocked on internal deps not yet on crates.io |

All 6 crates package without warnings. `AGENTS.md`/`CLAUDE.md` correctly excluded from all tarballs.

## Live publish blocker

Live acceptance (`cargo publish` without `--dry-run`) remains blocked on:
1. **crates.io crate name ownership** — names `plumb-core`, `plumb-format`, etc. must be claimed.
2. **`CARGO_REGISTRY_TOKEN`** — must be configured as a repo secret.
3. **`crates-io` GitHub environment** — must be created in repo settings to match the workflow's `environment: crates-io`.

These are external setup steps, not code changes. Once configured, the workflow will publish all 6 crates bottom-up on the next tag push.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo publish --dry-run -p plumb-core --locked` passes
- [x] `cargo package --list` succeeds for all 6 crates with no warnings
- [x] No `AGENTS.md`/`CLAUDE.md` in any package listing
- [x] Per-crate `README.md` included (not root README)
- [ ] CI passes on this PR
- [ ] After merge + first tag: verify `release-please.yml` triggers crates-io job

🤖 Generated with [Claude Code](https://claude.com/claude-code)