### PR TITLE
ci: guard install-smoke shell expressions

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -39,11 +39,14 @@ jobs:
         id: tag
         env:
           GH_TOKEN: ${{ github.token }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            tag="${{ github.ref_name }}"
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            tag="$REF_NAME"
           else
-            tag="$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName 2>/dev/null || true)"
+            tag="$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null || true)"
           fi
           if [[ -z "$tag" ]]; then
             echo "::warning::No release tag found — skipping smoke tests."
@@ -109,8 +112,10 @@ jobs:
     steps:
       - name: Skip gated channel
         if: matrix.gated
+        env:
+          CHANNEL: ${{ matrix.channel }}
         run: |
-          echo "::notice::${{ matrix.channel }} is gated — external prerequisites not yet available. Skipping."
+          echo "::notice::$CHANNEL is gated — external prerequisites not yet available. Skipping."
           exit 0
 
       # ── cargo install ─────────────────────────────────────────
@@ -118,8 +123,10 @@ jobs:
         if: "!matrix.gated && matrix.channel == 'cargo'"
         timeout-minutes: 45
         shell: bash
+        env:
+          VERSION: ${{ needs.resolve-tag.outputs.version }}
         run: |
-          cargo install plumb-cli --version "${{ needs.resolve-tag.outputs.version }}" --locked
+          cargo install plumb-cli --version "$VERSION" --locked
 
       # ── curl / install script ─────────────────────────────────
       - name: Install via curl (unix)
@@ -190,59 +197,126 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Assert report scripts use env indirection
+      - name: Assert shell runs use env indirection
         shell: bash
         run: |
           python3 - <<'PY'
           from pathlib import Path
-          import re
           import sys
 
-          lines = Path(".github/workflows/install-smoke.yml").read_text().splitlines()
-          direct_expr = re.compile(r"\$\{\{\s*(github\.|needs\.resolve-tag\.)")
+          workflow_path = Path(".github/workflows/install-smoke.yml")
+          lines = workflow_path.read_text().splitlines()
 
-          in_report = False
+          expr_open = "$" + "{{"
+          supported_run_markers = {"|", "|-", "|+"}
+
+          in_jobs = False
+          current_job = None
+          in_steps = False
           current_step = None
           in_run = False
           run_indent = None
           bad_lines = []
+          unsupported = []
+
+          def step_label(step_name: str | None) -> str:
+              return step_name or "<unnamed step>"
 
           for lineno, line in enumerate(lines, start=1):
               stripped = line.lstrip()
               indent = len(line) - len(stripped)
 
-              if indent == 2 and stripped.endswith(":"):
-                  in_report = stripped == "report:"
+              if not stripped or stripped.startswith("#"):
+                  continue
+
+              if in_run:
+                  if indent > run_indent:
+                      if expr_open in line:
+                          bad_lines.append((lineno, current_job, step_label(current_step), line.strip()))
+                      continue
+                  in_run = False
+                  run_indent = None
+
+              if indent == 0 and stripped == "jobs:":
+                  in_jobs = True
+                  current_job = None
+                  in_steps = False
                   current_step = None
-                  in_run = False
-                  run_indent = None
                   continue
 
-              if not in_report:
+              if indent == 0 and in_jobs:
+                  in_jobs = False
+                  current_job = None
+                  in_steps = False
+                  current_step = None
+
+              if not in_jobs:
                   continue
 
-              if indent == 6 and stripped.startswith("- name:"):
-                  current_step = stripped[len("- name:"):].strip()
-                  in_run = False
-                  run_indent = None
+              if indent == 2 and stripped.endswith(":"):
+                  current_job = stripped[:-1]
+                  in_steps = False
+                  current_step = None
+                  continue
+
+              if indent == 4 and stripped == "steps:":
+                  in_steps = True
+                  current_step = None
+                  continue
+
+              if indent <= 4 and stripped != "steps:":
+                  in_steps = False
+                  current_step = None
+
+              if not in_steps:
+                  continue
+
+              if indent == 6 and stripped.startswith("- "):
+                  current_step = None
+                  if stripped.startswith("- name:"):
+                      current_step = stripped[len("- name:"):].strip()
+                      continue
+                  if stripped.startswith("- uses:"):
+                      current_step = f"uses {stripped[len('- uses:'):].strip()}"
+                      continue
+                  if stripped.startswith("- run:"):
+                      unsupported.append(
+                          (lineno, current_job, step_label(current_step), "inline list-item run syntax is unsupported")
+                      )
+                      continue
+
+              if indent == 8 and stripped.startswith("name:"):
+                  current_step = stripped[len("name:"):].strip()
                   continue
 
               if indent == 8 and stripped.startswith("run:"):
+                  marker = stripped[len("run:"):].strip()
+                  if marker not in supported_run_markers:
+                      unsupported.append(
+                          (
+                              lineno,
+                              current_job,
+                              step_label(current_step),
+                              f"unsupported run syntax: {stripped}",
+                          )
+                      )
+                      continue
                   in_run = True
                   run_indent = indent
                   continue
 
-              if in_run:
-                  if stripped and indent <= run_indent:
-                      in_run = False
-                      run_indent = None
-                  elif direct_expr.search(line):
-                      bad_lines.append((lineno, current_step or "<unknown>", line.strip()))
+          if in_run:
+              in_run = False
 
-          if bad_lines:
-              for lineno, step_name, content in bad_lines:
+          if unsupported or bad_lines:
+              for lineno, job_name, step_name, message in unsupported:
                   print(
-                      f"{lineno}: report step {step_name!r} contains direct workflow interpolation: {content}",
+                      f"{workflow_path}:{lineno}: job {job_name!r} step {step_name!r}: {message}",
+                      file=sys.stderr,
+                  )
+              for lineno, job_name, step_name, content in bad_lines:
+                  print(
+                      f"{workflow_path}:{lineno}: job {job_name!r} step {step_name!r} contains direct workflow interpolation: {content}",
                       file=sys.stderr,
                   )
               sys.exit(1)


### PR DESCRIPTION
## Spec

Fixes #171

## Summary

- hoisted the remaining shell-consumed workflow expressions in `install-smoke.yml` into `env:` and switched the `resolve-tag`, gated skip, and cargo install shell bodies to quoted environment variables
- replaced the report-only interpolation assertion with a stdlib Python scanner that walks every job step `run:` block, rejects unsupported `run:` forms, and fails on direct workflow interpolation inside shell bodies
- preserved the existing smoke matrix, channel gating, installer URLs, tag resolution outputs, installer verification, and tracking-issue report behavior

## Test plan

- [ ] `just check` passes (fmt + clippy, no warnings)
- [ ] `just test` passes on my machine
- [ ] `just determinism-check` passes
- [ ] `cargo deny check` passes
- [x] New tests added (or reason-not given)
- [ ] Docs updated (`docs/src/**`, rustdoc, CHANGELOG if user-visible)
- [ ] Humanizer skill run on any `docs/src/**` prose

Validation run locally:
- `python3` scanner against `.github/workflows/install-smoke.yml` passed
- `git diff --check` passed
- full YAML parse could not be run locally because neither `ruby` nor `PyYAML` is available in this environment
- `just validate` could not be run locally because `just` is not installed in this environment

## Screenshots / terminal output

Not applicable.

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- checkout SHA pinning remains intentionally out of scope for this issue
- the remote branch was published via the GitHub app because local `git push` in this environment lacks GitHub HTTPS credentials