### PR TITLE
ci: prepare Chrome sandbox for CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Prepare Chrome sandbox
+        run: sudo bash scripts/ci-chrome-sandbox.sh
+
       - name: Install Chrome
         id: setup-chrome
         uses: browser-actions/setup-chrome@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: check-agents-md
         run: bash scripts/check-agents-md.sh
+      - name: Validate Chrome sandbox CI wiring
+        run: bash tests/ci-chrome-sandbox-validate.sh
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -29,6 +29,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Prepare Chrome sandbox
+        run: sudo bash scripts/ci-chrome-sandbox.sh
+
       - name: Install Chrome
         id: setup-chrome
         uses: browser-actions/setup-chrome@v2

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ fmt:
     cargo fmt --all
 
 # All static checks — fmt + clippy with zero tolerance. Matches CI preflight.
-check: check-agents
+check: check-agents ci-chrome-sandbox-validate
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -57,6 +57,10 @@ check: check-agents
 # symlinks + no drift phrases).
 check-agents:
     bash scripts/check-agents-md.sh
+
+# Validate the Chrome sandbox CI guardrails and workflow wiring.
+ci-chrome-sandbox-validate:
+    bash tests/ci-chrome-sandbox-validate.sh
 
 # Verify the local environment required by the Phase 3 gate.
 phase3-gate-env:

--- a/scripts/ci-chrome-sandbox.sh
+++ b/scripts/ci-chrome-sandbox.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ci-chrome-sandbox.sh — Prepare the Chrome sandbox on Linux CI runners.
+#
+# GitHub-hosted ubuntu-latest runners run as root inside unprivileged
+# containers. Chrome's setuid sandbox refuses to start unless the kernel
+# allows unprivileged user namespaces. This script enables them via
+# sysctl (and adjusts the AppArmor restriction Ubuntu 24.04+ added)
+# so Chrome can use its namespace sandbox — no --no-sandbox needed.
+#
+# The script is idempotent: re-running it when namespaces are already
+# enabled is a no-op.
+#
+# Usage:
+#   sudo ./scripts/ci-chrome-sandbox.sh
+#
+# Exits non-zero with a diagnostic if:
+#   - Not running on Linux.
+#   - The sysctl write fails and namespaces remain disabled.
+
+set -euo pipefail
+
+# ── Linux gate ───────────────────────────────────────────────────────
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "ci-chrome-sandbox.sh: not Linux ($(uname -s)), skipping." >&2
+    exit 1
+fi
+
+# ── Unprivileged user namespaces ─────────────────────────────────────
+USERNS_SYSCTL="kernel.unprivileged_userns_clone"
+APPARMOR_USERNS="/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+
+enable_userns() {
+    # Some kernels (Debian/Ubuntu patched) expose the clone sysctl.
+    if [ -f "/proc/sys/kernel/$USERNS_SYSCTL" ]; then
+        current=$(cat "/proc/sys/kernel/$USERNS_SYSCTL")
+        if [ "$current" = "1" ]; then
+            echo "User namespaces already enabled ($USERNS_SYSCTL = 1)."
+        else
+            echo "Enabling $USERNS_SYSCTL ..."
+            sysctl -w "${USERNS_SYSCTL}=1" >/dev/null
+        fi
+    fi
+
+    # Ubuntu 24.04+ restricts unprivileged user namespaces via AppArmor.
+    if [ -f "$APPARMOR_USERNS" ]; then
+        current=$(cat "$APPARMOR_USERNS")
+        if [ "$current" = "0" ]; then
+            echo "AppArmor userns restriction already disabled."
+        else
+            echo "Disabling AppArmor unprivileged userns restriction ..."
+            echo 0 > "$APPARMOR_USERNS"
+        fi
+    fi
+}
+
+enable_userns
+
+# ── Verify ───────────────────────────────────────────────────────────
+# Best-effort verification: if the clone sysctl exists, confirm it is 1.
+if [ -f "/proc/sys/kernel/$USERNS_SYSCTL" ]; then
+    val=$(cat "/proc/sys/kernel/$USERNS_SYSCTL")
+    if [ "$val" != "1" ]; then
+        echo "::error::Failed to enable unprivileged user namespaces ($USERNS_SYSCTL = $val)." >&2
+        exit 1
+    fi
+fi
+
+if [ -f "$APPARMOR_USERNS" ]; then
+    val=$(cat "$APPARMOR_USERNS")
+    if [ "$val" != "0" ]; then
+        echo "::error::Failed to disable AppArmor userns restriction ($APPARMOR_USERNS = $val)." >&2
+        exit 1
+    fi
+fi
+
+echo "Chrome sandbox preparation complete."

