### PR TITLE
ci: deploy mdBook to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: "latest"
+      - name: mdbook build
+        run: mdbook build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: book/
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/book.toml
+++ b/book.toml
@@ -12,8 +12,7 @@ create-missing = false
 edit-url-template = "https://github.com/aram-devdocs/plumb/edit/main/{path}"
 git-repository-url = "https://github.com/aram-devdocs/plumb"
 site-url = "/"
-# Uncomment once the domain is wired up.
-# cname = "plumb.aramhammoudeh.com"
+cname = "plumb.aramhammoudeh.com"
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pages.yml` — dedicated Pages deploy workflow triggered on `push` to `main` and `workflow_dispatch`. Uses `actions/upload-pages-artifact` + `actions/deploy-pages` with `contents: read`, `pages: write`, `id-token: write` permissions and a `pages` concurrency group.
- Uncomment `cname = "plumb.aramhammoudeh.com"` in `book.toml` so mdBook emits a `CNAME` file in `book/` for the custom domain.

Closes #186

## Validation

- [x] No `pull_request` trigger in pages workflow
- [x] `upload-pages-artifact` path is exactly `book/`
- [x] `git diff --check` clean
- [x] `cname` setting confirmed to emit `book/CNAME` per [mdBook docs](https://rust-lang.github.io/mdBook/format/configuration/renderers.html)
- [x] Permissions: `contents: read`, `pages: write`, `id-token: write`
- [x] Concurrency group `pages` with `cancel-in-progress: false`

## Test plan

- [ ] Merge to main and verify `github-pages` deployment succeeds
- [ ] Confirm `https://plumb.aramhammoudeh.com/` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)