### PR TITLE
chore(ci): prep homebrew tap activation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ name: release
 # This workflow is a hand-authored version of what `cargo dist init`
 # would generate. It stays in sync with `dist-workspace.toml`. Re-run
 # `cargo dist generate` locally and diff before editing.
+#
+# Homebrew tap publishing is intentionally inactive here. Do not add the
+# `tap` field in `dist-workspace.toml` until the external prerequisites
+# exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap` repo, and the
+# cargo-dist publishing token/permissions.
 
 on:
   push:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,8 +25,12 @@ github-attestations = true
 pr-run-mode = "plan"
 allow-dirty = ["ci"]
 
-# tap and npm-scope are intentionally commented out until the
-# plumb-dev/homebrew-tap repo and @plumb npm org exist.
+# Homebrew and npm publishing stay disabled in this prep-only state.
+# Uncomment these only after:
+# 1. the `plumb-dev` GitHub org exists,
+# 2. the `plumb-dev/homebrew-tap` repo exists and is wired for cargo-dist,
+# 3. the release token/permissions for cargo-dist publishing are in place.
+# Issue #51 is intentionally narrowed so this PR does not enable either.
 # tap = "plumb-dev/homebrew-tap"
 # npm-scope = "@plumb"
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
 # CI
 
 - [GitHub Code Scanning](./ci/github-code-scanning.md)
+- [Release Prep](./ci/release-prep.md)
 - [reviewdog](./ci/reviewdog.md)
 
 # Rules

--- a/docs/src/ci/release-prep.md
+++ b/docs/src/ci/release-prep.md
@@ -1,0 +1,43 @@
+# Release Prep
+
+This page records release work that is intentionally staged ahead of
+live distribution changes.
+
+## Homebrew tap activation
+
+Issue #51 is prep-only in this repo state. The release workflow and
+`dist-workspace.toml` already validate the cargo-dist setup, but they do
+not enable Homebrew publishing yet.
+
+Before anyone uncomments the `tap` setting in `dist-workspace.toml`,
+these prerequisites MUST exist:
+
+1. The `plumb-dev` GitHub organization.
+2. The `plumb-dev/homebrew-tap` repository.
+3. The token and GitHub permissions cargo-dist needs to update the tap
+   on release.
+
+Activation steps, once the external prerequisites exist:
+
+1. Confirm `cargo dist plan` still passes with the current repo state.
+2. Create or verify the `plumb-dev/homebrew-tap` repo settings that
+   cargo-dist expects for formula updates.
+3. Add the release token or permissions required for cargo-dist to push
+   Homebrew formula changes.
+4. Uncomment `tap = "plumb-dev/homebrew-tap"` in
+   `dist-workspace.toml`.
+5. Run `cargo dist plan` again and review the generated manifest for the
+   Homebrew artifacts.
+6. Cut a tag-driven dry run in GitHub Actions before claiming
+   `brew install` support.
+
+Current blockers this repo does not solve:
+
+- `plumb-dev` org does not exist here.
+- `plumb-dev/homebrew-tap` is not available here.
+- cargo-dist publishing credentials and permissions are external to this
+  repo.
+
+Until those blockers are resolved, the install docs describe the
+Homebrew command shape, but this repo MUST NOT claim `brew install`
+verification.


### PR DESCRIPTION
## Spec

Refs #51

## Summary

- document the Homebrew tap activation checklist and current external blockers in a new release-prep docs page
- tighten the commented cargo-dist tap contract so future activation is explicit and stays disabled in this prep-only PR
- add a matching note to the release workflow so maintainers do not enable tap publishing before the org, repo, and permissions exist

## Test plan

- [x] `just check` passes (fmt + clippy, no warnings)
- [ ] `just test` passes on my machine
- [ ] `just determinism-check` passes
- [ ] `cargo deny check` passes
- [x] New tests added (or reason-not given)
- [x] Docs updated (`docs/src/**`, rustdoc, CHANGELOG if user-visible)
- [x] Humanizer skill run on any `docs/src/**` prose

Reason not given for new tests: this PR changes docs and release comments only; no runtime behavior changed.

Validation details:
- `dist plan` passes locally with `cargo-dist 0.28.0` installed as `dist`
- `cargo fmt --all -- --check` passes
- `cargo xtask pre-release` passes after installing local `PyYAML` for the runbook validator
- `just validate` reaches the test phase, then fails in existing Chromium-dependent `plumb-cdp` tests because Chrome/Chromium is not installed in this environment

## Screenshots / terminal output

Relevant terminal output:
- `dist plan` announces `v0.0.1` and produces source tarballs plus shell/PowerShell installers, with no Homebrew tap artifacts enabled.
- `just validate` fails at `chromium_driver_captures_static_fixture` and `chromium_driver_snapshot_is_byte_identical` with `ChromiumNotFound`.

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- This PR does not uncomment `tap` in `dist-workspace.toml`.
- This PR does not create or assume `plumb-dev/homebrew-tap`.
- This PR does not claim `brew install` verification.
- External blockers remain: `plumb-dev` org, `plumb-dev/homebrew-tap`, and cargo-dist publishing token/permissions.
