### PR TITLE
test(ci): validate non-manual release channels

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -4,8 +4,10 @@ name: Install smoke test
 # across platforms. Runs weekly and on every release tag.
 #
 # Matrix: {cargo, brew, npm, curl} x {ubuntu, macos, windows}.
-# Brew and npm channels are gated — they skip until the external
-# prerequisites (plumb-dev org, homebrew-tap repo, npm scope) exist.
+# Cargo and curl are the current non-manual validation paths in this
+# repo state. Brew and npm stay gated/prep-only — they skip until the
+# external prerequisites (plumb-dev org, homebrew-tap repo, npm scope,
+# publish identity, and secrets/permissions) exist.
 # See dist-workspace.toml and docs/src/ci/release-prep.md for details.
 #
 # Non-gated failures open or update a single tracking issue so the team

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,17 @@ name: release
 # would generate. It stays in sync with `dist-workspace.toml`. Re-run
 # `cargo dist generate` locally and diff before editing.
 #
-# Homebrew tap and npm publishing are intentionally inactive here. Do not add
-# the `tap` or `npm-scope` fields in `dist-workspace.toml` until the external
-# prerequisites exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap` repo,
-# ownership of the `@plumb` npm scope and `@plumb/cli` package, and the
-# cargo-dist publishing token/permissions. npm activation also needs `npm`
-# added to the installer list; `npm-scope` alone does not emit npm artifacts
-# on cargo-dist 0.28.0. This workflow must not claim `npm i -g @plumb/cli`
-# support until a live publish verifies it.
+# Cargo publish and curl installers are the only non-manual release
+# channels this repo validates end-to-end today. Homebrew tap and npm
+# publishing are intentionally inactive here. Do not add the `tap` or
+# `npm-scope` fields in `dist-workspace.toml` until the external
+# prerequisites exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap`
+# repo, ownership of the `@plumb` npm scope and `@plumb/cli` package,
+# and the cargo-dist publishing token/permissions. npm activation also
+# needs `npm` added to the installer list; `npm-scope` alone does not
+# emit npm artifacts on cargo-dist 0.28.0. This workflow must not claim
+# `brew install` or `npm i -g @plumb/cli` support until a live publish
+# verifies those channels.
 
 on:
   push:

--- a/docs/runbooks/v0-release-readiness-spec.yaml
+++ b/docs/runbooks/v0-release-readiness-spec.yaml
@@ -7,16 +7,17 @@ parent:
   labels: ["phase-7", "kind:rfc"]
   summary: |
     Define the release-readiness gate that must pass before the first
-    Homebrew/npm distribution moves and before Phase 7 Gate 1 is
-    dispatchable. This runbook covers the website matrix, local
-    deterministic kits, install smoke, release dry-run checks,
-    token/security blockers, attestations, and reviewer sign-off lanes
-    needed to prove Plumb is ready for a first distribution release.
+    Homebrew/npm distribution moves and before #101 can be accepted as
+    the first distribution release. This runbook covers the website
+    matrix, local deterministic kits, install smoke, release dry-run
+    checks, token/security blockers, attestations, and reviewer
+    sign-off lanes needed to prove Plumb is ready for a first
+    distribution release.
 
     Parking rule: #65 and Phase 7 Gate 1 (#66–#85) remain parked and
-    not dispatchable until this runbook closes, #51/#52 pass their
-    release-channel wiring gates, and #101 passes as the first
-    distribution release. #193 is already closed and remains a recorded
+    not dispatchable until this runbook closes, #51/#52 have their
+    prep-only gating evidence, and #101 has the first-release evidence
+    it still needs. #193 is already closed and remains a recorded
     prerequisite.
 
     This spec is intentionally a shell for later slices. It defines the
@@ -28,8 +29,9 @@ parent:
     - "Local deterministic kits are checked in under `tests/fixtures/release-readiness/`, with the manifest at `tests/fixtures/release-readiness/manifest.json`, and cover static, large-DOM, responsive, typography, color/contrast, shadow/z/opacity/padding, dynamic/wait, auth/storage, and MCP scenarios."
     - "Install smoke expectations are defined per release channel and supported OS, including auth/no-secret-leak behavior."
     - "Release dry-run, token/security blockers, and attestation verification are defined as observable gates before publication."
