### PR TITLE
test: add deployed dogfood lint workflow

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 5 * * *" # Daily, 05:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: dogfood-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,44 @@
+name: Dogfood
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # Daily, 05:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: dogfood-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint-plumb-dev:
+    name: plumb lint https://plumb.dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: stable
+          install-dependencies: true
+
+      - name: Build plumb
+        run: cargo build --release -p plumb-cli
+
+      - name: Lint deployed docs
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          target/release/plumb lint https://plumb.dev \
+            --executable-path "$CHROME_PATH"


### PR DESCRIPTION
## Spec

Fixes #60.

## Summary

- Add a daily and manual `dogfood` workflow that builds `plumb` and runs `plumb lint https://plumb.dev`.
- Install Chrome explicitly in the job and pass its path to `plumb` so the deployed lint does not depend on runner-image browser defaults.
- Keep the change workflow-only; no rule, fixture, or runtime behavior changes.

## Test plan

- [ ] `just check` passes (fmt + clippy, no warnings)
- [ ] `just test` passes on my machine
- [ ] `just determinism-check` passes
- [ ] `cargo deny check` passes
- [ ] New tests added (or reason-not given)
- [ ] Docs updated (`docs/src/**`, rustdoc, CHANGELOG if user-visible)
- [ ] Humanizer skill run on any `docs/src/**` prose

Reason-not / results:
- No new tests added: scope is a GitHub Actions workflow only.
- `cargo build --release -p plumb-cli` passed locally.
- `target/release/plumb lint https://plumb.dev` failed locally with `Chromium executable not found...` because this host has no supported Chrome/Chromium binary installed.
- `git diff --check` passed.
- `actionlint` was not available on this host.
- `scripts/check-phase3-gate-env.sh` could not complete here because local Python dev dependencies `PyYAML` and `jsonschema` are not installed.

## Screenshots / terminal output

- `cargo build --release -p plumb-cli` → finished successfully.
- `target/release/plumb lint https://plumb.dev` → exit 2: `Chromium executable not found. Install Chrome/Chromium between major 131 and 150 (inclusive), or pass --executable-path <path> to a Chromium binary in that range that auto-detect missed.`

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- The workflow intentionally fails on any nonzero exit from `plumb lint`, including real violations and browser/bootstrap failures.
- If deployed dogfood starts surfacing false positives later, the next change should add a `plumb-core` snapshot repro before any rule-tolerance adjustment.
