### PR TITLE
chore(ci): prep npm cli activation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,14 @@ name: release
 # would generate. It stays in sync with `dist-workspace.toml`. Re-run
 # `cargo dist generate` locally and diff before editing.
 #
-# Homebrew tap publishing is intentionally inactive here. Do not add the
-# `tap` field in `dist-workspace.toml` until the external prerequisites
-# exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap` repo, and the
-# cargo-dist publishing token/permissions.
+# Homebrew tap and npm publishing are intentionally inactive here. Do not add
+# the `tap` or `npm-scope` fields in `dist-workspace.toml` until the external
+# prerequisites exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap` repo,
+# ownership of the `@plumb` npm scope and `@plumb/cli` package, and the
+# cargo-dist publishing token/permissions. npm activation also needs `npm`
+# added to the installer list; `npm-scope` alone does not emit npm artifacts
+# on cargo-dist 0.28.0. This workflow must not claim `npm i -g @plumb/cli`
+# support until a live publish verifies it.
 
 on:
   push:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,9 +29,18 @@ allow-dirty = ["ci"]
 # Uncomment these only after:
 # 1. the `plumb-dev` GitHub org exists,
 # 2. the `plumb-dev/homebrew-tap` repo exists and is wired for cargo-dist,
-# 3. the release token/permissions for cargo-dist publishing are in place.
-# Issue #51 is intentionally narrowed so this PR does not enable either.
+# 3. the `@plumb` npm scope and the `@plumb/cli` package are owned by the
+#    release account that will publish from this repo,
+# 4. the release token/permissions for cargo-dist publishing are in place,
+# 5. a live publish has verified the public install command shape before docs
+#    claim `npm i -g @plumb/cli` support.
+# Issues #51 and #52 are intentionally prep-only, so this repo must not enable
+# either installer yet.
 # tap = "plumb-dev/homebrew-tap"
+# Keep the value aligned with the intended package name `@plumb/cli`, but do
+# not uncomment this field until the external npm prerequisites above exist.
+# Future activation also needs `npm` added to `installers`; `npm-scope` alone
+# does not produce npm artifacts in cargo-dist 0.28.0.
 # npm-scope = "@plumb"
 
 [dist.github-custom-runners]

--- a/docs/src/ci/release-prep.md
+++ b/docs/src/ci/release-prep.md
@@ -41,3 +41,44 @@ Current blockers this repo does not solve:
 Until those blockers are resolved, the install docs describe the
 Homebrew command shape, but this repo MUST NOT claim `brew install`
 verification.
+
+## npm activation for `@plumb/cli`
+
+Issue #52 is also prep-only in this repo state. The release workflow and
+`dist-workspace.toml` may validate the cargo-dist config shape, but they
+do not enable npm publishing yet.
+
+Before anyone uncomments the `npm-scope` setting in
+`dist-workspace.toml`, these prerequisites MUST exist:
+
+1. The `@plumb` npm scope.
+2. Ownership or publish access for the `@plumb/cli` package under the
+   release identity used by this repo.
+3. The `NPM_TOKEN` secret and any required repo or environment
+   permissions for release publishing.
+
+Activation steps, once the external prerequisites exist:
+
+1. Confirm `cargo dist plan` still passes with the current repo state.
+2. Verify the commented config shape still matches the intended package
+   name: `npm-scope = "@plumb"` targets `@plumb/cli` for this binary.
+3. Add `npm` to the `installers` list when enabling npm publishing.
+   In cargo-dist 0.28.0, uncommenting `npm-scope` alone does not emit
+   npm artifacts.
+4. Add the `NPM_TOKEN` secret and any required GitHub repo or
+   environment permissions for cargo-dist publishing.
+5. Uncomment `npm-scope = "@plumb"` in `dist-workspace.toml`.
+6. Run `cargo dist plan` again and review the generated manifest for npm
+   installer entries before tagging a release.
+7. Publish from a controlled release tag and verify the live install on
+   macOS, Linux, and Windows before updating docs or acceptance claims.
+
+Current blockers this repo does not solve:
+
+- The `@plumb` npm scope may not exist yet.
+- Ownership of `@plumb/cli` is external to this repo.
+- `NPM_TOKEN` and the required repo or environment permissions are
+  external to this repo.
+
+Until those blockers are resolved, this repo MUST NOT claim that
+`npm i -g @plumb/cli` has been verified.


### PR DESCRIPTION
## Spec

Refs #52

## Summary

- documents the prep-only npm activation contract in `dist-workspace.toml`, including external ownership, token, and live-verification prerequisites without uncommenting `npm-scope`
- expands the release workflow warning and `docs/src/ci/release-prep.md` so future `@plumb/cli` activation calls out the required `npm` installer toggle, `NPM_TOKEN`, repo or environment permissions, and external npm ownership blockers
- records the current cargo-dist 0.28.0 validation result: `dist plan` passes today, and an isolated dry run shows `npm-scope` alone does not emit npm artifacts while `installers = ["shell", "powershell"]` remains unchanged

## Test plan

- [x] `just check` passes (fmt + clippy, no warnings)
- [ ] `just test` passes on my machine
- [ ] `just determinism-check` passes
- [ ] `cargo deny check` passes
- [x] New tests added (or reason-not given)
- [x] Docs updated (`docs/src/**`, rustdoc, CHANGELOG if user-visible)
- [x] Humanizer skill run on any `docs/src/**` prose

Reason not given for new tests: this is a prep-only docs/config comment change with no behavior change in Rust code.

`just test` is blocked in this environment because `plumb-cdp` integration tests require a local Chrome/Chromium binary in the supported range.

## Screenshots / terminal output

- `dist --version` -> `cargo-dist 0.28.0`
- `dist plan --output-format=json` passes in the tracked repo state
- isolated temp-copy dry run with `npm-scope = "@plumb"` uncommented still emits no npm artifacts on cargo-dist 0.28.0 until `npm` is also added to `installers`
- `just doc` passes for Rust docs; `mdbook` is not installed locally so the book build is skipped by the recipe

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- this PR intentionally does not uncomment `npm-scope`, add `npm` to `installers`, configure `NPM_TOKEN`, or claim `npm i -g @plumb/cli` verification
- external blockers remain unsolved here: npm `@plumb` org or package ownership, `NPM_TOKEN`, and repo or environment permissions for publishing