--- a/scripts/ci-chrome-sandbox.sh
+++ b/scripts/ci-chrome-sandbox.sh
@@ -26,18 +26,19 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # ── Unprivileged user namespaces ─────────────────────────────────────
-USERNS_SYSCTL="kernel.unprivileged_userns_clone"
+USERNS_SYSCTL_KEY="kernel.unprivileged_userns_clone"
+USERNS_SYSCTL_PROCFS="/proc/sys/kernel/unprivileged_userns_clone"
 APPARMOR_USERNS="/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
 
 enable_userns() {
     # Some kernels (Debian/Ubuntu patched) expose the clone sysctl.
-    if [ -f "/proc/sys/kernel/$USERNS_SYSCTL" ]; then
-        current=$(cat "/proc/sys/kernel/$USERNS_SYSCTL")
+    if [ -f "$USERNS_SYSCTL_PROCFS" ]; then
+        current=$(cat "$USERNS_SYSCTL_PROCFS")
         if [ "$current" = "1" ]; then
-            echo "User namespaces already enabled ($USERNS_SYSCTL = 1)."
+            echo "User namespaces already enabled ($USERNS_SYSCTL_KEY = 1)."
         else
-            echo "Enabling $USERNS_SYSCTL ..."
-            sysctl -w "${USERNS_SYSCTL}=1" >/dev/null
+            echo "Enabling $USERNS_SYSCTL_KEY ..."
+            sysctl -w "${USERNS_SYSCTL_KEY}=1" >/dev/null
         fi
     fi
 
@@ -57,10 +58,10 @@ enable_userns
 
 # ── Verify ───────────────────────────────────────────────────────────
 # Best-effort verification: if the clone sysctl exists, confirm it is 1.
-if [ -f "/proc/sys/kernel/$USERNS_SYSCTL" ]; then
-    val=$(cat "/proc/sys/kernel/$USERNS_SYSCTL")
+if [ -f "$USERNS_SYSCTL_PROCFS" ]; then
+    val=$(cat "$USERNS_SYSCTL_PROCFS")
     if [ "$val" != "1" ]; then
-        echo "::error::Failed to enable unprivileged user namespaces ($USERNS_SYSCTL = $val)." >&2
+        echo "::error::Failed to enable unprivileged user namespaces ($USERNS_SYSCTL_KEY = $val)." >&2
         exit 1
     fi
 fi

--- a/tests/ci-chrome-sandbox-validate.sh
+++ b/tests/ci-chrome-sandbox-validate.sh
@@ -58,6 +58,25 @@ else
     fail "no idempotency pattern detected"
 fi
 
+echo "3a. Sysctl/procfs path split"
+if grep -q '^USERNS_SYSCTL_KEY="kernel\.unprivileged_userns_clone"$' "$SCRIPT" 2>/dev/null; then
+    pass "sysctl key uses dotted kernel name"
+else
+    fail "sysctl key is missing or does not use kernel.unprivileged_userns_clone"
+fi
+
+if grep -q '^USERNS_SYSCTL_PROCFS="/proc/sys/kernel/unprivileged_userns_clone"$' "$SCRIPT" 2>/dev/null; then
+    pass "procfs path resolves to /proc/sys/kernel/unprivileged_userns_clone"
+else
+    fail "procfs path is missing or incorrect"
+fi
+
+if grep -Eq '/proc/sys/kernel/kernel\.unprivileged_userns_clone|/proc/sys/kernel/\$USERNS_SYSCTL([[:space:]]|$|")' "$SCRIPT" 2>/dev/null; then
+    fail "double-prefixed procfs path construction detected"
+else
+    pass "no double-prefixed procfs path construction"
+fi
+
 # ── 4. Fail-loud ────────────────────────────────────────────────────
 echo "4. Fail-loud"
 if grep -q 'set -euo pipefail' "$SCRIPT" 2>/dev/null; then
@@ -70,6 +89,19 @@ if grep -q 'exit 1' "$SCRIPT" 2>/dev/null; then
     pass "explicit exit 1 on failure"
 else
     fail "no exit 1 found for failure paths"
+fi
+
+if grep -Eq 'if \[ -f "\$USERNS_SYSCTL_PROCFS" \]; then' "$SCRIPT" 2>/dev/null && \
+   grep -Eq 'val=\$\(cat "\$USERNS_SYSCTL_PROCFS"\)' "$SCRIPT" 2>/dev/null; then
+    pass "verification reads the required procfs path explicitly"
+else
+    fail "verification does not read USERNS_SYSCTL_PROCFS explicitly"
+fi
+
+if grep -Eq 'if \[ -f "\$USERNS_SYSCTL" \]; then|if \[ -f "/proc/sys/kernel/\$USERNS_SYSCTL" \]; then' "$SCRIPT" 2>/dev/null; then
+    fail "verification can silently skip by probing the wrong sysctl path"
+else
+    pass "verification does not probe the wrong sysctl path"
 fi
 
 # ── 5. Maintained gate integration ──────────────────────────────────

--- a/tests/ci-chrome-sandbox-validate.sh
+++ b/tests/ci-chrome-sandbox-validate.sh
@@ -7,13 +7,16 @@
 #   2. Script has a Linux guard (exits on non-Linux).
 #   3. Script is idempotent (checks before writing).
 #   4. Script fails loud (set -euo pipefail + exit 1 on verify failure).
-#   5. Both workflows invoke the script before Chrome steps.
-#   6. No --no-sandbox flag anywhere in the repo's workflow files.
+#   5. The validator is wired into maintained local + CI gates.
+#   6. Both Chrome workflows invoke the prep script before Chrome steps.
+#   7. No --no-sandbox flag anywhere in the repo's workflow files.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/ci-chrome-sandbox.sh"
+JUSTFILE="$REPO_ROOT/justfile"
+CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
 BENCHMARKS="$REPO_ROOT/.github/workflows/benchmarks.yml"
 DOGFOOD="$REPO_ROOT/.github/workflows/dogfood.yml"
 
@@ -69,8 +72,29 @@ else
     fail "no exit 1 found for failure paths"
 fi
 
-# ── 5. Workflow integration ─────────────────────────────────────────
-echo "5. Workflow integration"
+# ── 5. Maintained gate integration ──────────────────────────────────
+echo "5. Maintained gate integration"
+
+if grep -Eq '^ci-chrome-sandbox-validate:' "$JUSTFILE" 2>/dev/null; then
+    pass "justfile defines ci-chrome-sandbox-validate"
+else
+    fail "justfile does not define ci-chrome-sandbox-validate"
+fi
+
+if grep -Eq '^check:.*ci-chrome-sandbox-validate' "$JUSTFILE" 2>/dev/null; then
+    pass "just check depends on ci-chrome-sandbox-validate"
+else
+    fail "just check does not depend on ci-chrome-sandbox-validate"
+fi
+
+if grep -q 'tests/ci-chrome-sandbox-validate.sh' "$CI_WORKFLOW" 2>/dev/null; then
+    pass "ci.yml invokes tests/ci-chrome-sandbox-validate.sh"
+else
+    fail "ci.yml does not invoke tests/ci-chrome-sandbox-validate.sh"
+fi
+
+# ── 6. Workflow integration ─────────────────────────────────────────
+echo "6. Workflow integration"
 
 check_workflow_order() {
     local wf_file="$1"
@@ -97,8 +121,8 @@ check_workflow_order() {
 check_workflow_order "$BENCHMARKS" "benchmarks.yml"
 check_workflow_order "$DOGFOOD" "dogfood.yml"
 
-# ── 6. No --no-sandbox ─────────────────────────────────────────────
-echo "6. No --no-sandbox"
+# ── 7. No --no-sandbox ─────────────────────────────────────────────
+echo "7. No --no-sandbox"
 if grep -r -- '--no-sandbox' "$REPO_ROOT/.github/workflows/" 2>/dev/null; then
     fail "--no-sandbox found in workflow files"
 else

--- a/tests/ci-chrome-sandbox-validate.sh
+++ b/tests/ci-chrome-sandbox-validate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# ci-chrome-sandbox-validate.sh — Static validation for the Chrome sandbox
+# prep script and its workflow integration.
+#
+# Checks:
+#   1. Script exists and is executable.
+#   2. Script has a Linux guard (exits on non-Linux).
+#   3. Script is idempotent (checks before writing).
+#   4. Script fails loud (set -euo pipefail + exit 1 on verify failure).
+#   5. Both workflows invoke the script before Chrome steps.
+#   6. No --no-sandbox flag anywhere in the repo's workflow files.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ci-chrome-sandbox.sh"
+BENCHMARKS="$REPO_ROOT/.github/workflows/benchmarks.yml"
+DOGFOOD="$REPO_ROOT/.github/workflows/dogfood.yml"
+
+fail=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; fail=1; }
+
+echo "=== Chrome sandbox prep validation ==="
+echo ""
+
+# ── 1. Script exists and is executable ───────────────────────────────
+echo "1. Script exists and is executable"
+if [ -f "$SCRIPT" ]; then
+    pass "scripts/ci-chrome-sandbox.sh exists"
+else
+    fail "scripts/ci-chrome-sandbox.sh not found"
+fi
+
+if [ -x "$SCRIPT" ]; then
+    pass "script is executable"
+else
+    fail "script is not executable"
+fi
+
+# ── 2. Linux guard ──────────────────────────────────────────────────
+echo "2. Linux guard"
+if grep -q 'uname -s.*Linux\|uname.*!=.*Linux' "$SCRIPT" 2>/dev/null; then
+    pass "Linux guard present"
+else
+    fail "no Linux guard found"
+fi
+
+# ── 3. Idempotency ─────────────────────────────────────────────────
+echo "3. Idempotency (checks before writing)"
+if grep -q 'already enabled\|already disabled' "$SCRIPT" 2>/dev/null; then
+    pass "idempotent check-before-write pattern found"
+else
+    fail "no idempotency pattern detected"
+fi
+
+# ── 4. Fail-loud ────────────────────────────────────────────────────
+echo "4. Fail-loud"
+if grep -q 'set -euo pipefail' "$SCRIPT" 2>/dev/null; then
+    pass "set -euo pipefail present"
+else
+    fail "set -euo pipefail missing"
+fi
+
+if grep -q 'exit 1' "$SCRIPT" 2>/dev/null; then
+    pass "explicit exit 1 on failure"
+else
+    fail "no exit 1 found for failure paths"
+fi
+
+# ── 5. Workflow integration ─────────────────────────────────────────
+echo "5. Workflow integration"
+
+check_workflow_order() {
+    local wf_file="$1"
+    local wf_name="$2"
+
+    if ! grep -q 'ci-chrome-sandbox.sh' "$wf_file" 2>/dev/null; then
+        fail "$wf_name does not invoke ci-chrome-sandbox.sh"
+        return
+    fi
+    pass "$wf_name invokes ci-chrome-sandbox.sh"
+
+    # Verify sandbox step comes before Chrome install step.
+    local sandbox_line chrome_line
+    sandbox_line=$(grep -n 'ci-chrome-sandbox.sh' "$wf_file" | head -1 | cut -d: -f1)
+    chrome_line=$(grep -n 'setup-chrome' "$wf_file" | head -1 | cut -d: -f1)
+
+    if [ -n "$sandbox_line" ] && [ -n "$chrome_line" ] && [ "$sandbox_line" -lt "$chrome_line" ]; then
+        pass "$wf_name: sandbox prep comes before Chrome install"
+    else
+        fail "$wf_name: sandbox prep must come before Chrome install"
+    fi
+}
+
+check_workflow_order "$BENCHMARKS" "benchmarks.yml"
+check_workflow_order "$DOGFOOD" "dogfood.yml"
+
+# ── 6. No --no-sandbox ─────────────────────────────────────────────
+echo "6. No --no-sandbox"
+if grep -r -- '--no-sandbox' "$REPO_ROOT/.github/workflows/" 2>/dev/null; then
+    fail "--no-sandbox found in workflow files"
+else
+    pass "no --no-sandbox in any workflow"
+fi
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+    echo "FAILED: one or more checks failed."
+    exit 1
+else
+    echo "PASSED: all checks passed."
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/ci-chrome-sandbox.sh`: idempotent, Linux-only script that enables unprivileged user namespaces and disables the AppArmor userns restriction on GitHub-hosted runners so Chrome can use its namespace sandbox properly.
- Calls the script in `benchmarks.yml` and `dogfood.yml` before Chrome install steps.
- Wires `tests/ci-chrome-sandbox-validate.sh` into maintained gates so the workflow-order and no-`--no-sandbox` assertions cannot silently rot:
  - `just check` now depends on `ci-chrome-sandbox-validate`, so `just validate` picks it up locally.
  - CI preflight now runs `bash tests/ci-chrome-sandbox-validate.sh`.
  - The validator now fails if either the `justfile` or `ci.yml` invocation disappears.
- Splits the unprivileged-userns sysctl key from its procfs path so verification uses `/proc/sys/kernel/unprivileged_userns_clone` instead of the broken `/proc/sys/kernel/kernel.unprivileged_userns_clone` path.
- Strengthens the validator so it fails on that exact double-prefix regression and on verify blocks that can silently probe the wrong path.
- No `--no-sandbox` flag introduced anywhere.

Closes #188

## Validation

- `bash tests/ci-chrome-sandbox-validate.sh`
  - Script exists and is executable.
  - Linux guard present.
  - Idempotent check-before-write pattern found.
  - Sysctl key is `kernel.unprivileged_userns_clone` and procfs path is `/proc/sys/kernel/unprivileged_userns_clone`.
  - Validator rejects double-prefixed procfs path construction.
  - `set -euo pipefail` and explicit `exit 1` on failure present.
  - Verification reads `USERNS_SYSCTL_PROCFS` explicitly and rejects wrong-path probing.
  - Maintained gate wiring present in `justfile` and `.github/workflows/ci.yml`.
  - Both Chrome workflows invoke the prep script before Chrome install.
  - No `--no-sandbox` in any workflow file.
- `bash -n scripts/ci-chrome-sandbox.sh tests/ci-chrome-sandbox-validate.sh`
- `git diff --check`
- `just validate` could not be executed locally because `just` is not installed in this environment.
- `shellcheck` unavailable locally (`command -v shellcheck` returned missing).

## Test plan

- [x] PR title check on the new head `9d02269381b07232e9cf4377308d4384c01270f5` is running: https://github.com/aram-devdocs/plumb/actions/runs/25235863008
- [x] CI on the new head `9d02269381b07232e9cf4377308d4384c01270f5` is running: https://github.com/aram-devdocs/plumb/actions/runs/25235863384
- [x] Claude review on the new head `9d02269381b07232e9cf4377308d4384c01270f5` is running: https://github.com/aram-devdocs/plumb/actions/runs/25235863386
- [x] Benchmarks workflow dispatched on the new head `9d02269381b07232e9cf4377308d4384c01270f5` and is running: https://github.com/aram-devdocs/plumb/actions/runs/25235872789
- [x] Dogfood workflow dispatched on the new head `9d02269381b07232e9cf4377308d4384c01270f5` and is running: https://github.com/aram-devdocs/plumb/actions/runs/25235872829

Acceptance still does not have to wait for `main`: both post-merge workflows support `workflow_dispatch`, and both accepted branch dispatch for `issue-188-ci-chrome-sandbox-prep` on the current pushed head.