-    - "Reviewer sign-off lanes are defined so #192, #51/#52, and #101 can be evaluated as one release-readiness boundary."
-    - "#65 and #66–#85 remain parked until this runbook, #51/#52, and #101 all pass."
+    - "Cargo and curl are defined as the current non-manual validation channels, while Homebrew (#51) and npm (#52) remain explicit prep-only/gated channels until external setup and live publish verification exist."
+    - "Reviewer sign-off lanes are defined so #192, #51/#52, and #101 can be evaluated as one release-readiness boundary without treating #51/#52 as complete."
+    - "#65 and #66–#85 remain parked until this runbook closes, #51/#52 retain prep-only gating evidence, and #101 clears its first-release evidence."
   related_prd_sections: ["§10.6", "§14.1", "§14.2", "§14.4", "§15.1", "§15.3", "§15.4", "§15.5", "§16"]
 
 batches:
@@ -83,6 +85,7 @@ batches:
         acceptance_criteria:
           - "The contract names the required channels and operating systems."
           - "Acceptance includes auth/no-secret-leak behavior where install smoke touches protected paths or tokens."
+          - "Cargo and curl are the only non-manual channels that must execute in this repo state; Homebrew and npm stay documented as gated/prep-only."
           - "This slice does not add the workflow; it defines the observable gate."
         reviewers: ["02-spec-reviewer", "03-code-quality-reviewer", "05-architecture-validator", "04-test-runner", "06-security-auditor"]
       - slug: readiness-token-security-blockers
@@ -143,7 +146,7 @@ batches:
           release evidence is present.
         acceptance_criteria:
           - "Required sign-off lanes are named for readiness, release-channel wiring, and first-release evidence."
-          - "The closure rule states that #65 and #66–#85 remain parked until sign-off completes across #192, #51/#52, and #101."
+          - "The closure rule states that #65 and #66–#85 remain parked until sign-off completes across #192, #51/#52 prep-only evidence, and #101 first-release evidence."
           - "This slice defines the review contract only."
         reviewers: ["02-spec-reviewer", "03-code-quality-reviewer", "05-architecture-validator", "04-test-runner", "06-security-auditor"]
 
@@ -151,8 +154,10 @@ phase_gate:
   criterion: |
     All readiness batches closed with observable reporting in place AND
     local kits, install smoke, release dry-run, token/security blocker,
-    attestation, and reviewer sign-off evidence captured AND #51/#52
-    release-channel wiring gates pass AND #101 passes as the first
-    distribution release. Until then, #65 and Phase 7 Gate 1 (#66–#85)
-    remain parked and not dispatchable.
+    attestation, and reviewer sign-off evidence captured AND cargo/curl
+    non-manual channel evidence captured AND #51/#52 retain their
+    prep-only gating evidence until external prerequisites exist AND
+    #101 clears its first distribution release evidence. Until then,
+    #65 and Phase 7 Gate 1 (#66–#85) remain parked and not
+    dispatchable.
   unblocks: "issue-51, issue-52, issue-65 gate-1 dispatch, issue-101 completion"

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -8,6 +8,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/install-smoke.yml"
 JUSTFILE="$REPO_ROOT/justfile"
 CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+RELEASE_PREP_DOC="$REPO_ROOT/docs/src/ci/release-prep.md"
 
 failures=0
 
@@ -95,6 +96,38 @@ else
     fail "curl channel should not be gated"
 fi
 
+# Current repo contract: cargo/curl run automatically on all supported
+# platforms; brew/npm stay documented as prep-only until external setup
+# exists.
+cargo_count=$(grep -c 'channel: cargo' "$WORKFLOW" || true)
+curl_count=$(grep -c 'channel: curl' "$WORKFLOW" || true)
+brew_count=$(grep -c 'channel: brew' "$WORKFLOW" || true)
+npm_count=$(grep -c 'channel: npm' "$WORKFLOW" || true)
+
+if [ "$cargo_count" -eq 3 ]; then
+    pass "cargo channel covers all three OSes as a non-manual path"
+else
+    fail "cargo channel count is $cargo_count (expected 3 OS legs)"
+fi
+
+if [ "$curl_count" -eq 3 ]; then
+    pass "curl channel covers all three OSes as a non-manual path"
+else
+    fail "curl channel count is $curl_count (expected 3 OS legs)"
+fi
+
+if [ "$brew_count" -eq 2 ]; then
+    pass "brew channel stays limited to supported gated OS legs"
+else
+    fail "brew channel count is $brew_count (expected 2 gated OS legs)"
+fi
+
+if [ "$npm_count" -eq 3 ]; then
+    pass "npm channel stays limited to supported gated OS legs"
+else
+    fail "npm channel count is $npm_count (expected 3 gated OS legs)"
+fi
+
 # ── 5. Verification steps ──────────────────────────────────────────
 
 echo "5. Verification steps"
