### PR TITLE
ci: add performance benchmark alerts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: benchmarks-${{ github.ref }}
-  cancel-in-progress: true
+  group: benchmarks-${{ github.sha }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,13 +27,16 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install Chromium
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-browser
-          echo "CHROME_PATH=$(which chromium-browser)" >> "$GITHUB_ENV"
+      - name: Install Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: stable
+          install-dependencies: true
 
       - name: Run full benchmark suite
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: cargo bench -p plumb-cdp --features e2e-chromium
 
       - name: Check p50 thresholds

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,6 @@
 name: Benchmarks
 
+# Post-merge monitoring only — not a pre-merge PR gate.
 on:
   push:
     branches: [main]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Performance benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Chromium
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+          echo "CHROME_PATH=$(which chromium-browser)" >> "$GITHUB_ENV"
+
+      - name: Run full benchmark suite
+        run: cargo bench -p plumb-cdp --features e2e-chromium
+
+      - name: Check p50 thresholds
+        run: bash scripts/bench-threshold-check.sh target/criterion
+
+      - name: Upload Criterion report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: criterion-report
+          path: target/criterion/
+          if-no-files-found: ignore

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -56,5 +56,20 @@ cargo bench -p plumb-cdp -- --baseline before
 
 ## CI
 
-The benchmark harness is not part of the default CI pipeline.
-There is no automated threshold gate; regressions are caught by running benchmarks locally before and after a change.
+A dedicated workflow (`.github/workflows/benchmarks.yml`) runs the full benchmark suite on every push to `main` and on manual dispatch.
+It installs system Chromium, runs `cargo bench -p plumb-cdp --features e2e-chromium`, then checks p50 (median) latency against hard thresholds:
+
+| Benchmark | p50 limit |
+|---|---|
+| `cold_start` | 2 000 ms |
+| `warm_run` | 500 ms |
+
+If either threshold is breached the job fails with an `::error::` annotation.
+Criterion HTML reports are uploaded as a build artifact on every run regardless of pass/fail.
+
+The threshold script lives at `scripts/bench-threshold-check.sh` and can be run locally:
+
+```sh
+cargo bench -p plumb-cdp --features e2e-chromium
+bash scripts/bench-threshold-check.sh
+```

--- a/scripts/bench-threshold-check.sh
+++ b/scripts/bench-threshold-check.sh
@@ -35,14 +35,14 @@ check_threshold() {
     local median_ns
     median_ns=$(python3 -c "
 import json, sys
-with open('$estimates_file') as f:
+with open(sys.argv[1]) as f:
     data = json.load(f)
 print(data['median']['point_estimate'])
-")
+" "$estimates_file")
 
     # Convert to integer for shell comparison.
     local median_int
-    median_int=$(python3 -c "print(int(float($median_ns)))")
+    median_int=$(python3 -c "import sys; print(int(float(sys.argv[1])))" "$median_ns")
 
     local limit_ms=$((limit_ns / 1000000))
     local median_ms=$((median_int / 1000000))
@@ -59,6 +59,10 @@ echo "=== Benchmark p50 threshold check ==="
 echo "Criterion dir: $CRITERION_DIR"
 echo ""
 
+# per_rule_dom has no threshold: it scales with DOM size and rule count,
+# so a fixed limit would be either too tight for 10k-node runs or too
+# loose for 100-node runs. Use Criterion's statistical change detection
+# for per_rule_dom regressions instead.
 check_threshold "cold_start" "$COLD_START_LIMIT_NS"
 check_threshold "warm_run" "$WARM_RUN_LIMIT_NS"
 

--- a/scripts/bench-threshold-check.sh
+++ b/scripts/bench-threshold-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# bench-threshold-check.sh — Parse Criterion JSON estimates and enforce p50
+# regression thresholds. Exits non-zero if any threshold is breached.
+#
+# Thresholds (nanoseconds):
+#   cold_start  p50 > 2 000 000 000  (2 s)
+#   warm_run    p50 >   500 000 000  (500 ms)
+#
+# Usage:
+#   ./scripts/bench-threshold-check.sh [criterion_base_dir]
+#
+# criterion_base_dir defaults to target/criterion.
+
+set -euo pipefail
+
+CRITERION_DIR="${1:-target/criterion}"
+
+# Thresholds in nanoseconds.
+COLD_START_LIMIT_NS=2000000000
+WARM_RUN_LIMIT_NS=500000000
+
+fail=0
+
+check_threshold() {
+    local name="$1"
+    local limit_ns="$2"
+    local estimates_file="$CRITERION_DIR/$name/new/estimates.json"
+
+    if [ ! -f "$estimates_file" ]; then
+        echo "::warning::$name estimates not found at $estimates_file (skipped)"
+        return
+    fi
+
+    # Extract median point_estimate (nanoseconds, floating point).
+    local median_ns
+    median_ns=$(python3 -c "
+import json, sys
+with open('$estimates_file') as f:
+    data = json.load(f)
+print(data['median']['point_estimate'])
+")
+
+    # Convert to integer for shell comparison.
+    local median_int
+    median_int=$(python3 -c "print(int(float($median_ns)))")
+
+    local limit_ms=$((limit_ns / 1000000))
+    local median_ms=$((median_int / 1000000))
+
+    echo "$name: p50 = ${median_ms} ms (limit: ${limit_ms} ms)"
+
+    if [ "$median_int" -gt "$limit_ns" ]; then
+        echo "::error::$name p50 regression: ${median_ms} ms exceeds ${limit_ms} ms threshold"
+        fail=1
+    fi
+}
+
+echo "=== Benchmark p50 threshold check ==="
+echo "Criterion dir: $CRITERION_DIR"
+echo ""
+
+check_threshold "cold_start" "$COLD_START_LIMIT_NS"
+check_threshold "warm_run" "$WARM_RUN_LIMIT_NS"
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+    echo "FAILED: one or more benchmarks exceeded p50 thresholds."
+    exit 1
+else
+    echo "PASSED: all benchmarks within thresholds."
+fi

--- a/scripts/bench-threshold-check.sh
+++ b/scripts/bench-threshold-check.sh
@@ -27,7 +27,8 @@ check_threshold() {
     local estimates_file="$CRITERION_DIR/$name/new/estimates.json"
 
     if [ ! -f "$estimates_file" ]; then
-        echo "::warning::$name estimates not found at $estimates_file (skipped)"
+        echo "::error::$name estimates not found at $estimates_file"
+        fail=1
         return
     fi
 

--- a/scripts/bench-threshold-check.sh
+++ b/scripts/bench-threshold-check.sh
@@ -21,6 +21,16 @@ WARM_RUN_LIMIT_NS=500000000
 
 fail=0
 
+# extract_median <estimates.json> → prints integer nanoseconds
+extract_median() {
+    python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(int(data['median']['point_estimate']))
+" "$1"
+}
+
 check_threshold() {
     local name="$1"
     local limit_ns="$2"
@@ -32,18 +42,8 @@ check_threshold() {
         return
     fi
 
-    # Extract median point_estimate (nanoseconds, floating point).
-    local median_ns
-    median_ns=$(python3 -c "
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-print(data['median']['point_estimate'])
-" "$estimates_file")
-
-    # Convert to integer for shell comparison.
     local median_int
-    median_int=$(python3 -c "import sys; print(int(float(sys.argv[1])))" "$median_ns")
+    median_int=$(extract_median "$estimates_file")
 
     local limit_ms=$((limit_ns / 1000000))
     local median_ms=$((median_int / 1000000))


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmarks.yml` — runs the full Criterion benchmark suite (including Chromium cold_start/warm_run) on pushes to `main` and on `workflow_dispatch`.
- Adds `scripts/bench-threshold-check.sh` — parses Criterion JSON estimates and fails if p50 exceeds thresholds: cold_start > 2 s, warm_run > 500 ms.
- Updates `docs/src/performance.md` CI section to document the new workflow and thresholds.

Refs #61

## Validation

- [x] Threshold script tested with passing fixture data (1520 ms / 310 ms → PASS)
- [x] Threshold script tested with failing fixture data (2450 ms → FAIL with `::error::` annotation)
- [x] Workflow YAML structurally validated
- [x] `git diff --check` clean (no whitespace issues)
- [x] No Rust code modified — fmt/clippy not applicable

**Note:** Live benchmark run requires Chromium, which is not available in this environment. The CI workflow installs `chromium-browser` via apt. The threshold script gracefully warns and skips if estimates files are missing.

## Test plan

- [ ] Verify `benchmarks.yml` workflow triggers on push to main
- [ ] Verify Chromium installs and benchmarks complete in CI
- [ ] Verify threshold check parses real Criterion output correctly
- [ ] Verify failure annotation appears in GitHub Actions UI when threshold breached

🤖 Generated with [Claude Code](https://claude.com/claude-code)