### PR TITLE
perf(cdp): add benchmark harness report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +390,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +505,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +564,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -892,6 +973,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1009,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "html5ever"
@@ -1205,6 +1303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1324,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1407,6 +1525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,10 +1677,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "plumb-cdp"
 version = "0.0.1"
 dependencies = [
  "chromiumoxide",
+ "criterion",
  "futures-util",
  "indexmap",
  "plumb-core",
@@ -2032,6 +2185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +3018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +3178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -38,6 +38,11 @@ tokio = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "cdp_benchmarks"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/plumb-cdp/benches/cdp_benchmarks.rs
+++ b/crates/plumb-cdp/benches/cdp_benchmarks.rs
@@ -1,0 +1,232 @@
+//! Criterion benchmarks for the Plumb CDP pipeline.
+//!
+//! ## Benchmark groups
+//!
+//! | Group              | What it measures                                     | Chromium? |
+//! |--------------------|------------------------------------------------------|-----------|
+//! | `per_rule_dom`     | Rule-engine cost on 100 / 1 000 / 10 000 node DOMs  | No        |
+//! | `cold_start`       | Launch Chromium + first snapshot                     | Yes       |
+//! | `warm_run`         | Subsequent snapshot on a reused browser               | Yes       |
+//!
+//! ## Running locally
+//!
+//! ```sh
+//! # Rule-engine benchmarks only (no Chromium required):
+//! cargo bench -p plumb-cdp
+//!
+//! # Full suite including CDP cold-start / warm-run (requires Chromium):
+//! cargo bench -p plumb-cdp --features e2e-chromium
+//! ```
+
+// Benchmarks are standalone binaries; relax workspace lint strictness that
+// is impractical outside library code.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::wildcard_imports,
+    unreachable_pub,
+    missing_docs
+)]
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use indexmap::IndexMap;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, Rect, ViewportKey};
+
+// ---------------------------------------------------------------------------
+// Synthetic snapshot builder
+// ---------------------------------------------------------------------------
+
+/// Build a `PlumbSnapshot` with `n` leaf `<div>` nodes under `<html><body>`.
+///
+/// Every node gets realistic computed styles so rules have work to do:
+/// - `padding-top` / `margin-bottom` set to values deliberately off the
+///   default 4 px spacing grid so `spacing/grid-conformance` fires.
+/// - `font-size` set to `15px` (off the default type scale).
+/// - A bounding `Rect` sized for a 1 280 × 800 viewport.
+fn synthetic_snapshot(n: usize) -> PlumbSnapshot {
+    let child_orders: Vec<u64> = (2..2 + n as u64).collect();
+
+    let mut nodes = Vec::with_capacity(n + 2);
+
+    // <html> root
+    nodes.push(SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: None,
+        children: vec![1],
+    });
+
+    // <body>
+    nodes.push(SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: Some(0),
+        children: child_orders,
+    });
+
+    // Leaf <div> nodes
+    for i in 0..n {
+        let dom_order = 2 + i as u64;
+        let mut styles = IndexMap::new();
+        // Off-grid spacing to exercise spacing rules.
+        styles.insert("padding-top".into(), "13px".into());
+        styles.insert("margin-bottom".into(), "7px".into());
+        // Off-scale font size to exercise type rules.
+        styles.insert("font-size".into(), "15px".into());
+        styles.insert("line-height".into(), "20px".into());
+        styles.insert("display".into(), "block".into());
+        styles.insert("color".into(), "rgb(51, 51, 51)".into());
+        styles.insert("background-color".into(), "rgb(255, 255, 255)".into());
+
+        #[allow(clippy::cast_possible_truncation)]
+        let row = (i / 3) as u32;
+        #[allow(clippy::cast_possible_truncation)]
+        let col = (i % 3) as u32;
+        let card_w: u32 = 400;
+        let card_h: u32 = 120;
+
+        nodes.push(SnapshotNode {
+            dom_order,
+            selector: format!("html > body > div:nth-child({})", i + 1),
+            tag: "div".into(),
+            attrs: IndexMap::new(),
+            computed_styles: styles,
+            rect: Some(Rect {
+                #[allow(clippy::cast_possible_wrap)]
+                x: (col * card_w) as i32,
+                #[allow(clippy::cast_possible_wrap)]
+                y: (row * card_h) as i32,
+                width: card_w,
+                height: card_h,
+            }),
+            parent: Some(1),
+            children: Vec::new(),
+        });
+    }
+
+    PlumbSnapshot {
+        url: format!("plumb-fake://bench-{n}"),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// per_rule_dom — rule-engine cost on varying DOM sizes
+// ---------------------------------------------------------------------------
+
+fn per_rule_dom(c: &mut Criterion) {
+    let config = Config::default();
+    let mut group = c.benchmark_group("per_rule_dom");
+
+    for &size in &[100_usize, 1_000, 10_000] {
+        let snapshot = synthetic_snapshot(size);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &snapshot, |b, snap| {
+            b.iter(|| plumb_core::run(snap, &config));
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// CDP benchmarks — require a real Chromium binary (e2e-chromium feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "e2e-chromium")]
+mod cdp {
+    use super::*;
+    use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, PersistentBrowser, Target};
+    use std::path::PathBuf;
+    use tokio::runtime::Runtime;
+
+    /// Build a [`Target`] pointing at a local bench fixture HTML file.
+    fn fixture_target(name: &str) -> Target {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("benches/fixtures")
+            .join(name);
+        Target {
+            url: format!("file://{}", path.display()),
+            viewport: ViewportKey::new("desktop"),
+            width: 1280,
+            height: 800,
+            device_pixel_ratio: 1.0,
+        }
+    }
+
+    /// cold_start: construct a fresh `ChromiumDriver`, snapshot one page
+    /// (which launches and tears down the browser each call).
+    pub fn cold_start(c: &mut Criterion) {
+        let rt = Runtime::new().unwrap();
+        let target = fixture_target("fixed-dom-1k-nodes.html");
+
+        c.bench_function("cold_start", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let driver = ChromiumDriver::new(ChromiumOptions::default());
+                    let _snap = driver.snapshot(target.clone()).await.expect("snapshot");
+                });
+            });
+        });
+    }
+
+    /// warm_run: reuse a `PersistentBrowser` for subsequent snapshots.
+    pub fn warm_run(c: &mut Criterion) {
+        let rt = Runtime::new().unwrap();
+        let target = fixture_target("fixed-dom-1k-nodes.html");
+
+        let browser = rt
+            .block_on(PersistentBrowser::launch(ChromiumOptions::default()))
+            .expect("Chromium launch");
+
+        c.bench_function("warm_run", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _snap = browser.snapshot(target.clone()).await.expect("snapshot");
+                });
+            });
+        });
+
+        rt.block_on(browser.shutdown()).expect("shutdown");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Group registration
+// ---------------------------------------------------------------------------
+
+// Always register per_rule_dom (pure, no Chromium needed).
+#[cfg(not(feature = "e2e-chromium"))]
+criterion_group!(benches, per_rule_dom);
+
+// With Chromium available, register the full suite.
+#[cfg(feature = "e2e-chromium")]
+criterion_group!(benches, per_rule_dom, cdp::cold_start, cdp::warm_run);
+
+criterion_main!(benches);

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -36,6 +36,10 @@
 - [spacing/scale-conformance](./rules/spacing-scale-conformance.md)
 - [type/scale-conformance](./rules/type-scale-conformance.md)
 
