### PR TITLE
test: add release-readiness local kits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: bash tests/ci-chrome-sandbox-validate.sh
       - name: Validate canonical docs URL wiring
         run: bash tests/ci-canonical-docs-url-validate.sh
+      - name: Validate release-readiness local kits wiring
+        run: bash tests/release-readiness-local-kits-validate.sh
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,8 @@ dependencies = [
  "clap",
  "plumb-config",
  "plumb-core",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 

--- a/docs/runbooks/v0-release-readiness-spec.yaml
+++ b/docs/runbooks/v0-release-readiness-spec.yaml
@@ -25,7 +25,7 @@ parent:
     channel wiring.
   acceptance_criteria:
     - "Live and local readiness legs are documented with explicit infra-vs-violation classification and per-leg failure reporting."
-    - "Local deterministic kits are defined for static, large-DOM, responsive, typography, color/contrast, token, dynamic, auth, and MCP scenarios."
+    - "Local deterministic kits are checked in under `tests/fixtures/release-readiness/`, with the manifest at `tests/fixtures/release-readiness/manifest.json`, and cover static, large-DOM, responsive, typography, color/contrast, shadow/z/opacity/padding, dynamic/wait, auth/storage, and MCP scenarios."
     - "Install smoke expectations are defined per release channel and supported OS, including auth/no-secret-leak behavior."
     - "Release dry-run, token/security blockers, and attestation verification are defined as observable gates before publication."
     - "Reviewer sign-off lanes are defined so #192, #51/#52, and #101 can be evaluated as one release-readiness boundary."
@@ -65,11 +65,12 @@ batches:
         summary: |
           Define the checked-in local kits that the readiness gate will
           cover, including reuse of existing fixtures where that keeps
-          the matrix deterministic.
+          the matrix deterministic. The source-of-truth manifest lives
+          at `tests/fixtures/release-readiness/manifest.json`.
         acceptance_criteria:
-          - "The local-kit set covers static, large-DOM, responsive, typography, color/contrast, token, dynamic, auth, and MCP cases."
+          - "The local-kit set covers static, large-DOM, responsive, typography, color/contrast, shadow/z/opacity/padding, dynamic/wait, auth/storage, and MCP cases."
           - "Each kit names the observable behavior it proves and whether it is live-only, local-only, or both."
-          - "This slice defines the contract only; fixture implementation lands later."
+          - "Checked-in fixture files and reuse metadata live in the repository, and large-DOM coverage may reuse existing deterministic local fixtures."
         reviewers: ["02-spec-reviewer", "03-code-quality-reviewer", "05-architecture-validator", "04-test-runner"]
       - slug: readiness-install-smoke-shell
         title: "test(ci): define install-smoke release gate"

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ fmt:
     cargo fmt --all
 
 # All static checks — fmt + clippy with zero tolerance. Matches CI preflight.
-check: check-agents ci-chrome-sandbox-validate ci-canonical-docs-url-validate
+check: check-agents ci-chrome-sandbox-validate ci-canonical-docs-url-validate release-readiness-local-kits-validate
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -65,6 +65,10 @@ ci-chrome-sandbox-validate:
 # Validate canonical docs URL usage in CI/release acceptance paths.
 ci-canonical-docs-url-validate:
     bash tests/ci-canonical-docs-url-validate.sh
+
+# Validate release-readiness local kit wiring and fixture constraints.
+release-readiness-local-kits-validate:
+    bash tests/release-readiness-local-kits-validate.sh
 
 # Verify the local environment required by the Phase 3 gate.
 phase3-gate-env:

--- a/tests/fixtures/release-readiness/README.md
+++ b/tests/fixtures/release-readiness/README.md
@@ -9,6 +9,9 @@ gate.
   scripts, or APIs.
 - Every kit is deterministic. The files avoid wall-clock reads,
   randomness, and environment-sensitive content.
+- `dynamic-wait` is deterministic only when capture waits for the
+  delayed mutation: use `wait-ms >= 50` or an equivalent wait-for
+  selector such as `.ready-card`.
 - Every kit is reusable from both release-readiness surfaces:
   `plumb lint file://...` on the CLI and `lint_url` over MCP.
 - The manifest at `tests/fixtures/release-readiness/manifest.json` is the
@@ -27,9 +30,10 @@ gate.
 - `shadow-z-opacity-padding` — overlapping layers and spacing/token-like
   surfaces without network dependencies.
 - `dynamic-wait` — deterministic delayed DOM mutation for `wait-for` and
-  `wait-ms` style gates.
-- `auth-storage` — local cookie, sessionStorage, and localStorage state
-  hooks for future driver auth/storage checks.
+  `wait-ms` style gates. Capture the post-mutation DOM with `wait-ms >= 50`
+  or an equivalent wait-for selector such as `.ready-card`.
+- `auth-storage` — deterministic cookie, sessionStorage, and
+  localStorage seeding hooks for future driver auth/storage checks.
 - `mcp-inputs` — checked-in MCP request examples that target the local
   kits without live URLs.
 

--- a/tests/fixtures/release-readiness/README.md
+++ b/tests/fixtures/release-readiness/README.md
@@ -1,0 +1,41 @@
+# Release Readiness Local Kits
+
+These checked-in fixtures back the offline side of the v0 release-readiness
+gate.
+
+## Contract
+
+- Every kit is offline-only. No kit fetches remote CSS, fonts, images,
+  scripts, or APIs.
+- Every kit is deterministic. The files avoid wall-clock reads,
+  randomness, and environment-sensitive content.
+- Every kit is reusable from both release-readiness surfaces:
+  `plumb lint file://...` on the CLI and `lint_url` over MCP.
+- The manifest at `tests/fixtures/release-readiness/manifest.json` is the
+  source of truth for kit names, file paths, purpose, and CLI/MCP reuse
+  metadata.
+
+## Kit Set
+
+- `minimal` — smallest static page for baseline offline capture.
+- `large-dom` — reuses the existing checked-in fixed DOM benchmark
+  fixtures at 100, 1k, and 10k nodes.
+- `responsive` — one fixture with stable mobile and desktop layout
+  changes.
+- `typography` — local font stacks, weights, and baseline-sensitive text.
+- `contrast` — known pass and fail foreground/background pairings.
+- `shadow-z-opacity-padding` — overlapping layers and spacing/token-like
+  surfaces without network dependencies.
+- `dynamic-wait` — deterministic delayed DOM mutation for `wait-for` and
+  `wait-ms` style gates.
+- `auth-storage` — local cookie, sessionStorage, and localStorage state
+  hooks for future driver auth/storage checks.
+- `mcp-inputs` — checked-in MCP request examples that target the local
+  kits without live URLs.
+
+## Direct Validation
+
+Run either maintained entry point:
+
+- `cargo xtask validate-release-readiness-kits`
+- `bash tests/release-readiness-local-kits-validate.sh`

--- a/tests/fixtures/release-readiness/auth-storage.html
+++ b/tests/fixtures/release-readiness/auth-storage.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness auth storage fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #f8f3eb;
+        color: #1f1a15;
+        font: 16px/1.5 Georgia, "Times New Roman", serif;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+      }
+      .tile {
+        padding: 16px;
+        border: 1px solid #ccbca8;
+        background: #fffdf9;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="grid">
+      <section class="tile" id="cookie-state" data-state="pending">cookie-pending</section>
+      <section class="tile" id="local-state" data-state="pending">local-pending</section>
+      <section class="tile" id="session-state" data-state="pending">session-pending</section>
+    </main>
+    <script>
+      const cookieState = document.getElementById("cookie-state");
+      const localState = document.getElementById("local-state");
+      const sessionState = document.getElementById("session-state");
+
+      const cookieSeen = document.cookie.includes("plumb_readiness=1");
+      document.cookie = "plumb_readiness=1; SameSite=Lax";
+      cookieState.dataset.state = cookieSeen ? "cookie-present" : "cookie-fresh";
+      cookieState.textContent = cookieSeen ? "cookie-present" : "cookie-fresh";
+
+      const localSeen = window.localStorage.getItem("plumb-readiness-local");
+      window.localStorage.setItem("plumb-readiness-local", "1");
+      localState.dataset.state = localSeen === null ? "local-fresh" : "local-present";
+      localState.textContent = localSeen === null ? "local-fresh" : "local-present";
+
+      const sessionSeen = window.sessionStorage.getItem("plumb-readiness-session");
+      window.sessionStorage.setItem("plumb-readiness-session", "1");
+      sessionState.dataset.state = sessionSeen === null ? "session-fresh" : "session-present";
+      sessionState.textContent = sessionSeen === null ? "session-fresh" : "session-present";
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/auth-storage.html
+++ b/tests/fixtures/release-readiness/auth-storage.html
@@ -34,20 +34,17 @@
       const localState = document.getElementById("local-state");
       const sessionState = document.getElementById("session-state");
 
-      const cookieSeen = document.cookie.includes("plumb_readiness=1");
       document.cookie = "plumb_readiness=1; SameSite=Lax";
-      cookieState.dataset.state = cookieSeen ? "cookie-present" : "cookie-fresh";
-      cookieState.textContent = cookieSeen ? "cookie-present" : "cookie-fresh";
+      cookieState.dataset.state = "cookie-seeded";
+      cookieState.textContent = "cookie-seeded";
 
-      const localSeen = window.localStorage.getItem("plumb-readiness-local");
       window.localStorage.setItem("plumb-readiness-local", "1");
-      localState.dataset.state = localSeen === null ? "local-fresh" : "local-present";
-      localState.textContent = localSeen === null ? "local-fresh" : "local-present";
+      localState.dataset.state = "local-seeded";
+      localState.textContent = "local-seeded";
 
-      const sessionSeen = window.sessionStorage.getItem("plumb-readiness-session");
       window.sessionStorage.setItem("plumb-readiness-session", "1");
-      sessionState.dataset.state = sessionSeen === null ? "session-fresh" : "session-present";
-      sessionState.textContent = sessionSeen === null ? "session-fresh" : "session-present";
+      sessionState.dataset.state = "session-seeded";
+      sessionState.textContent = "session-seeded";
     </script>
   </body>
 </html>

--- a/tests/fixtures/release-readiness/contrast.html
+++ b/tests/fixtures/release-readiness/contrast.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness contrast fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #f3efe8;
+        font: 16px/1.5 Georgia, "Times New Roman", serif;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+      }
+      article {
+        padding: 16px;
+        border: 1px solid #c6b49f;
+      }
+      .strong {
+        background: #171410;
+        color: #faf7f1;
+      }
+      .muted {
+        background: #ebe7df;
+        color: #c8c3bb;
+      }
+      .accent {
+        background: #123a54;
+        color: #f4fbff;
+      }
+      .weak-accent {
+        background: #d9e5ee;
+        color: #9eb0be;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="grid">
+      <article class="strong">
+        <h1>High contrast</h1>
+        <p>Dark surface with bright text.</p>
+      </article>
+      <article class="muted">
+        <h1>Weak contrast</h1>
+        <p>Light surface with low-contrast text.</p>
+      </article>
+      <article class="accent">
+        <h1>Strong accent contrast</h1>
+        <p>Accessible accent panel.</p>
+      </article>
+      <article class="weak-accent">
+        <h1>Weak accent contrast</h1>
+        <p>Near-tone text on a near-tone background.</p>
+      </article>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/dynamic-wait.html
+++ b/tests/fixtures/release-readiness/dynamic-wait.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness dynamic wait fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #f4efe6;
+        color: #1c1814;
+        font: 16px/1.5 Georgia, "Times New Roman", serif;
+      }
+      main {
+        display: grid;
+        gap: 12px;
+      }
+      .status {
+        padding: 12px;
+        border: 1px solid #c9baa7;
+        background: #fffaf2;
+      }
+      .ready-card {
+        padding: 16px;
+        border: 1px solid #9c8e7b;
+        background: #fffdf9;
+      }
+    </style>
+  </head>
+  <body>
+    <main data-state="booting">
+      <section class="status" id="status">booting</section>
+      <section class="status">The delayed mutation always fires once after 50 ms.</section>
+    </main>
+    <script>
+      setTimeout(() => {
+        const main = document.querySelector("main");
+        const status = document.getElementById("status");
+        const card = document.createElement("section");
+        card.className = "ready-card";
+        card.textContent = "ready-card-visible";
+        main.appendChild(card);
+        main.dataset.state = "ready";
+        status.textContent = "ready";
+      }, 50);
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/manifest.json
+++ b/tests/fixtures/release-readiness/manifest.json
@@ -1,0 +1,132 @@
+{
+  "version": 1,
+  "location": "tests/fixtures/release-readiness",
+  "offline_only": true,
+  "deterministic": true,
+  "shared_gate_targets": ["cli", "mcp"],
+  "kits": [
+    {
+      "name": "minimal",
+      "files": [
+        "tests/fixtures/release-readiness/minimal.html"
+      ],
+      "purpose": "Baseline offline page for the smallest deterministic local lint target.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/minimal.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/minimal.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "large-dom",
+      "files": [
+        "crates/plumb-cdp/benches/fixtures/fixed-dom-100-nodes.html",
+        "crates/plumb-cdp/benches/fixtures/fixed-dom-1k-nodes.html",
+        "crates/plumb-cdp/benches/fixtures/fixed-dom-10k-nodes.html"
+      ],
+      "purpose": "Reuses the checked-in large DOM benchmark fixtures so readiness gates cover heavier local pages without duplicating inputs.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-100-nodes.html --format json",
+        "plumb lint file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-1k-nodes.html --format json",
+        "plumb lint file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-10k-nodes.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-100-nodes.html\",\"detail\":\"compact\"}",
+        "lint_url {\"url\":\"file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-1k-nodes.html\",\"detail\":\"compact\"}",
+        "lint_url {\"url\":\"file://{repo_root}/crates/plumb-cdp/benches/fixtures/fixed-dom-10k-nodes.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "responsive",
+      "files": [
+        "tests/fixtures/release-readiness/responsive.html"
+      ],
+      "purpose": "Exercises stable layout differences across viewport widths without changing network or runtime inputs.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/responsive.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/responsive.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "typography",
+      "files": [
+        "tests/fixtures/release-readiness/typography.html"
+      ],
+      "purpose": "Covers local font-family stacks, font-size steps, weights, and text rhythm with no remote font loading.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/typography.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/typography.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "contrast",
+      "files": [
+        "tests/fixtures/release-readiness/contrast.html"
+      ],
+      "purpose": "Provides stable foreground/background contrast pairs with known strong and weak readability outcomes.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/contrast.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/contrast.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "shadow-z-opacity-padding",
+      "files": [
+        "tests/fixtures/release-readiness/shadow-z-opacity-padding.html"
+      ],
+      "purpose": "Collects overlapping layers, opacity differences, shadows, and spacing surfaces into one offline fixture.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/shadow-z-opacity-padding.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/shadow-z-opacity-padding.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "dynamic-wait",
+      "files": [
+        "tests/fixtures/release-readiness/dynamic-wait.html"
+      ],
+      "purpose": "Uses one deterministic delayed DOM mutation so wait-based capture paths can be exercised without wall-clock content drift.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/dynamic-wait.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/dynamic-wait.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "auth-storage",
+      "files": [
+        "tests/fixtures/release-readiness/auth-storage.html"
+      ],
+      "purpose": "Exposes deterministic cookie, localStorage, and sessionStorage markers for future auth and storage-state gates.",
+      "cli_examples": [
+        "plumb lint file://{repo_root}/tests/fixtures/release-readiness/auth-storage.html --format json"
+      ],
+      "mcp_examples": [
+        "lint_url {\"url\":\"file://{repo_root}/tests/fixtures/release-readiness/auth-storage.html\",\"detail\":\"compact\"}"
+      ]
+    },
+    {
+      "name": "mcp-inputs",
+      "files": [
+        "tests/fixtures/release-readiness/mcp-inputs.json"
+      ],
+      "purpose": "Checked-in MCP request inputs that stay offline and point only at local fixture URLs or local working directories.",
+      "cli_examples": [
+        "cat tests/fixtures/release-readiness/mcp-inputs.json"
+      ],
+      "mcp_examples": [
+        "Use the JSON entries in tests/fixtures/release-readiness/mcp-inputs.json as request bodies for lint_url, get_config, and echo."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/release-readiness/manifest.json
+++ b/tests/fixtures/release-readiness/manifest.json
@@ -94,7 +94,7 @@
       "files": [
         "tests/fixtures/release-readiness/dynamic-wait.html"
       ],
-      "purpose": "Uses one deterministic delayed DOM mutation so wait-based capture paths can be exercised without wall-clock content drift.",
+      "purpose": "Uses one deterministic delayed DOM mutation so wait-based capture paths can be exercised without wall-clock content drift. Capture the post-mutation DOM with wait-ms >= 50 or an equivalent wait-for selector such as .ready-card.",
       "cli_examples": [
         "plumb lint file://{repo_root}/tests/fixtures/release-readiness/dynamic-wait.html --format json"
       ],
@@ -107,7 +107,7 @@
       "files": [
         "tests/fixtures/release-readiness/auth-storage.html"
       ],
-      "purpose": "Exposes deterministic cookie, localStorage, and sessionStorage markers for future auth and storage-state gates.",
+      "purpose": "Seeds deterministic cookie, localStorage, and sessionStorage markers for future auth and storage-state gates.",
       "cli_examples": [
         "plumb lint file://{repo_root}/tests/fixtures/release-readiness/auth-storage.html --format json"
       ],

--- a/tests/fixtures/release-readiness/mcp-inputs.json
+++ b/tests/fixtures/release-readiness/mcp-inputs.json
@@ -1,0 +1,43 @@
+{
+  "purpose": "Offline MCP request inputs for release-readiness local kits.",
+  "requests": [
+    {
+      "tool": "echo",
+      "args": {
+        "message": "release-readiness-local-kits"
+      },
+      "notes": "Transport smoke check with fixed text."
+    },
+    {
+      "tool": "get_config",
+      "args": {
+        "working_dir": "{repo_root}"
+      },
+      "notes": "Local-only config resolution against the repo root."
+    },
+    {
+      "tool": "lint_url",
+      "args": {
+        "url": "file://{repo_root}/tests/fixtures/release-readiness/minimal.html",
+        "detail": "compact"
+      },
+      "notes": "Smallest local file URL path."
+    },
+    {
+      "tool": "lint_url",
+      "args": {
+        "url": "file://{repo_root}/tests/fixtures/release-readiness/responsive.html",
+        "detail": "full"
+      },
+      "notes": "Viewport-sensitive local file URL path."
+    },
+    {
+      "tool": "lint_url",
+      "args": {
+        "url": "file://{repo_root}/tests/fixtures/release-readiness/auth-storage.html",
+        "detail": "compact"
+      },
+      "notes": "Local stateful fixture path for auth/storage smoke coverage."
+    }
+  ]
+}

--- a/tests/fixtures/release-readiness/minimal.html
+++ b/tests/fixtures/release-readiness/minimal.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness minimal fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 13px;
+        font: 16px/1.4 Georgia, "Times New Roman", serif;
+        color: #1f1b16;
+        background: #faf6ef;
+      }
+    </style>
+  </head>
+  <body>
+    <main>offline minimal fixture</main>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/responsive.html
+++ b/tests/fixtures/release-readiness/responsive.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness responsive fixture</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        font: 16px/1.5 Georgia, "Times New Roman", serif;
+        background: #f4efe6;
+        color: #1f1b16;
+      }
+      main {
+        padding: 16px;
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 12px;
+      }
+      .hero,
+      .details,
+      .rail {
+        padding: 16px;
+        border: 1px solid #ab9c89;
+        background: #fffaf2;
+      }
+      .rail {
+        display: none;
+      }
+      @media (min-width: 900px) {
+        .layout {
+          grid-template-columns: 2fr 1fr;
+          gap: 24px;
+        }
+        .hero {
+          grid-column: 1;
+        }
+        .details {
+          grid-column: 1;
+        }
+        .rail {
+          display: block;
+          grid-column: 2;
+          grid-row: 1 / span 2;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="layout">
+        <section class="hero">
+          <h1>Responsive hero</h1>
+          <p>Stacks on narrow viewports and splits into content plus rail on wide viewports.</p>
+        </section>
+        <section class="details">
+          <h2>Stable content lane</h2>
+          <p>Spacing and text stay fixed while grid structure changes at 900px.</p>
+        </section>
+        <aside class="rail">
+          <h2>Desktop rail</h2>
+          <p>Appears only above the desktop breakpoint.</p>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/shadow-z-opacity-padding.html
+++ b/tests/fixtures/release-readiness/shadow-z-opacity-padding.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness shadow z opacity padding fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #ede7dd;
+        color: #1f1b16;
+        font: 16px/1.4 Georgia, "Times New Roman", serif;
+      }
+      .stage {
+        position: relative;
+        height: 280px;
+        padding: 24px;
+        background: #fffaf2;
+        border: 1px solid #c9b9a4;
+      }
+      .card {
+        position: absolute;
+        width: 220px;
+        min-height: 120px;
+        padding: 18px;
+        border-radius: 8px;
+        background: #ffffff;
+        box-shadow: 0 12px 28px rgba(31, 27, 22, 0.18);
+      }
+      .card-a {
+        top: 24px;
+        left: 24px;
+        z-index: 1;
+      }
+      .card-b {
+        top: 56px;
+        left: 132px;
+        z-index: 3;
+        opacity: 0.88;
+      }
+      .card-c {
+        top: 124px;
+        left: 268px;
+        z-index: 2;
+        padding: 10px 26px 22px 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="stage">
+      <section class="card card-a">
+        <h1>Layer A</h1>
+        <p>Base layer with even padding.</p>
+      </section>
+      <section class="card card-b">
+        <h1>Layer B</h1>
+        <p>Raised overlap with reduced opacity.</p>
+      </section>
+      <section class="card card-c">
+        <h1>Layer C</h1>
+        <p>Asymmetric padding for spacing checks.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/release-readiness/typography.html
+++ b/tests/fixtures/release-readiness/typography.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>plumb readiness typography fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #fcf9f4;
+        color: #1b1713;
+      }
+      .serif {
+        font-family: Georgia, "Times New Roman", serif;
+      }
+      .sans {
+        font-family: "Trebuchet MS", Verdana, sans-serif;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 36px;
+        line-height: 1.1;
+        font-weight: 700;
+      }
+      h2 {
+        margin: 24px 0 8px;
+        font-size: 24px;
+        line-height: 1.2;
+        font-weight: 600;
+      }
+      p {
+        margin: 0 0 12px;
+        font-size: 16px;
+        line-height: 1.5;
+      }
+      .meta {
+        font-size: 13px;
+        line-height: 1.3;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .weight-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .weight-grid div {
+        padding: 12px;
+        border: 1px solid #c2b29c;
+        background: #fffdf9;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="serif">
+      <p class="meta sans">Offline typography kit</p>
+      <h1>Measured type rhythm</h1>
+      <p>Every face here comes from a local fallback stack. No web fonts are requested.</p>
+      <h2 class="sans">Weight and family samples</h2>
+      <div class="weight-grid sans">
+        <div style="font-weight: 400;">Regular supporting copy</div>
+        <div style="font-weight: 600;">Semibold supporting copy</div>
+        <div style="font-weight: 700;">Bold supporting copy</div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/release-readiness-local-kits-validate.sh
+++ b/tests/release-readiness-local-kits-validate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# release-readiness-local-kits-validate.sh — Static validation for the
+# offline release-readiness local kits and their maintained wiring.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+README="$REPO_ROOT/tests/fixtures/release-readiness/README.md"
+MANIFEST="$REPO_ROOT/tests/fixtures/release-readiness/manifest.json"
+JUSTFILE="$REPO_ROOT/justfile"
+CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+failures=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; failures=1; }
+
+echo "=== Release-readiness local kit validation ==="
+echo ""
+
+echo "1. Checked-in contract files exist"
+if [ -f "$README" ]; then
+    pass "README exists"
+else
+    fail "README missing at tests/fixtures/release-readiness/README.md"
+fi
+
+if [ -f "$MANIFEST" ]; then
+    pass "manifest exists"
+else
+    fail "manifest missing at tests/fixtures/release-readiness/manifest.json"
+fi
+
+echo "2. Maintained local + CI wiring"
+if grep -Eq '^release-readiness-local-kits-validate:$' "$JUSTFILE"; then
+    pass "justfile defines release-readiness-local-kits-validate"
+else
+    fail "justfile does not define release-readiness-local-kits-validate"
+fi
+
+if grep -Eq '^check:.*release-readiness-local-kits-validate' "$JUSTFILE"; then
+    pass "just check depends on release-readiness-local-kits-validate"
+else
+    fail "just check does not depend on release-readiness-local-kits-validate"
+fi
+
+if grep -Fq 'tests/release-readiness-local-kits-validate.sh' "$CI_WORKFLOW"; then
+    pass "ci.yml invokes tests/release-readiness-local-kits-validate.sh"
+else
+    fail "ci.yml does not invoke tests/release-readiness-local-kits-validate.sh"
+fi
+
+echo "3. Direct validator passes"
+if (cd "$REPO_ROOT" && cargo xtask validate-release-readiness-kits >/dev/null); then
+    pass "cargo xtask validate-release-readiness-kits passes"
+else
+    fail "cargo xtask validate-release-readiness-kits failed"
+fi
+
+echo ""
+if [ "$failures" -ne 0 ]; then
+    echo "FAILED: one or more checks failed."
+    exit 1
+else
+    echo "PASSED: all checks passed."
+fi

--- a/xtask/AGENTS.md
+++ b/xtask/AGENTS.md
@@ -14,6 +14,7 @@ quoting. Not published. Invoked via the `cargo xtask` alias in
 - `sync-rules-index` — verify every `register_builtin` rule has a matching `docs/src/rules/<slug>.md`.
 - `validate-runbooks` — validate every `docs/runbooks/*.yaml` against `schemas/runbook-spec.json` (delegates to the Python generator's `--validate-only`).
 - `validate-landing-page` — verify the docs landing page uses checked-in demo assets, rejects remote embeds, and keeps install CTA targets valid.
+- `validate-release-readiness-kits` — verify the checked-in offline local-kit manifest, required kit set, reuse metadata, and offline/deterministic content rules.
 - `pre-release` — chains the above checks + schema-currency check.
 
 ## Non-negotiable invariants

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,8 @@ plumb-config = { workspace = true }
 plumb-core = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -86,6 +86,7 @@ const DISALLOWED_KIT_PATTERNS: &[&str] = &[
     "performance.now",
     "new Date(",
     "crypto.randomUUID",
+    "setTimeout(",
     "fetch(",
     "XMLHttpRequest",
     "WebSocket",
@@ -354,7 +355,7 @@ fn validate_release_readiness_manifest_header(
 ) -> Result<()> {
     if manifest.version != 1 {
         anyhow::bail!(
-            "{} must stay at version 1 for this slice.",
+            "{} must stay at version 1 until this validator is updated for a new manifest schema.",
             manifest_path.display()
         );
     }
@@ -399,8 +400,20 @@ fn validate_release_readiness_kit(kit: &ReleaseReadinessKit, workspace_root: &Pa
             kit.name
         );
     }
+    validate_release_readiness_kit_contract(kit)?;
     validate_release_readiness_examples(kit)?;
     validate_release_readiness_kit_files(kit, workspace_root)
+}
+
+fn validate_release_readiness_kit_contract(kit: &ReleaseReadinessKit) -> Result<()> {
+    if kit.name == "dynamic-wait"
+        && (!kit.purpose.contains("wait-ms >= 50") || !kit.purpose.contains(".ready-card"))
+    {
+        anyhow::bail!(
+            "kit `dynamic-wait` must document the `wait-ms >= 50` / `.ready-card` capture contract."
+        );
+    }
+    Ok(())
 }
 
 fn validate_release_readiness_examples(kit: &ReleaseReadinessKit) -> Result<()> {
@@ -451,6 +464,9 @@ fn validate_release_readiness_file(path: &Path) -> Result<()> {
     let src = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
 
     for pattern in DISALLOWED_KIT_PATTERNS {
+        if *pattern == "setTimeout(" && is_dynamic_wait_fixture(path) {
+            continue;
+        }
         if src.contains(pattern) {
             anyhow::bail!(
                 "{} contains disallowed offline/determinism pattern `{pattern}`.",
@@ -476,8 +492,32 @@ fn validate_release_readiness_file(path: &Path) -> Result<()> {
     {
         validate_release_readiness_mcp_inputs(&src, path)?;
     }
+    if is_dynamic_wait_fixture(path) {
+        validate_dynamic_wait_fixture(&src, path)?;
+    }
     if path.extension().is_some_and(|ext| ext == "html") && !src.contains("<!DOCTYPE html>") {
         anyhow::bail!("{} must remain an HTML5 fixture.", path.display());
+    }
+    Ok(())
+}
+
+fn is_dynamic_wait_fixture(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| name == "dynamic-wait.html")
+}
+
+fn validate_dynamic_wait_fixture(src: &str, path: &Path) -> Result<()> {
+    if !src.contains("setTimeout(") || !src.contains("}, 50);") {
+        anyhow::bail!(
+            "{} must keep exactly one explicit 50 ms delayed mutation for wait-gate coverage.",
+            path.display()
+        );
+    }
+    if !src.contains(".ready-card") && !src.contains("ready-card") {
+        anyhow::bail!(
+            "{} must keep a stable ready marker such as `.ready-card` for wait-for style capture.",
+            path.display()
+        );
     }
     Ok(())
 }
@@ -746,10 +786,10 @@ fn markdown_anchor_slug(heading: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        RELEASE_READINESS_MANIFEST_PATH, ReleaseReadinessManifest, collect_markdown_anchors,
-        extract_html_sources, extract_markdown_links, markdown_anchor_slug,
-        validate_local_markdown_link, validate_no_remote_embeds, validate_release_readiness_file,
-        workspace_root,
+        RELEASE_READINESS_MANIFEST_PATH, ReleaseReadinessKit, ReleaseReadinessManifest,
+        collect_markdown_anchors, extract_html_sources, extract_markdown_links,
+        markdown_anchor_slug, validate_local_markdown_link, validate_no_remote_embeds,
+        validate_release_readiness_file, validate_release_readiness_kit_contract, workspace_root,
     };
     use std::{fs, path::Path};
     use tempfile::tempdir;
@@ -872,6 +912,13 @@ mod tests {
             serde_json::from_str(&src).expect("manifest should parse");
         assert_eq!(manifest.version, 1);
         assert!(!manifest.kits.is_empty(), "kits should not be empty");
+        let dynamic_wait = manifest
+            .kits
+            .iter()
+            .find(|kit| kit.name == "dynamic-wait")
+            .expect("dynamic-wait kit present");
+        assert!(dynamic_wait.purpose.contains("wait-ms >= 50"));
+        assert!(dynamic_wait.purpose.contains(".ready-card"));
     }
 
     #[test]
@@ -898,5 +945,33 @@ mod tests {
         .expect("write fixture");
         let err = validate_release_readiness_file(&path).expect_err("remote URL must fail");
         assert!(err.to_string().contains("https://"));
+    }
+
+    #[test]
+    fn release_readiness_dynamic_wait_contract_requires_wait_note() {
+        let kit = ReleaseReadinessKit {
+            name: "dynamic-wait".to_owned(),
+            files: vec!["tests/fixtures/release-readiness/dynamic-wait.html".to_owned()],
+            purpose: "deterministic delayed DOM mutation".to_owned(),
+            cli_examples: vec!["plumb lint file://fixture --format json".to_owned()],
+            mcp_examples: vec!["lint_url {\"url\":\"file://fixture\"}".to_owned()],
+        };
+        let err = validate_release_readiness_kit_contract(&kit)
+            .expect_err("dynamic-wait note must be required");
+        assert!(err.to_string().contains("wait-ms >= 50"));
+    }
+
+    #[test]
+    fn release_readiness_file_rejects_timeout_outside_dynamic_wait_fixture() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("timeout.html");
+        fs::write(
+            &path,
+            "<!DOCTYPE html><script>setTimeout(() => { document.body.dataset.state = \"ready\"; }, 50);</script>",
+        )
+        .expect("write fixture");
+        let err = validate_release_readiness_file(&path)
+            .expect_err("setTimeout should be rejected outside dynamic-wait");
+        assert!(err.to_string().contains("setTimeout("));
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use std::process::{Command, ExitCode};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use serde::Deserialize;
 
 #[derive(Debug, Parser)]
 #[command(name = "xtask", about = "Plumb developer task runner.")]
@@ -47,6 +48,8 @@ enum Cmd {
     },
     /// Validate the docs landing page demo asset and CTA targets.
     ValidateLandingPage,
+    /// Validate the checked-in offline release-readiness local kits.
+    ValidateReleaseReadinessKits,
     /// Pre-release sanity suite: schema up-to-date, rules-index in sync,
     /// every runbook spec valid.
     PreRelease,
@@ -62,6 +65,55 @@ const REQUIRED_INSTALL_CTA_LINKS: &[&str] = &[
     "./install.md#homebrew",
     "./install.md#build-from-source",
 ];
+const RELEASE_READINESS_README_PATH: &str = "tests/fixtures/release-readiness/README.md";
+const RELEASE_READINESS_MANIFEST_PATH: &str = "tests/fixtures/release-readiness/manifest.json";
+const REQUIRED_RELEASE_READINESS_KITS: &[&str] = &[
+    "minimal",
+    "large-dom",
+    "responsive",
+    "typography",
+    "contrast",
+    "shadow-z-opacity-padding",
+    "dynamic-wait",
+    "auth-storage",
+    "mcp-inputs",
+];
+const DISALLOWED_KIT_PATTERNS: &[&str] = &[
+    "http://",
+    "https://",
+    "Date.now",
+    "Math.random",
+    "performance.now",
+    "new Date(",
+    "crypto.randomUUID",
+    "fetch(",
+    "XMLHttpRequest",
+    "WebSocket",
+    "EventSource",
+    "navigator.serviceWorker",
+    "SharedWorker",
+    "importScripts(",
+];
+const REQUIRED_MCP_TOOLS: &[&str] = &["echo", "get_config", "lint_url"];
+
+#[derive(Debug, Deserialize)]
+struct ReleaseReadinessManifest {
+    version: u64,
+    location: String,
+    offline_only: bool,
+    deterministic: bool,
+    shared_gate_targets: Vec<String>,
+    kits: Vec<ReleaseReadinessKit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseReadinessKit {
+    name: String,
+    files: Vec<String>,
+    purpose: String,
+    cli_examples: Vec<String>,
+    mcp_examples: Vec<String>,
+}
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -80,6 +132,7 @@ fn run(cli: Cli) -> Result<()> {
         Cmd::SyncRulesIndex => sync_rules_index(),
         Cmd::ValidateRunbooks { dir } => validate_runbooks(&dir),
         Cmd::ValidateLandingPage => validate_landing_page(),
+        Cmd::ValidateReleaseReadinessKits => validate_release_readiness_kits(),
         Cmd::PreRelease => pre_release(),
     }
 }
@@ -220,7 +273,237 @@ fn pre_release() -> Result<()> {
     // 4. Runbook specs valid (skips cleanly if docs/runbooks/ doesn't exist yet).
     validate_runbooks(Path::new("docs/runbooks"))?;
 
+    // 5. Local release-readiness kits valid.
+    validate_release_readiness_kits()?;
+
     let _ = writeln!(std::io::stdout(), "▸ OK — pre-release gates green.");
+    Ok(())
+}
+
+fn validate_release_readiness_kits() -> Result<()> {
+    let workspace_root = workspace_root();
+    let readme_path = workspace_root.join(RELEASE_READINESS_README_PATH);
+    let manifest_path = workspace_root.join(RELEASE_READINESS_MANIFEST_PATH);
+
+    validate_release_readiness_readme(&readme_path)?;
+    let manifest = load_release_readiness_manifest(&manifest_path)?;
+    validate_release_readiness_manifest_header(
+        &manifest,
+        &manifest_path,
+        &workspace_root,
+        &readme_path,
+    )?;
+
+    let mut names: Vec<&str> = manifest.kits.iter().map(|kit| kit.name.as_str()).collect();
+    names.sort_unstable();
+    let mut expected = REQUIRED_RELEASE_READINESS_KITS.to_vec();
+    expected.sort_unstable();
+    if names != expected {
+        anyhow::bail!(
+            "{} must define exactly the required kit set: {:?}; found {:?}.",
+            manifest_path.display(),
+            expected,
+            names
+        );
+    }
+
+    for kit in &manifest.kits {
+        validate_release_readiness_kit(kit, &workspace_root)?;
+    }
+
+    let _ = writeln!(
+        std::io::stdout(),
+        "▸ release-readiness local kits valid: {} kits, offline-only and reusable by CLI/MCP.",
+        manifest.kits.len()
+    );
+    Ok(())
+}
+
+fn validate_release_readiness_readme(readme_path: &Path) -> Result<()> {
+    let readme = std::fs::read_to_string(readme_path)
+        .with_context(|| format!("read {}", readme_path.display()))?;
+    for phrase in [
+        "offline-only",
+        "deterministic",
+        "CLI",
+        "MCP",
+        "manifest.json",
+    ] {
+        if !readme.contains(phrase) {
+            anyhow::bail!(
+                "{} must mention `{phrase}` so the kit contract stays documented.",
+                readme_path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn load_release_readiness_manifest(manifest_path: &Path) -> Result<ReleaseReadinessManifest> {
+    let manifest_src = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    serde_json::from_str(&manifest_src)
+        .with_context(|| format!("parse {}", manifest_path.display()))
+}
+
+fn validate_release_readiness_manifest_header(
+    manifest: &ReleaseReadinessManifest,
+    manifest_path: &Path,
+    workspace_root: &Path,
+    readme_path: &Path,
+) -> Result<()> {
+    if manifest.version != 1 {
+        anyhow::bail!(
+            "{} must stay at version 1 for this slice.",
+            manifest_path.display()
+        );
+    }
+    if manifest.location != "tests/fixtures/release-readiness" {
+        anyhow::bail!(
+            "{} has unexpected location `{}`.",
+            manifest_path.display(),
+            manifest.location
+        );
+    }
+    if !manifest.offline_only || !manifest.deterministic {
+        anyhow::bail!(
+            "{} must declare offline_only=true and deterministic=true.",
+            manifest_path.display()
+        );
+    }
+    if manifest.shared_gate_targets != ["cli", "mcp"] {
+        anyhow::bail!(
+            "{} must declare shared_gate_targets exactly as [\"cli\", \"mcp\"].",
+            manifest_path.display()
+        );
+    }
+    if workspace_root.join(&manifest.location) != readme_path.parent().unwrap_or(workspace_root) {
+        anyhow::bail!(
+            "{} must point at the checked-in local-kit directory only.",
+            manifest_path.display()
+        );
+    }
+    Ok(())
+}
+
+fn validate_release_readiness_kit(kit: &ReleaseReadinessKit, workspace_root: &Path) -> Result<()> {
+    if kit.files.is_empty() {
+        anyhow::bail!("kit `{}` must list at least one checked-in file.", kit.name);
+    }
+    if kit.purpose.trim().is_empty() {
+        anyhow::bail!("kit `{}` must include a non-empty purpose.", kit.name);
+    }
+    if kit.cli_examples.is_empty() || kit.mcp_examples.is_empty() {
+        anyhow::bail!(
+            "kit `{}` must include both CLI and MCP reuse metadata.",
+            kit.name
+        );
+    }
+    validate_release_readiness_examples(kit)?;
+    validate_release_readiness_kit_files(kit, workspace_root)
+}
+
+fn validate_release_readiness_examples(kit: &ReleaseReadinessKit) -> Result<()> {
+    for example in &kit.cli_examples {
+        if !example.contains("file://") && !example.contains("cat ") {
+            anyhow::bail!(
+                "kit `{}` has a CLI example that does not stay local/offline: `{example}`.",
+                kit.name
+            );
+        }
+    }
+    for example in &kit.mcp_examples {
+        if !example.contains("lint_url")
+            && !example.contains("get_config")
+            && !example.contains("echo")
+        {
+            anyhow::bail!(
+                "kit `{}` has an MCP example that does not reference a current MCP surface: `{example}`.",
+                kit.name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_release_readiness_kit_files(
+    kit: &ReleaseReadinessKit,
+    workspace_root: &Path,
+) -> Result<()> {
+    for file in &kit.files {
+        let path = workspace_root.join(file);
+        if !path.exists() {
+            anyhow::bail!("kit `{}` references missing file `{file}`.", kit.name);
+        }
+        validate_release_readiness_file(&path)?;
+    }
+    Ok(())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
+}
+
+fn validate_release_readiness_file(path: &Path) -> Result<()> {
+    let src = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+
+    for pattern in DISALLOWED_KIT_PATTERNS {
+        if src.contains(pattern) {
+            anyhow::bail!(
+                "{} contains disallowed offline/determinism pattern `{pattern}`.",
+                path.display()
+            );
+        }
+    }
+    if src.contains("<link ") {
+        anyhow::bail!(
+            "{} contains a <link> tag; use inline checked-in styling only.",
+            path.display()
+        );
+    }
+    if src.contains("<img ") || src.contains("<iframe ") || src.contains("<object ") {
+        anyhow::bail!(
+            "{} contains an externalizable embed tag; keep the kits self-contained text/CSS/DOM fixtures.",
+            path.display()
+        );
+    }
+    if path
+        .file_name()
+        .is_some_and(|name| name == "mcp-inputs.json")
+    {
+        validate_release_readiness_mcp_inputs(&src, path)?;
+    }
+    if path.extension().is_some_and(|ext| ext == "html") && !src.contains("<!DOCTYPE html>") {
+        anyhow::bail!("{} must remain an HTML5 fixture.", path.display());
+    }
+    Ok(())
+}
+
+fn validate_release_readiness_mcp_inputs(src: &str, path: &Path) -> Result<()> {
+    let value: serde_json::Value =
+        serde_json::from_str(src).with_context(|| format!("parse {}", path.display()))?;
+    let requests = value
+        .get("requests")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("{} must contain a `requests` array.", path.display()))?;
+
+    for tool in REQUIRED_MCP_TOOLS {
+        if !requests.iter().any(|entry| {
+            entry
+                .get("tool")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|name| name == *tool)
+        }) {
+            anyhow::bail!(
+                "{} must include a `{tool}` request so the MCP reuse contract stays covered.",
+                path.display()
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -463,8 +746,10 @@ fn markdown_anchor_slug(heading: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_markdown_anchors, extract_html_sources, extract_markdown_links,
-        markdown_anchor_slug, validate_local_markdown_link, validate_no_remote_embeds,
+        RELEASE_READINESS_MANIFEST_PATH, ReleaseReadinessManifest, collect_markdown_anchors,
+        extract_html_sources, extract_markdown_links, markdown_anchor_slug,
+        validate_local_markdown_link, validate_no_remote_embeds, validate_release_readiness_file,
+        workspace_root,
     };
     use std::{fs, path::Path};
     use tempfile::tempdir;
@@ -577,5 +862,41 @@ mod tests {
         let err = validate_local_markdown_link(&landing_page, "./install.md#cargo")
             .expect_err("anchor mismatch must fail");
         assert!(err.to_string().contains("missing anchor `#cargo`"));
+    }
+
+    #[test]
+    fn release_readiness_manifest_parses() {
+        let path = workspace_root().join(RELEASE_READINESS_MANIFEST_PATH);
+        let src = fs::read_to_string(path).expect("read manifest");
+        let manifest: ReleaseReadinessManifest =
+            serde_json::from_str(&src).expect("manifest should parse");
+        assert_eq!(manifest.version, 1);
+        assert!(!manifest.kits.is_empty(), "kits should not be empty");
+    }
+
+    #[test]
+    fn release_readiness_mcp_inputs_must_cover_required_tools() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("mcp-inputs.json");
+        fs::write(
+            &path,
+            r#"{"requests":[{"tool":"echo"},{"tool":"get_config"}]}"#,
+        )
+        .expect("write mcp inputs");
+        let err = validate_release_readiness_file(&path).expect_err("missing lint_url must fail");
+        assert!(err.to_string().contains("lint_url"));
+    }
+
+    #[test]
+    fn release_readiness_file_rejects_remote_url() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("remote.html");
+        fs::write(
+            &path,
+            "<!DOCTYPE html><img src=\"https://example.com/x.png\" alt=\"x\" />",
+        )
+        .expect("write fixture");
+        let err = validate_release_readiness_file(&path).expect_err("remote URL must fail");
+        assert!(err.to_string().contains("https://"));
     }
 }


### PR DESCRIPTION
## Summary
- add checked-in offline deterministic release-readiness local kits under `tests/fixtures/release-readiness/`
- add minimal validator and `xtask`/CI/`justfile` wiring for CLI/MCP reuse and offline-content enforcement
- update the v0 release-readiness runbook slice so Slice B points only at the checked-in local-kit location

## Scope
- Slice B for #192 only
- no live workflow wiring
- no install-smoke wiring
- no release wiring

## Validation
- `bash tests/release-readiness-local-kits-validate.sh` ✅
- `cargo xtask validate-release-readiness-kits` ✅
- `cargo test -p xtask` ✅
- `cargo fmt --check` ✅
- `cargo clippy -p xtask --all-targets -- -D warnings` ✅
- `git diff --check` ✅
- `cargo xtask validate-runbooks` ⚠️ blocked locally: `ModuleNotFoundError: No module named 'yaml'`
- `cargo xtask pre-release` ⚠️ blocked locally by the same missing `PyYAML` dependency in `.agents/skills/gh-runbook/scripts/generate_runbook.py`
- `just validate` ⚠️ unavailable locally: `just: command not found`

Refs #192
Part of #192
