### PR TITLE
docs: add v0.6 launch post

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,6 +2,10 @@
 
 [Introduction](./introduction.md)
 
+# Blog
+
+- [Plumb v0.6 is here](./blog/launch-v0.6.md)
+
 # Getting started
 
 - [Install](./install.md)

--- a/docs/src/blog/launch-v0.6.md
+++ b/docs/src/blog/launch-v0.6.md
@@ -1,0 +1,82 @@
+# Plumb v0.6 is here
+
+Plumb now has a public docs site, a better place for release notes, and
+an open Discussions tab for questions, ideas, and field reports.
+
+If you want to see the project as it exists today, start with
+[plumb.aramhammoudeh.com](https://plumb.aramhammoudeh.com/). That is
+the current public docs URL. `plumb.dev` is not the canonical docs
+domain yet, so keep using the `aramhammoudeh.com` address for now.
+
+## What shipped in v0.6
+
+This release is about making Plumb easier to follow from the outside.
+The book is live, the roadmap issue is pinned, and GitHub Discussions is
+open.
+
+Plumb itself is still a deterministic design-system linter for rendered
+websites. It has two entry points:
+
+- `plumb lint <url>` for local runs and CI
+- `plumb mcp` for AI coding agents
+
+## Install status
+
+The install page in the book lists four channels:
+
+- install script
+- `cargo install`
+- Homebrew
+- build from source
+
+Today, the supported path is still build from source. The other channels
+are documented so the book does not need a rewrite on release day, but
+they do not replace the source build yet.
+
+If you want to try Plumb right now:
+
+```bash
+git clone https://github.com/aram-devdocs/plumb
+cd plumb
+just setup
+just build-release
+target/release/plumb --version
+target/release/plumb lint plumb-fake://hello
+```
+
+The full setup notes live on the [Install](../install.md) and
+[Quick start](../quickstart.md) pages.
+
+## Demo and docs
+
+The live docs site is the easiest demo at the moment:
+
+- [Docs home](https://plumb.aramhammoudeh.com/)
+- [Install](https://plumb.aramhammoudeh.com/install.html)
+- [Quick start](https://plumb.aramhammoudeh.com/quickstart.html)
+
+If you already have a local build, you can lint the live site directly:
+
+```bash
+plumb lint https://plumb.aramhammoudeh.com
+```
+
+## Join the discussion
+
+GitHub Discussions is now on for the repo:
+
+- [GitHub Discussions](https://github.com/aram-devdocs/plumb/discussions)
+- [Pinned roadmap issue](https://github.com/aram-devdocs/plumb/issues/56)
+
+Use Discussions for setup questions, rule ideas, workflow feedback, or
+examples from real sites. If you hit a concrete bug, open a GitHub
+issue instead.
+
+## Contact
+
+The best public contact point right now is GitHub:
+
+- start a thread in [Discussions](https://github.com/aram-devdocs/plumb/discussions)
+- file a bug in [Issues](https://github.com/aram-devdocs/plumb/issues)
+
+That keeps the conversation attached to the code and the roadmap.


### PR DESCRIPTION
Closes #64.

## Summary

- add a new mdBook launch post at `docs/src/blog/launch-v0.6.md`
- link the post from `docs/src/SUMMARY.md`
- keep the post plain Markdown with no remote embeds and no docs stack changes

## Repo settings already completed outside this PR

- GitHub Discussions enabled on `aram-devdocs/plumb`
- starter discussion categories are present
- roadmap issue `#56` is pinned

## Notes

- no `book.toml` or CNAME change in this PR
- `plumb.dev` currently resolves but returns HTTP 403, so the post keeps the current public docs URL at `https://plumb.aramhammoudeh.com/`

## Verification

- `rg -n -i "\b(delve|tapestry|landscape|leverage|robust|seamless|comprehensive|vibrant|streamline|streamlined|unleash|unlock|journey|elevate|in today's fast-paced|in the world of|dive in|dive into|in conclusion|it's important to note)\b" docs/src/blog/launch-v0.6.md docs/src/SUMMARY.md` -> no matches
- `rg -n "<(img|script|iframe|video)|!\[[^\]]*\]\(https?://|<https?://[^>]+\.(png|jpg|jpeg|gif|svg|webm|mp4)" docs/src/blog/launch-v0.6.md` -> no matches
- `git diff --check` -> pass
- `git diff --cached --check` -> pass
- `git status --short` -> clean after commit

## Environment blockers

- `just` is not installed in this environment, so `just validate` could not be run here
- `mdbook` is not installed in this environment, so a full mdBook build could not be run here
