### PR TITLE
ci: document install-smoke scanner assumptions

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -207,7 +207,12 @@ jobs:
           workflow_path = Path(".github/workflows/install-smoke.yml")
           lines = workflow_path.read_text().splitlines()
 
+          # This is a small stdlib guard for this workflow, not a general
+          # YAML parser. It intentionally fail-closes on syntax it does not
+          # recognize instead of trying to accept every GitHub Actions form.
           expr_open = "$" + "{{"
+          # ubuntu-latest currently provides Python 3.10+, so `str | None`
+          # is valid here without importing Optional.
           supported_run_markers = {"|", "|-", "|+"}
 
           in_jobs = False
@@ -219,6 +224,9 @@ jobs:
           bad_lines = []
           unsupported = []
 
+          # The scanner assumes the repo-standard 2-space GitHub Actions
+          # indentation used in this file and block-scalar `run: |`,
+          # `run: |-`, and `run: |+` forms.
           def step_label(step_name: str | None) -> str:
               return step_name or "<unnamed step>"
 


### PR DESCRIPTION
## Target branch

> All PRs target `main`. Plumb has no `dev` branch.

- [x] This PR targets `main`

## Spec

Fixes #173

## Summary

- Document the install-smoke scanner as a narrow stdlib guard rather than a general YAML parser.
- Note that `ubuntu-latest` provides Python 3.10+, so the existing `str | None` annotation is intentional.
- Record the expected 2-space GitHub Actions indentation and supported `run: |`, `run: |-`, and `run: |+` block forms.

## Crates touched

- [x] `.github/`

## System impact

- [ ] New public API item (needs doc + `# Errors` section if fallible)
- [ ] New MCP tool (needs `tools/list` entry + protocol test)
- [ ] New rule (needs docs page + golden test + `register_builtin` entry)
- [ ] CDP / browser surface change (needs security-auditor review)
- [ ] Config schema change (run `cargo xtask schema` + commit result)
- [ ] Dependency added / bumped (cargo-deny must still pass)
- [ ] Determinism invariant touched (see `.agents/rules/determinism.md`)

## Architectural compliance

- [x] Layer discipline: not applicable to this workflow-comment change.
- [x] Error shape: unchanged.
- [x] No new `unwrap`/`expect`/`panic!` in library crates.
- [x] No new `SystemTime::now` / `Instant::now` in `plumb-core`.
- [x] No new `HashMap` in observable output paths (use `IndexMap`).
- [x] Every `#[allow(...)]` is local and has a one-line rationale.

## Test plan

- [ ] `just validate` passes locally
- [ ] `cargo xtask pre-release` passes (if rule or schema changed)
- [ ] `just determinism-check` passes (3× byte-diff clean)
- [ ] `cargo deny check` passes
- [x] New/changed behavior has a test (unit, golden snapshot, or integration)

Validation run for this scoped change:
- Executed the embedded `Assert shell runs use env indirection` Python scanner against `.github/workflows/install-smoke.yml`.
- Ran `git diff --check`.
- Attempted YAML parse via PyYAML; PyYAML was not installed in this environment, so that parse was skipped.
- Confirmed the diff is limited to `.github/workflows/install-smoke.yml` and adds comments only.

## Documentation

- [ ] Rustdoc added for every new public item
- [ ] `# Errors` section on every new public fallible fn
- [ ] `docs/src/` updated when user-visible behavior changed
- [ ] `docs/src/rules/<category>-<id>.md` written for new rules
- [ ] CHANGELOG updated if user-visible (otherwise release-please handles it)
- [ ] Humanizer skill run on docs changes

## Breaking change?

- [x] No
- [ ] Yes — describe migration path

## Checklist

- [x] Conventional Commits title
- [ ] Branch name: `codex/<primary>-<type>-<slug>`
- [x] All review gates passed: spec → quality → architecture → test (+ security if triggered)
- [ ] `/gh-review --local-diff main...HEAD` run locally

## Reviewer notes

This PR is intentionally comments-only and preserves the scanner logic and fail-closed behavior exactly.