+# Performance
+
+- [Benchmarks](./performance.md)
+
 # Contributing
 
 - [Architecture decision records](./adr.md)

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -1,0 +1,60 @@
+# Performance
+
+Plumb ships a [Criterion](https://bheisler.github.io/criterion.rs/book/) benchmark suite in `crates/plumb-cdp/benches/`.
+Use it to measure rule-engine throughput and CDP snapshot latency on your own hardware.
+
+## Benchmark groups
+
+| Group | What it measures | Chromium required? |
+|---|---|---|
+| `per_rule_dom` | Rule-engine cost on 100, 1 000, and 10 000 node synthetic DOMs | No |
+| `cold_start` | Launch Chromium and take a first snapshot | Yes |
+| `warm_run` | Subsequent snapshot on a reused browser | Yes |
+
+## Running benchmarks
+
+```sh
+# Rule-engine benchmarks only (no Chromium needed):
+just bench
+
+# Full suite including CDP cold-start / warm-run:
+just bench-full
+```
+
+Or with `cargo` directly:
+
+```sh
+cargo bench -p plumb-cdp                          # per_rule_dom only
+cargo bench -p plumb-cdp --features e2e-chromium  # full suite
+```
+
+Criterion writes HTML reports to `target/criterion/`. Open `target/criterion/report/index.html` to browse results.
+
+## Fixtures
+
+The benchmark uses fixed DOM fixtures from `crates/plumb-cdp/benches/fixtures/`:
+
+- `fixed-dom-100-nodes.html` — 100 leaf nodes
+- `fixed-dom-1k-nodes.html` — 1 000 leaf nodes
+- `fixed-dom-10k-nodes.html` — 10 000 leaf nodes
+
+These are static HTML files with deterministic structure so that benchmark variance reflects engine changes, not fixture drift.
+The `per_rule_dom` group builds equivalent DOMs synthetically in code rather than loading the HTML fixtures through Chromium.
+
+## Interpreting results
+
+Criterion reports the mean, median, standard deviation, and confidence intervals for each benchmark.
+A statistically significant regression appears as a red entry in the HTML report.
+
+To compare against a baseline:
+
+```sh
+cargo bench -p plumb-cdp -- --save-baseline before
+# ... make changes ...
+cargo bench -p plumb-cdp -- --baseline before
+```
+
+## CI
+
+The benchmark harness is not part of the default CI pipeline.
+There is no automated threshold gate; regressions are caught by running benchmarks locally before and after a change.

--- a/justfile
+++ b/justfile
@@ -122,6 +122,14 @@ determinism-check:
     @diff -q /tmp/plumb-det-2.json /tmp/plumb-det-3.json
     @echo "▸ OK — all three runs produced byte-identical output."
 
+# Run per_rule_dom benchmarks (no Chromium required).
+bench:
+    cargo bench -p plumb-cdp
+
+# Run full benchmark suite including CDP cold-start / warm-run (requires Chromium).
+bench-full:
+    cargo bench -p plumb-cdp --features e2e-chromium
+
 # Size guard: stripped release binary must stay under 25 MiB.
 size-guard:
     cargo build --release -p plumb-cli


### PR DESCRIPTION
## Summary

- Add Criterion benchmark suite (`crates/plumb-cdp/benches/cdp_benchmarks.rs`) with three groups: `per_rule_dom` (100/1k/10k node synthetic DOMs), `cold_start`, and `warm_run` (CDP benchmarks behind `e2e-chromium` feature gate)
- Wire `just bench` and `just bench-full` targets in the Justfile
- Add `docs/src/performance.md` with benchmark usage, fixture descriptions, and result interpretation guidance

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p plumb-cdp --benches -- -D warnings` — clean
- `cargo bench -p plumb-cdp --no-run` — compiles successfully
- `git diff --check` — no whitespace issues
- CDP benchmarks (`cold_start`, `warm_run`) require a real Chromium binary and are gated behind the `e2e-chromium` feature; they will not run in CI without Chromium installed

## Blockers

- No automated CI threshold gate (out of scope per #61)
- `cold_start` and `warm_run` benchmarks cannot execute without Chromium; the `per_rule_dom` group runs without it

Refs #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)