@@ -152,6 +185,21 @@ else
     fail "npm channel gating/install contract is incorrect"
 fi
 
+if grep -Fq 'Cargo and curl are the current non-manual validation paths' "$WORKFLOW" \
+    && grep -Fq 'Brew and npm stay gated/prep-only' "$WORKFLOW"; then
+    pass "workflow docs describe non-manual vs prep-only channel state"
+else
+    fail "workflow docs do not describe the current non-manual/prep-only channel state"
+fi
+
+if [ -f "$RELEASE_PREP_DOC" ] \
+    && grep -Fq 'Issue #51 is prep-only in this repo state.' "$RELEASE_PREP_DOC" \
+    && grep -Fq 'Issue #52 is also prep-only in this repo state.' "$RELEASE_PREP_DOC"; then
+    pass "release prep doc records #51/#52 as prep-only"
+else
+    fail "release prep doc does not record #51/#52 as prep-only"
+fi
+
 # Exit code handling: 0 and 3 are acceptable, 2 is infra failure.
 if grep -Eq 'rc.*-ne 0.*rc.*-ne 3|exit 0.*exit 3' "$WORKFLOW"; then
     pass "workflow distinguishes acceptable exit codes (0, 3) from failures"
@@ -187,6 +235,12 @@ if grep -Fq 'install-smoke' "$WORKFLOW" && grep -Fq 'gh issue' "$WORKFLOW"; then
     pass "workflow auto-creates tracking issues on failure"
 else
     fail "workflow does not auto-create tracking issues on failure"
+fi
+
+if grep -Fq 'One or more non-gated install channels failed.' "$WORKFLOW"; then
+    pass "failure reporting is scoped to non-gated channels"
+else
+    fail "failure reporting is not scoped to non-gated channels"
 fi
 
 # ── 8. Permissions are minimal ─────────────────────────────────────

--- a/tests/release-readiness-matrix-validate.sh
+++ b/tests/release-readiness-matrix-validate.sh
@@ -10,6 +10,7 @@ MATRIX_WORKFLOW="$REPO_ROOT/.github/workflows/release-readiness-matrix.yml"
 JUSTFILE="$REPO_ROOT/justfile"
 CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
 MANIFEST="$REPO_ROOT/tests/fixtures/release-readiness/manifest.json"
+RUNBOOK="$REPO_ROOT/docs/runbooks/v0-release-readiness-spec.yaml"
 
 failures=0
 
@@ -194,6 +195,34 @@ if grep -Fq 'malformed-edge' "$MATRIX_SCRIPT"; then
     pass "matrix has malformed-edge leg"
 else
     fail "matrix missing malformed-edge leg"
+fi
+
+# ── 10. Release-readiness contract wiring ──────────────────────────
+
+echo "10. Release-readiness contract"
+if [ -f "$RUNBOOK" ]; then
+    pass "v0 release-readiness runbook exists"
+else
+    fail "v0 release-readiness runbook missing"
+fi
+
+if grep -Fq 'Cargo and curl are defined as the current non-manual validation channels' "$RUNBOOK"; then
+    pass "runbook records cargo/curl as current non-manual validation channels"
+else
+    fail "runbook does not record cargo/curl as current non-manual validation channels"
+fi
+
+if grep -Fq 'Homebrew (#51) and npm (#52) remain explicit prep-only/gated channels' "$RUNBOOK"; then
+    pass "runbook records #51/#52 as prep-only/gated channels"
+else
+    fail "runbook does not record #51/#52 as prep-only/gated channels"
+fi
+
+if grep -Fq 'before #101 can be accepted as' "$RUNBOOK" \
+    && grep -Fq 'the first distribution release.' "$RUNBOOK"; then
+    pass "runbook uses current #101 readiness wording"
+else
+    fail "runbook does not use the current #101 readiness wording"
 fi
 
 echo ""

