### PR TITLE
ci: use canonical dogfood URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: bash scripts/check-agents-md.sh
       - name: Validate Chrome sandbox CI wiring
         run: bash tests/ci-chrome-sandbox-validate.sh
+      - name: Validate canonical docs URL wiring
+        run: bash tests/ci-canonical-docs-url-validate.sh
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -18,8 +18,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  lint-plumb-dev:
-    name: plumb lint https://plumb.dev
+  lint-canonical-docs:
+    name: plumb lint https://plumb.aramhammoudeh.com/
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -46,5 +46,5 @@ jobs:
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |
-          target/release/plumb lint https://plumb.dev \
+          target/release/plumb lint https://plumb.aramhammoudeh.com/ \
             --executable-path "$CHROME_PATH"

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ fmt:
     cargo fmt --all
 
 # All static checks — fmt + clippy with zero tolerance. Matches CI preflight.
-check: check-agents ci-chrome-sandbox-validate
+check: check-agents ci-chrome-sandbox-validate ci-canonical-docs-url-validate
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -61,6 +61,10 @@ check-agents:
 # Validate the Chrome sandbox CI guardrails and workflow wiring.
 ci-chrome-sandbox-validate:
     bash tests/ci-chrome-sandbox-validate.sh
+
+# Validate canonical docs URL usage in CI/release acceptance paths.
+ci-canonical-docs-url-validate:
+    bash tests/ci-canonical-docs-url-validate.sh
 
 # Verify the local environment required by the Phase 3 gate.
 phase3-gate-env:

--- a/tests/ci-canonical-docs-url-validate.sh
+++ b/tests/ci-canonical-docs-url-validate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ci-canonical-docs-url-validate.sh — Static validation for canonical docs URL
+# usage in CI and release acceptance paths.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOGFOOD="$REPO_ROOT/.github/workflows/dogfood.yml"
+JUSTFILE="$REPO_ROOT/justfile"
+CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+ACTIVE_PATHS=(
+    "$REPO_ROOT/.github/workflows"
+    "$REPO_ROOT/justfile"
+    "$REPO_ROOT/scripts"
+    "$REPO_ROOT/tests"
+    "$REPO_ROOT/docs/runbooks"
+    "$REPO_ROOT/docs/src/ci"
+)
+
+failures=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; failures=1; }
+
+echo "=== Canonical docs URL validation ==="
+echo ""
+
+echo "1. Dogfood workflow targets the canonical docs URL"
+if grep -Eq '^  lint-canonical-docs:$' "$DOGFOOD"; then
+    pass "dogfood job id is lint-canonical-docs"
+else
+    fail "dogfood job id is not lint-canonical-docs"
+fi
+
+if grep -Fq 'name: plumb lint https://plumb.aramhammoudeh.com/' "$DOGFOOD"; then
+    pass "dogfood job name uses canonical docs URL"
+else
+    fail "dogfood job name does not use canonical docs URL"
+fi
+
+if grep -Fq 'target/release/plumb lint https://plumb.aramhammoudeh.com/ \' "$DOGFOOD"; then
+    pass "dogfood lint command uses canonical docs URL"
+else
+    fail "dogfood lint command does not use canonical docs URL"
+fi
+
+echo "2. Maintained validation wiring"
+if grep -Eq '^ci-canonical-docs-url-validate:$' "$JUSTFILE"; then
+    pass "justfile defines ci-canonical-docs-url-validate"
+else
+    fail "justfile does not define ci-canonical-docs-url-validate"
+fi
+
+if grep -Eq '^check:.*ci-canonical-docs-url-validate' "$JUSTFILE"; then
+    pass "just check depends on ci-canonical-docs-url-validate"
+else
+    fail "just check does not depend on ci-canonical-docs-url-validate"
+fi
+
+if grep -Fq 'tests/ci-canonical-docs-url-validate.sh' "$CI_WORKFLOW"; then
+    pass "ci.yml invokes tests/ci-canonical-docs-url-validate.sh"
+else
+    fail "ci.yml does not invoke tests/ci-canonical-docs-url-validate.sh"
+fi
+
+echo "3. No plumb.dev in active CI/release acceptance paths"
+matches=()
+for path in "${ACTIVE_PATHS[@]}"; do
+    while IFS= read -r line; do
+        if [[ "$line" == *"tests/ci-canonical-docs-url-validate.sh:"* ]]; then
+            continue
+        fi
+        matches+=("$line")
+    done < <(rg -n 'plumb\.dev' "$path" || true)
+done
+
+if [ "${#matches[@]}" -eq 0 ]; then
+    pass "no active CI/release acceptance path references plumb.dev"
+else
+    fail "active CI/release acceptance paths still reference plumb.dev"
+    printf '%s\n' "${matches[@]}" >&2
+fi
+
+echo ""
+if [ "$failures" -ne 0 ]; then
+    echo "FAILED: one or more checks failed."
+    exit 1
+else
+    echo "PASSED: all checks passed."
+fi


### PR DESCRIPTION
## Spec

Closes #193.

## Summary

- Canonicalized the Dogfood workflow job id, display name, and lint target to `https://plumb.aramhammoudeh.com/`.
- Added `tests/ci-canonical-docs-url-validate.sh` and wired it into `just check` plus CI preflight so reviewers can verify active CI/release acceptance paths do not target `plumb.dev`.
- Kept scope limited to CI/workflow validation only; no #192, #65, #51, #52, or #101 work is included.

## Test plan

- [ ] `just check` passes (fmt + clippy, no warnings)
- [ ] `just test` passes on my machine
- [ ] `just determinism-check` passes
- [ ] `cargo deny check` passes
- [x] New tests added (or reason-not given)
- [ ] Docs updated (`docs/src/**`, rustdoc, CHANGELOG if user-visible)
- [ ] Humanizer skill run on any `docs/src/**` prose

Validation run in this environment:
- `bash tests/ci-canonical-docs-url-validate.sh`
- `git diff --check`
- `just validate` was unavailable because `just` is not installed in this environment.

Files changed:
- `.github/workflows/dogfood.yml`
- `.github/workflows/ci.yml`
- `justfile`
- `tests/ci-canonical-docs-url-validate.sh`

## Screenshots / terminal output

Not applicable.

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- The new validator intentionally scans active CI/release acceptance paths only, so historical non-canonical prose outside those paths can remain untouched.
- `just validate` could not be run locally here because `just` is not installed; CI will exercise the wired path.
