### PR TITLE
docs: validate landing-page demo asset and CTAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,7 @@ dependencies = [
  "clap",
  "plumb-config",
  "plumb-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/xtask/AGENTS.md
+++ b/xtask/AGENTS.md
@@ -13,7 +13,8 @@ quoting. Not published. Invoked via the `cargo xtask` alias in
 - `schema` — emit the JSON Schema for `plumb.toml` to `schemas/plumb.toml.json`.
 - `sync-rules-index` — verify every `register_builtin` rule has a matching `docs/src/rules/<slug>.md`.
 - `validate-runbooks` — validate every `docs/runbooks/*.yaml` against `schemas/runbook-spec.json` (delegates to the Python generator's `--validate-only`).
-- `pre-release` — chains the above + schema-currency check.
+- `validate-landing-page` — verify the docs landing page uses checked-in demo assets, rejects remote embeds, and keeps install CTA targets valid.
+- `pre-release` — chains the above checks + schema-currency check.
 
 ## Non-negotiable invariants
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,5 +15,8 @@ plumb-core = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -464,9 +464,10 @@ fn markdown_anchor_slug(heading: &str) -> String {
 mod tests {
     use super::{
         collect_markdown_anchors, extract_html_sources, extract_markdown_links,
-        markdown_anchor_slug, validate_no_remote_embeds,
+        markdown_anchor_slug, validate_local_markdown_link, validate_no_remote_embeds,
     };
-    use std::path::Path;
+    use std::{fs, path::Path};
+    use tempfile::tempdir;
 
     #[test]
     fn heading_slug_matches_install_anchor_shape() {
@@ -549,5 +550,32 @@ mod tests {
 "#,
         )
         .expect("fenced examples must be ignored");
+    }
+
+    #[test]
+    fn validates_local_markdown_link_when_file_and_anchor_exist() {
+        let dir = tempdir().expect("tempdir");
+        let landing_page = dir.path().join("index.md");
+        let target = dir.path().join("install.md");
+
+        fs::write(&landing_page, "[Install](./install.md#cargo)\n").expect("write landing page");
+        fs::write(&target, "# Install\n## Cargo\n").expect("write target markdown");
+
+        validate_local_markdown_link(&landing_page, "./install.md#cargo")
+            .expect("existing file and anchor must pass");
+    }
+
+    #[test]
+    fn rejects_local_markdown_link_when_anchor_does_not_match() {
+        let dir = tempdir().expect("tempdir");
+        let landing_page = dir.path().join("index.md");
+        let target = dir.path().join("install.md");
+
+        fs::write(&landing_page, "[Install](./install.md#cargo)\n").expect("write landing page");
+        fs::write(&target, "# Install\n## Quick start\n").expect("write target markdown");
+
+        let err = validate_local_markdown_link(&landing_page, "./install.md#cargo")
+            .expect_err("anchor mismatch must fail");
+        assert!(err.to_string().contains("missing anchor `#cargo`"));
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -279,7 +279,17 @@ fn validate_landing_page() -> Result<()> {
 }
 
 fn validate_no_remote_embeds(path: &Path, src: &str) -> Result<()> {
+    let mut in_code_fence = false;
+
     for (index, raw_line) in src.lines().enumerate() {
+        if raw_line.trim_start().starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+
         let line = raw_line.trim();
         let has_embed_tag = ["<img", "<video", "<iframe", "<embed", "<object", "<source"]
             .iter()
@@ -374,8 +384,18 @@ fn extract_markdown_links(src: &str) -> Vec<String> {
 
 fn extract_html_sources(src: &str) -> Vec<String> {
     let mut sources = Vec::new();
+    let mut in_code_fence = false;
 
-    for line in src.lines() {
+    for raw_line in src.lines() {
+        if raw_line.trim_start().starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+
+        let line = raw_line;
         let mut rest = line;
         while let Some(start) = rest.find("src=") {
             let after = &rest[start + 4..];
@@ -482,6 +502,19 @@ mod tests {
     }
 
     #[test]
+    fn ignores_html_sources_inside_code_fences() {
+        let src = r#"
+```html
+<img src="ignored.svg" alt="ignored" />
+```
+
+<img src="demo-terminal.svg" alt="demo" />
+"#;
+        let sources = extract_html_sources(src);
+        assert_eq!(sources, vec!["demo-terminal.svg"]);
+    }
+
+    #[test]
     fn collects_heading_anchors_outside_code_fences() {
         let src = r"
 # Install
@@ -503,5 +536,18 @@ mod tests {
         )
         .expect_err("remote embeds must fail");
         assert!(err.to_string().contains("remote embed"));
+    }
+
+    #[test]
+    fn ignores_remote_embeds_inside_code_fences() {
+        validate_no_remote_embeds(
+            Path::new("docs/src/introduction.md"),
+            r#"
+```html
+<img src="https://example.com/demo.svg" alt="example" />
+```
+"#,
+        )
+        .expect("fenced examples must be ignored");
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,10 +45,23 @@ enum Cmd {
         #[arg(long, default_value = "docs/runbooks")]
         dir: PathBuf,
     },
+    /// Validate the docs landing page demo asset and CTA targets.
+    ValidateLandingPage,
     /// Pre-release sanity suite: schema up-to-date, rules-index in sync,
     /// every runbook spec valid.
     PreRelease,
 }
+
+const LANDING_PAGE_PATH: &str = "docs/src/introduction.md";
+const LANDING_DEMO_ASSET_PATH: &str = "docs/src/demo-terminal.svg";
+const LANDING_DEMO_LIMIT_BYTES: u64 = 2 * 1024 * 1024;
+const REQUIRED_DEMO_EMBED_SRCS: &[&str] = &["demo-terminal.svg"];
+const REQUIRED_INSTALL_CTA_LINKS: &[&str] = &[
+    "./install.md#install-script-macos--linux--windows",
+    "./install.md#cargo",
+    "./install.md#homebrew",
+    "./install.md#build-from-source",
+];
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -66,6 +79,7 @@ fn run(cli: Cli) -> Result<()> {
         Cmd::Schema { out } => emit_schema(&out),
         Cmd::SyncRulesIndex => sync_rules_index(),
         Cmd::ValidateRunbooks { dir } => validate_runbooks(&dir),
+        Cmd::ValidateLandingPage => validate_landing_page(),
         Cmd::PreRelease => pre_release(),
     }
 }
@@ -200,9 +214,294 @@ fn pre_release() -> Result<()> {
     // 2. Rules index in sync.
     sync_rules_index()?;
 
-    // 3. Runbook specs valid (skips cleanly if docs/runbooks/ doesn't exist yet).
+    // 3. Landing page demo asset + CTA targets valid.
+    validate_landing_page()?;
+
+    // 4. Runbook specs valid (skips cleanly if docs/runbooks/ doesn't exist yet).
     validate_runbooks(Path::new("docs/runbooks"))?;
 
     let _ = writeln!(std::io::stdout(), "▸ OK — pre-release gates green.");
     Ok(())
+}
+
+fn validate_landing_page() -> Result<()> {
+    let landing_page = Path::new(LANDING_PAGE_PATH);
+    let landing_src = std::fs::read_to_string(landing_page)
+        .with_context(|| format!("read {}", landing_page.display()))?;
+
+    let demo_asset = Path::new(LANDING_DEMO_ASSET_PATH);
+    if !demo_asset.exists() {
+        anyhow::bail!(
+            "landing page demo asset missing at {}; add a checked-in asset.",
+            demo_asset.display()
+        );
+    }
+
+    let demo_size = std::fs::metadata(demo_asset)
+        .with_context(|| format!("stat {}", demo_asset.display()))?
+        .len();
+    if demo_size > LANDING_DEMO_LIMIT_BYTES {
+        anyhow::bail!(
+            "landing page demo asset is {demo_size} bytes; limit is {LANDING_DEMO_LIMIT_BYTES} bytes."
+        );
+    }
+
+    validate_no_remote_embeds(landing_page, &landing_src)?;
+
+    let embed_sources = extract_html_sources(&landing_src);
+    for src in REQUIRED_DEMO_EMBED_SRCS {
+        if !embed_sources.iter().any(|candidate| candidate == src) {
+            anyhow::bail!("landing page is missing required demo embed source `{src}`.");
+        }
+    }
+    for src in &embed_sources {
+        validate_local_markdown_link(landing_page, src)?;
+    }
+
+    let links = extract_markdown_links(&landing_src);
+    for href in REQUIRED_INSTALL_CTA_LINKS {
+        if !links.iter().any(|link| link == href) {
+            anyhow::bail!("landing page is missing required install CTA link `{href}`.");
+        }
+    }
+
+    for href in &links {
+        validate_local_markdown_link(landing_page, href)?;
+    }
+
+    let _ = writeln!(
+        std::io::stdout(),
+        "▸ landing page valid: demo asset present ({} bytes), no remote embeds, {} local link(s) checked.",
+        demo_size,
+        links.len()
+    );
+    Ok(())
+}
+
+fn validate_no_remote_embeds(path: &Path, src: &str) -> Result<()> {
+    for (index, raw_line) in src.lines().enumerate() {
+        let line = raw_line.trim();
+        let has_embed_tag = ["<img", "<video", "<iframe", "<embed", "<object", "<source"]
+            .iter()
+            .any(|tag| line.contains(tag));
+        if has_embed_tag
+            && [
+                "src=\"http",
+                "src='http",
+                "data=\"http",
+                "data='http",
+                "poster=\"http",
+                "poster='http",
+            ]
+            .iter()
+            .any(|pattern| line.contains(pattern))
+        {
+            anyhow::bail!(
+                "{}:{} contains a remote embed; use checked-in docs assets only.",
+                path.display(),
+                index + 1
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_local_markdown_link(base_file: &Path, href: &str) -> Result<()> {
+    if href.starts_with("http://")
+        || href.starts_with("https://")
+        || href.starts_with("mailto:")
+        || href.starts_with('#')
+    {
+        return Ok(());
+    }
+
+    let (relative_target, anchor) = href
+        .split_once('#')
+        .map_or((href, None), |(path, anchor)| (path, Some(anchor)));
+    let target_path = base_file
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(relative_target);
+    if !target_path.exists() {
+        anyhow::bail!(
+            "landing page link `{href}` points to missing file `{}`.",
+            target_path.display()
+        );
+    }
+
+    if let Some(anchor) = anchor {
+        let target_src = std::fs::read_to_string(&target_path)
+            .with_context(|| format!("read {}", target_path.display()))?;
+        let anchors = collect_markdown_anchors(&target_src);
+        if !anchors.iter().any(|candidate| candidate == anchor) {
+            anyhow::bail!(
+                "landing page link `{href}` points to missing anchor `#{anchor}` in `{}`.",
+                target_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_markdown_links(src: &str) -> Vec<String> {
+    let mut links = Vec::new();
+    let mut in_code_fence = false;
+
+    for line in src.lines() {
+        if line.trim_start().starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+
+        let mut rest = line;
+        while let Some(start) = rest.find("](") {
+            let after = &rest[start + 2..];
+            if let Some(end) = after.find(')') {
+                links.push(after[..end].to_owned());
+                rest = &after[end + 1..];
+            } else {
+                break;
+            }
+        }
+    }
+
+    links
+}
+
+fn extract_html_sources(src: &str) -> Vec<String> {
+    let mut sources = Vec::new();
+
+    for line in src.lines() {
+        let mut rest = line;
+        while let Some(start) = rest.find("src=") {
+            let after = &rest[start + 4..];
+            let Some(quote) = after.chars().next() else {
+                break;
+            };
+            if quote != '"' && quote != '\'' {
+                rest = after;
+                continue;
+            }
+
+            let value_start = quote.len_utf8();
+            let value = &after[value_start..];
+            if let Some(end) = value.find(quote) {
+                sources.push(value[..end].to_owned());
+                rest = &value[end + quote.len_utf8()..];
+            } else {
+                break;
+            }
+        }
+    }
+
+    sources
+}
+
+fn collect_markdown_anchors(src: &str) -> Vec<String> {
+    let mut anchors = Vec::new();
+    let mut in_code_fence = false;
+
+    for line in src.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence || !trimmed.starts_with('#') {
+            continue;
+        }
+
+        let heading = trimmed.trim_start_matches('#').trim();
+        if !heading.is_empty() {
+            anchors.push(markdown_anchor_slug(heading));
+        }
+    }
+
+    anchors
+}
+
+fn markdown_anchor_slug(heading: &str) -> String {
+    heading
+        .chars()
+        .flat_map(char::to_lowercase)
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                Some(ch)
+            } else if ch.is_ascii_whitespace() || ch == '-' {
+                Some('-')
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        collect_markdown_anchors, extract_html_sources, extract_markdown_links,
+        markdown_anchor_slug, validate_no_remote_embeds,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn heading_slug_matches_install_anchor_shape() {
+        let slug = markdown_anchor_slug("Install script (macOS / Linux / Windows)");
+        assert_eq!(slug, "install-script-macos--linux--windows");
+    }
+
+    #[test]
+    fn extracts_markdown_links_outside_code_fences() {
+        let src = r"
+[Install](./install.md#cargo)
+
+```md
+[ignored](./ignored.md)
+```
+
+[Quick start](./quickstart.md)
+";
+        let links = extract_markdown_links(src);
+        assert_eq!(links, vec!["./install.md#cargo", "./quickstart.md"]);
+    }
+
+    #[test]
+    fn extracts_html_sources() {
+        let src = r#"
+<p align="center">
+  <img src="demo-terminal.svg" alt="demo" width="720" />
+  <source src='clip.webm' type="video/webm" />
+</p>
+"#;
+        let sources = extract_html_sources(src);
+        assert_eq!(sources, vec!["demo-terminal.svg", "clip.webm"]);
+    }
+
+    #[test]
+    fn collects_heading_anchors_outside_code_fences() {
+        let src = r"
+# Install
+## Cargo
+
+```md
+# Ignored
+```
+";
+        let anchors = collect_markdown_anchors(src);
+        assert_eq!(anchors, vec!["install", "cargo"]);
+    }
+
+    #[test]
+    fn rejects_remote_embeds() {
+        let err = validate_no_remote_embeds(
+            Path::new("docs/src/introduction.md"),
+            r#"<img src="https://example.com/demo.svg" alt="bad" />"#,
+        )
+        .expect_err("remote embeds must fail");
+        assert!(err.to_string().contains("remote embed"));
+    }
 }


### PR DESCRIPTION
## Spec

Fixes #63

## Summary

- rebase PR #185 onto `main` after #184 landed the public landing-page demo and CTA copy
- keep #185 focused on a deterministic `cargo xtask validate-landing-page` gate for the merged landing page
- validate the checked-in demo asset on `main`, reject remote embeds, verify the local HTML demo source, and verify the install CTA anchors resolve to local docs targets
- leave `book.toml`, domain, and CNAME unchanged; do not treat deployed-root acceptance as complete while `https://plumb.dev/` still returns HTTP 403

## Test plan

- [x] `cargo xtask validate-landing-page`
- [x] `cargo test -p xtask`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] CTA verification covered by the validator
- [x] No final diff under `docs/src/**`, so no humanizer/banned-phrase rerun was needed

## Notes for reviewers

- `main` already contains the public-facing landing-page asset and CTA copy from #184; this PR now changes only `xtask/src/main.rs`.
- The validator targets the merged landing page as it exists on `main` today, including `docs/src/demo-terminal.svg` and the current install CTA anchors.
- `https://plumb.dev/` still returns HTTP 403, so this PR does not claim deployed-root acceptance.

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path