--- a/tests/release-security-validate.sh
+++ b/tests/release-security-validate.sh
@@ -12,6 +12,7 @@ SECURITY_WORKFLOW="$REPO_ROOT/.github/workflows/security.yml"
 DIST_CONFIG="$REPO_ROOT/dist-workspace.toml"
 JUSTFILE="$REPO_ROOT/justfile"
 CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+RELEASE_PREP_DOC="$REPO_ROOT/docs/src/ci/release-prep.md"
 
 failures=0
 
@@ -90,6 +91,14 @@ if grep -Fq 'attestations: write' "$RELEASE_WORKFLOW"; then
     pass "release workflow has attestations: write permission"
 else
     fail "release workflow missing attestations: write permission"
+fi
+
+if grep -Fq 'Cargo publish and curl installers are the only non-manual release' "$RELEASE_WORKFLOW" \
+    && grep -Fq 'Homebrew tap and npm' "$RELEASE_WORKFLOW" \
+    && grep -Fq 'publishing are intentionally inactive here.' "$RELEASE_WORKFLOW"; then
+    pass "release workflow docs distinguish active non-manual channels from gated ones"
+else
+    fail "release workflow docs do not distinguish active non-manual channels from gated ones"
 fi
 
 # ── 3. Token handling via env indirection ──────────────────────────
@@ -186,6 +195,13 @@ else
     pass "dist-workspace.toml not found — Homebrew publish correctly absent"
 fi
 
+if [ -f "$DIST_CONFIG" ] \
+    && grep -Fq 'Issues #51 and #52 are intentionally prep-only' "$DIST_CONFIG"; then
+    pass "dist-workspace.toml documents #51/#52 as prep-only"
+else
+    fail "dist-workspace.toml does not document #51/#52 as prep-only"
+fi
+
 # ── 6. NPM scope publish is gated ─────────────────────────────────
 
 echo "6. NPM publish gating"
@@ -206,11 +222,26 @@ if [ -f "$DIST_CONFIG" ]; then
     fi
 fi
 
+if [ -f "$DIST_CONFIG" ] \
+    && grep -Fq 'installers = ["shell", "powershell"]' "$DIST_CONFIG"; then
+    pass "dist-workspace.toml keeps npm out of the active installer list"
+else
+    fail "dist-workspace.toml does not keep npm out of the active installer list"
+fi
+
 # The install-smoke workflow documents NPM_TOKEN is not yet wired.
 if grep -Fq 'npm' "$INSTALL_SMOKE"; then
     pass "install-smoke acknowledges npm channel"
 else
     fail "install-smoke does not acknowledge npm channel"
+fi
+
+if [ -f "$RELEASE_PREP_DOC" ] \
+    && grep -Fq 'Until those blockers are resolved, the install docs describe the' "$RELEASE_PREP_DOC" \
+    && grep -Fq 'Until those blockers are resolved, this repo MUST NOT claim that' "$RELEASE_PREP_DOC"; then
+    pass "release prep doc keeps Homebrew/npm claims gated behind external blockers"
+else
+    fail "release prep doc does not keep Homebrew/npm claims gated behind external blockers"
 fi
 
 # ── 7. Security audit workflow exists ──────────────────────────────


### PR DESCRIPTION
## Spec

Related issues: #51, #52

## Summary

- tighten release/install validation so cargo and curl are explicitly documented and enforced as the current non-manual channels
- keep Homebrew and npm in prep-only/gated state with stronger validator checks and no tap/npm/secrets/publish wiring
- refresh v0 release-readiness wording so #101 is treated as first-release evidence, not as stale pre-Gate-1 wording

## Test plan

- [x] `bash tests/install-smoke-validate.sh`
- [x] `bash tests/release-security-validate.sh`
- [x] `bash tests/release-readiness-matrix-validate.sh`
- [x] `git diff --check`
- [ ] `bash tests/release-readiness-local-kits-validate.sh` in this shell (`cargo` is not installed in the current environment)

## Screenshots / terminal output

N/A

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- The new assertions intentionally preserve #51/#52 as open prep-only issues: no tap repo setup, no npm org/package setup, no secrets, no publish wiring.
