### PR TITLE
docs: refresh landing page copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Changed
 
+- Docs landing page now frames Plumb around the rendered-UI gap, adds a
+  demo placeholder, and points readers to install, MCP, and CI entry
+  points.
 - Renamed `radius.allowed_px` to `radius.scale` for naming consistency with `spacing.scale` and `type.scale`. The old name is rejected; update any pre-existing `plumb.toml`.
 - `plumb-cdp` accepts a Chromium major-version range
   (`MIN_SUPPORTED_CHROMIUM_MAJOR..=MAX_SUPPORTED_CHROMIUM_MAJOR`,

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -37,8 +37,8 @@ runs. Determinism is a hard guarantee.
 
 ## Demo
 
-> Demo slot for Issue #63 Slice B: a short rendered-UI walkthrough will
-> land here once the checked-in asset is ready.
+> Demo slot: a short rendered-UI walkthrough will land here once the
+> checked-in asset is ready.
 
 Until then, the live docs are the easiest public target to lint:
 
@@ -65,8 +65,7 @@ Then continue with the docs for your workflow:
 ## Status
 
 Pre-alpha. The current public docs live at
-`https://plumb.aramhammoudeh.com/`. Canonical copy may refer to
-`plumb.dev`, but the root-domain deployment step is still pending.
+`https://plumb.aramhammoudeh.com/`.
 
 ## Next
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,12 +1,30 @@
 # Introduction
 
+Most UI bugs live in the rendered 90% that source linters never see.
+Spacing drift, off-scale type, near-miss alignment, and touch targets
+that almost pass all show up after the browser computes the page.
+
 Plumb is a deterministic design-system linter for rendered websites. It
 opens a page in a headless browser at multiple viewports, measures the
-computed DOM against a declared spec, and emits structured, pixel-precise
-violations that an AI coding agent can act on without guessing.
+computed DOM against a declared spec, and emits structured,
+pixel-precise violations that an AI coding agent can act on without
+guessing.
 
-Where ESLint checks source code, Plumb checks the output — the thing
-your users actually see.
+Where ESLint checks source code, Plumb checks the output your users
+actually get.
+
+## What Plumb is for
+
+Plumb fits the gap between source linting and screenshot diffing.
+
+- Source linters such as ESLint and stylelint catch problems in the code
+  you wrote.
+- Visual regression tools catch that a screenshot changed.
+- Plumb checks the computed DOM and tells you which design-system rule
+  broke, where it broke, and by how much.
+
+That makes it useful in CI, local debugging, and agent workflows where a
+machine-readable violation is more useful than a red screenshot.
 
 ## Two entry points
 
@@ -15,13 +33,40 @@ your users actually see.
   Cursor, Codex, Windsurf) via the Model Context Protocol.
 
 Both share the same rule engine. The outputs match byte-for-byte across
-runs — determinism is a hard guarantee, not a goal.
+runs. Determinism is a hard guarantee.
+
+## Demo
+
+> Demo slot for Issue #63 Slice B: a short rendered-UI walkthrough will
+> land here once the checked-in asset is ready.
+
+Until then, the live docs are the easiest public target to lint:
+
+```bash
+plumb lint https://plumb.aramhammoudeh.com
+```
+
+## Install and try it
+
+Start with the path that matches how you work:
+
+- [Install script](./install.md#install-script-macos--linux--windows)
+- [`cargo install`](./install.md#cargo)
+- [Homebrew](./install.md#homebrew)
+- [Build from source](./install.md#build-from-source)
+
+Then continue with the docs for your workflow:
+
+- [Quick start](./quickstart.md) for the first local run
+- [MCP server](./mcp.md) for agent setup
+- [GitHub Code Scanning](./ci/github-code-scanning.md) for SARIF in CI
+- [reviewdog](./ci/reviewdog.md) for PR feedback in CI
 
 ## Status
 
-Pre-alpha. The walking skeleton is in place; real rules land over the
-next several PRs. See the PRD in `docs/local/prd.md` for the full
-roadmap.
+Pre-alpha. The current public docs live at
+`https://plumb.aramhammoudeh.com/`. Canonical copy may refer to
+`plumb.dev`, but the root-domain deployment step is still pending.
 
 ## Next
 


### PR DESCRIPTION
## Summary
- refresh the docs landing page copy in `docs/src/introduction.md`
- add the 90%-UI problem framing, conservative competitor positioning, a demo placeholder, and install / MCP / CI CTA links
- keep this to Issue #63 Slice A only

## Scope
- Refs #63
- This PR delivers Slice A: copy and shell only.
- Demo asset and CTA click verification remain for Slice B (`issue-63b-demo-asset-cta-verification`).
- No `book.toml` or domain-root change is included here because `plumb.dev` root deployment is still blocked by HTTP 403.

## Verification
- `git diff --check`
- banned-phrase scan on touched docs: no matches for the docs/AGENTS blocked list
- remote embed scan on `docs/src/introduction.md`: no matches
- diff scope check: docs-only (`docs/src/introduction.md`) plus required user-visible `CHANGELOG.md` note
- `just` not installed in this environment
- `mdbook` not installed in this environment
- substitute checks run for CTA targets and section headings referenced by the new links
