### PR TITLE
feat(core): add color/contrast-aa rule

### DIFF
--- a/crates/plumb-core/src/rules/color/contrast_aa.rs
+++ b/crates/plumb-core/src/rules/color/contrast_aa.rs
@@ -1,0 +1,407 @@
+//! `color/contrast-aa` — enforce WCAG 2.1 AA text contrast from
+//! existing computed styles only.
+//!
+//! The rule pairs a node's computed `color`, `font-size`,
+//! optional `font-weight`, and the nearest composited
+//! `background-color` in the DOM ancestor chain.
+//!
+//! Thresholds follow WCAG 2.1 AA:
+//!
+//! - normal text: 4.5:1 minimum,
+//! - large text: 3.0:1 minimum,
+//! - "large" means at least 24px regular or 18.5px bold.
+
+use indexmap::IndexMap;
+use palette::{LinSrgb, Srgb};
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::rules::util::{CssColor, parse_css_color, parse_px};
+use crate::snapshot::{PlumbSnapshot, SnapshotCtx, SnapshotNode};
+
+const DEFAULT_BACKGROUND: CssColor = CssColor {
+    r: 1.0,
+    g: 1.0,
+    b: 1.0,
+    a: 1.0,
+};
+
+const FOREGROUND_COLOR: &str = "color";
+const BACKGROUND_COLOR: &str = "background-color";
+const FONT_SIZE: &str = "font-size";
+const FONT_WEIGHT: &str = "font-weight";
+
+const NORMAL_TEXT_MIN_RATIO: f64 = 4.5;
+const LARGE_TEXT_MIN_RATIO: f64 = 3.0;
+const LARGE_TEXT_MIN_PX: f64 = 24.0;
+const LARGE_BOLD_TEXT_MIN_PX: f64 = 18.5;
+const BOLD_WEIGHT_MIN: u16 = 700;
+
+/// Flags text whose computed foreground/background contrast misses the
+/// WCAG 2.1 AA threshold for its size class.
+#[derive(Debug, Clone, Copy)]
+pub struct ContrastAa;
+
+impl Rule for ContrastAa {
+    fn id(&self) -> &'static str {
+        "color/contrast-aa"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags text whose computed foreground/background contrast misses WCAG 2.1 AA."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let snapshot = ctx.snapshot();
+        let parents = parent_index(snapshot);
+
+        for node in ctx.nodes() {
+            if let Some(violation) = violation_for_node(ctx, config, snapshot, &parents, node) {
+                sink.push(violation);
+            }
+        }
+    }
+}
+
+fn violation_for_node(
+    ctx: &SnapshotCtx<'_>,
+    config: &Config,
+    snapshot: &PlumbSnapshot,
+    parents: &IndexMap<u64, u64>,
+    node: &SnapshotNode,
+) -> Option<Violation> {
+    let raw_foreground = node.computed_styles.get(FOREGROUND_COLOR)?;
+    let foreground = parse_css_color(raw_foreground)?;
+    if foreground.a <= 0.0 {
+        return None;
+    }
+
+    let raw_font_size = node.computed_styles.get(FONT_SIZE)?;
+    let font_size_px = parse_px(raw_font_size)?;
+    if !font_size_px.is_finite() || font_size_px <= 0.0 {
+        return None;
+    }
+
+    let font_weight = node
+        .computed_styles
+        .get(FONT_WEIGHT)
+        .and_then(|raw| parse_font_weight(raw));
+    let is_large = classify_large_text(font_size_px, font_weight);
+    let required_ratio = required_ratio(config, is_large);
+    let background = resolve_background(snapshot, parents, node);
+    let effective_foreground = if (foreground.a - 1.0).abs() < f32::EPSILON {
+        foreground
+    } else {
+        composite_over(foreground, background)
+    };
+    let measured_ratio = contrast_ratio(effective_foreground, background);
+    if measured_ratio >= required_ratio {
+        return None;
+    }
+
+    Some(Violation {
+        rule_id: "color/contrast-aa".to_owned(),
+        severity: Severity::Warning,
+        message: violation_message(node, measured_ratio, required_ratio, is_large),
+        selector: node.selector.clone(),
+        viewport: snapshot.viewport.clone(),
+        rect: ctx.rect_for(node.dom_order),
+        dom_order: node.dom_order,
+        fix: Some(Fix {
+            kind: FixKind::Description {
+                text: fix_text(required_ratio, is_large),
+            },
+            description: format!(
+                "Raise `{selector}` to the WCAG 2.1 AA contrast floor.",
+                selector = node.selector,
+            ),
+            confidence: Confidence::Low,
+        }),
+        doc_url: "https://plumb.aramhammoudeh.com/rules/color-contrast-aa".to_owned(),
+        metadata: build_metadata(
+            node,
+            raw_foreground,
+            measured_ratio,
+            required_ratio,
+            font_size_px,
+            is_large,
+        ),
+    })
+}
+
+fn classify_large_text(font_size_px: f64, font_weight: Option<u16>) -> bool {
+    if font_size_px >= LARGE_TEXT_MIN_PX {
+        return true;
+    }
+    font_size_px >= LARGE_BOLD_TEXT_MIN_PX && font_weight.is_some_and(is_bold_weight)
+}
+
+fn is_bold_weight(weight: u16) -> bool {
+    weight >= BOLD_WEIGHT_MIN
+}
+
+fn parse_font_weight(raw: &str) -> Option<u16> {
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("normal") {
+        return Some(400);
+    }
+    if trimmed.eq_ignore_ascii_case("bold") {
+        return Some(700);
+    }
+    if trimmed.eq_ignore_ascii_case("bolder") {
+        return Some(700);
+    }
+    if trimmed.eq_ignore_ascii_case("lighter") {
+        return Some(300);
+    }
+    trimmed.parse::<u16>().ok()
+}
+
+fn contrast_ratio(foreground: CssColor, background: CssColor) -> f64 {
+    let fg_luminance = relative_luminance(foreground);
+    let bg_luminance = relative_luminance(background);
+    let lighter = fg_luminance.max(bg_luminance);
+    let darker = fg_luminance.min(bg_luminance);
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+fn relative_luminance(color: CssColor) -> f64 {
+    let linear: LinSrgb<f32> = Srgb::new(color.r, color.g, color.b).into_linear();
+    0.0722f64.mul_add(
+        f64::from(linear.blue),
+        0.2126f64.mul_add(f64::from(linear.red), 0.7152 * f64::from(linear.green)),
+    )
+}
+
+fn parent_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, u64> {
+    snapshot
+        .nodes
+        .iter()
+        .filter_map(|node| node.parent.map(|parent| (node.dom_order, parent)))
+        .collect()
+}
+
+fn node_by_dom_order(snapshot: &PlumbSnapshot, dom_order: u64) -> Option<&SnapshotNode> {
+    snapshot
+        .nodes
+        .iter()
+        .find(|node| node.dom_order == dom_order)
+}
+
+fn resolve_background(
+    snapshot: &PlumbSnapshot,
+    parents: &IndexMap<u64, u64>,
+    start: &SnapshotNode,
+) -> CssColor {
+    let mut layers = Vec::new();
+    let mut current = Some(start.dom_order);
+
+    while let Some(dom_order) = current {
+        let Some(node) = node_by_dom_order(snapshot, dom_order) else {
+            break;
+        };
+        if let Some(background) = node
+            .computed_styles
+            .get(BACKGROUND_COLOR)
+            .and_then(|raw| parse_css_color(raw))
+            && background.a > 0.0
+        {
+            let opaque = (background.a - 1.0).abs() < f32::EPSILON;
+            layers.push(background);
+            if opaque {
+                break;
+            }
+        }
+        current = parents.get(&dom_order).copied();
+    }
+
+    let mut backdrop = DEFAULT_BACKGROUND;
+    for layer in layers.iter().rev() {
+        backdrop = composite_over(*layer, backdrop);
+    }
+    backdrop
+}
+
+fn composite_over(src: CssColor, dst: CssColor) -> CssColor {
+    let src_linear: LinSrgb<f32> = Srgb::new(src.r, src.g, src.b).into_linear();
+    let dst_linear: LinSrgb<f32> = Srgb::new(dst.r, dst.g, dst.b).into_linear();
+    let alpha = src.a;
+    let inverse_alpha = 1.0 - alpha;
+    let blended = LinSrgb::new(
+        src_linear
+            .red
+            .mul_add(alpha, dst_linear.red * inverse_alpha),
+        src_linear
+            .green
+            .mul_add(alpha, dst_linear.green * inverse_alpha),
+        src_linear
+            .blue
+            .mul_add(alpha, dst_linear.blue * inverse_alpha),
+    );
+    let out: Srgb<f32> = Srgb::from_linear(blended);
+    CssColor {
+        r: out.red,
+        g: out.green,
+        b: out.blue,
+        a: 1.0,
+    }
+}
+
+fn rounded_json_number(value: f64) -> Option<serde_json::Value> {
+    let rounded = (value * 1000.0).round() / 1000.0;
+    serde_json::Number::from_f64(rounded).map(serde_json::Value::Number)
+}
+
+fn rounded_decimal_string(value: f64) -> String {
+    let rounded = (value * 1000.0).round() / 1000.0;
+    format!("{rounded:.3}")
+}
+
+fn required_ratio(config: &Config, is_large: bool) -> f64 {
+    let mut ratio = if is_large {
+        LARGE_TEXT_MIN_RATIO
+    } else {
+        NORMAL_TEXT_MIN_RATIO
+    };
+    if let Some(min_ratio) = config.a11y.min_contrast_ratio
+        && min_ratio.is_finite()
+        && min_ratio > 0.0
+    {
+        ratio = ratio.max(f64::from(min_ratio));
+    }
+    ratio
+}
+
+fn violation_message(
+    node: &SnapshotNode,
+    measured_ratio: f64,
+    required_ratio: f64,
+    is_large: bool,
+) -> String {
+    format!(
+        "`{selector}` has contrast ratio {ratio}:1; WCAG 2.1 AA requires at least {required}:1 for {kind} text.",
+        selector = node.selector,
+        ratio = rounded_decimal_string(measured_ratio),
+        required = rounded_decimal_string(required_ratio),
+        kind = if is_large { "large" } else { "normal" },
+    )
+}
+
+fn fix_text(required_ratio: f64, is_large: bool) -> String {
+    format!(
+        "Increase the foreground/background contrast to at least {}:1 for this {} text.",
+        rounded_decimal_string(required_ratio),
+        if is_large { "large" } else { "normal" },
+    )
+}
+
+fn build_metadata(
+    node: &SnapshotNode,
+    raw_foreground: &str,
+    measured_ratio: f64,
+    required_ratio: f64,
+    font_size_px: f64,
+    is_large: bool,
+) -> IndexMap<String, serde_json::Value> {
+    let mut metadata = IndexMap::new();
+    metadata.insert(
+        "contrast_ratio".to_owned(),
+        rounded_json_number(measured_ratio).unwrap_or(serde_json::Value::Null),
+    );
+    metadata.insert(
+        "required_ratio".to_owned(),
+        rounded_json_number(required_ratio).unwrap_or(serde_json::Value::Null),
+    );
+    metadata.insert(
+        "font_size_px".to_owned(),
+        rounded_json_number(font_size_px).unwrap_or(serde_json::Value::Null),
+    );
+    metadata.insert("large_text".to_owned(), serde_json::Value::Bool(is_large));
+    metadata.insert(
+        "foreground_color".to_owned(),
+        serde_json::Value::String(raw_foreground.to_owned()),
+    );
+    if let Some(raw_weight) = node.computed_styles.get(FONT_WEIGHT) {
+        metadata.insert(
+            "font_weight".to_owned(),
+            serde_json::Value::String(raw_weight.clone()),
+        );
+    }
+    metadata
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CssColor, LARGE_BOLD_TEXT_MIN_PX, LARGE_TEXT_MIN_PX, classify_large_text, composite_over,
+        contrast_ratio, is_bold_weight, parse_font_weight,
+    };
+
+    #[test]
+    fn classifies_large_text_per_wcag_thresholds() {
+        assert!(classify_large_text(LARGE_TEXT_MIN_PX, Some(400)));
+        assert!(!classify_large_text(LARGE_TEXT_MIN_PX - 0.1, Some(400)));
+        assert!(classify_large_text(LARGE_BOLD_TEXT_MIN_PX, Some(700)));
+        assert!(!classify_large_text(
+            LARGE_BOLD_TEXT_MIN_PX - 0.1,
+            Some(700)
+        ));
+    }
+
+    #[test]
+    fn bold_weight_threshold_is_700() {
+        assert!(!is_bold_weight(600));
+        assert!(is_bold_weight(700));
+        assert!(is_bold_weight(900));
+    }
+
+    #[test]
+    fn parse_font_weight_handles_keywords_and_numbers() {
+        assert_eq!(parse_font_weight("normal"), Some(400));
+        assert_eq!(parse_font_weight("bold"), Some(700));
+        assert_eq!(parse_font_weight("700"), Some(700));
+        assert_eq!(parse_font_weight("garbage"), None);
+    }
+
+    #[test]
+    fn contrast_ratio_matches_wcag_reference_pairs() {
+        let black = CssColor {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        };
+        let white = CssColor {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
+        };
+        let ratio = contrast_ratio(black, white);
+        assert!((ratio - 21.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn composite_over_returns_opaque_color() {
+        let translucent_black = CssColor {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0.5,
+        };
+        let white = CssColor {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
+        };
+        let composited = composite_over(translucent_black, white);
+        assert!((composited.a - 1.0).abs() < 1e-6);
+        assert!(composited.r > 0.5 && composited.r < 0.85);
+    }
+}

--- a/crates/plumb-core/src/rules/color/contrast_aa.rs
+++ b/crates/plumb-core/src/rules/color/contrast_aa.rs
@@ -9,7 +9,8 @@
 //!
 //! - normal text: 4.5:1 minimum,
 //! - large text: 3.0:1 minimum,
-//! - "large" means at least 24px regular or 18.5px bold.
+//! - "large" means at least 24px regular or 14pt bold
+//!   (`14.0 * 96.0 / 72.0` CSS px).
 
 use indexmap::IndexMap;
 use palette::{LinSrgb, Srgb};
@@ -35,7 +36,7 @@ const FONT_WEIGHT: &str = "font-weight";
 const NORMAL_TEXT_MIN_RATIO: f64 = 4.5;
 const LARGE_TEXT_MIN_RATIO: f64 = 3.0;
 const LARGE_TEXT_MIN_PX: f64 = 24.0;
-const LARGE_BOLD_TEXT_MIN_PX: f64 = 18.5;
+const LARGE_BOLD_TEXT_MIN_PX: f64 = 14.0 * 96.0 / 72.0;
 const BOLD_WEIGHT_MIN: u16 = 700;
 
 /// Flags text whose computed foreground/background contrast misses the
@@ -59,9 +60,12 @@ impl Rule for ContrastAa {
     fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
         let snapshot = ctx.snapshot();
         let parents = parent_index(snapshot);
+        let nodes_by_dom_order = nodes_by_dom_order(snapshot);
 
         for node in ctx.nodes() {
-            if let Some(violation) = violation_for_node(ctx, config, snapshot, &parents, node) {
+            if let Some(violation) =
+                violation_for_node(ctx, config, snapshot, &parents, &nodes_by_dom_order, node)
+            {
                 sink.push(violation);
             }
         }
@@ -73,6 +77,7 @@ fn violation_for_node(
     config: &Config,
     snapshot: &PlumbSnapshot,
     parents: &IndexMap<u64, u64>,
+    nodes_by_dom_order: &IndexMap<u64, &SnapshotNode>,
     node: &SnapshotNode,
 ) -> Option<Violation> {
     let raw_foreground = node.computed_styles.get(FOREGROUND_COLOR)?;
@@ -93,7 +98,7 @@ fn violation_for_node(
         .and_then(|raw| parse_font_weight(raw));
     let is_large = classify_large_text(font_size_px, font_weight);
     let required_ratio = required_ratio(config, is_large);
-    let background = resolve_background(snapshot, parents, node);
+    let background = resolve_background(parents, nodes_by_dom_order, node);
     let effective_foreground = if (foreground.a - 1.0).abs() < f32::EPSILON {
         foreground
     } else {
@@ -153,11 +158,8 @@ fn parse_font_weight(raw: &str) -> Option<u16> {
     if trimmed.eq_ignore_ascii_case("bold") {
         return Some(700);
     }
-    if trimmed.eq_ignore_ascii_case("bolder") {
-        return Some(700);
-    }
-    if trimmed.eq_ignore_ascii_case("lighter") {
-        return Some(300);
+    if trimmed.eq_ignore_ascii_case("bolder") || trimmed.eq_ignore_ascii_case("lighter") {
+        return None;
     }
     trimmed.parse::<u16>().ok()
 }
@@ -186,23 +188,24 @@ fn parent_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, u64> {
         .collect()
 }
 
-fn node_by_dom_order(snapshot: &PlumbSnapshot, dom_order: u64) -> Option<&SnapshotNode> {
+fn nodes_by_dom_order(snapshot: &PlumbSnapshot) -> IndexMap<u64, &SnapshotNode> {
     snapshot
         .nodes
         .iter()
-        .find(|node| node.dom_order == dom_order)
+        .map(|node| (node.dom_order, node))
+        .collect()
 }
 
 fn resolve_background(
-    snapshot: &PlumbSnapshot,
     parents: &IndexMap<u64, u64>,
+    nodes_by_dom_order: &IndexMap<u64, &SnapshotNode>,
     start: &SnapshotNode,
 ) -> CssColor {
     let mut layers = Vec::new();
     let mut current = Some(start.dom_order);
 
     while let Some(dom_order) = current {
-        let Some(node) = node_by_dom_order(snapshot, dom_order) else {
+        let Some(node) = nodes_by_dom_order.get(&dom_order).copied() else {
             break;
         };
         if let Some(background) = node
@@ -348,9 +351,10 @@ mod tests {
         assert!(!classify_large_text(LARGE_TEXT_MIN_PX - 0.1, Some(400)));
         assert!(classify_large_text(LARGE_BOLD_TEXT_MIN_PX, Some(700)));
         assert!(!classify_large_text(
-            LARGE_BOLD_TEXT_MIN_PX - 0.1,
+            LARGE_BOLD_TEXT_MIN_PX - 0.001,
             Some(700)
         ));
+        assert!(!classify_large_text(18.6, Some(700)));
     }
 
     #[test]
@@ -364,6 +368,8 @@ mod tests {
     fn parse_font_weight_handles_keywords_and_numbers() {
         assert_eq!(parse_font_weight("normal"), Some(400));
         assert_eq!(parse_font_weight("bold"), Some(700));
+        assert_eq!(parse_font_weight("bolder"), None);
+        assert_eq!(parse_font_weight("lighter"), None);
         assert_eq!(parse_font_weight("700"), Some(700));
         assert_eq!(parse_font_weight("garbage"), None);
     }

--- a/crates/plumb-core/src/rules/color/mod.rs
+++ b/crates/plumb-core/src/rules/color/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! Currently:
 //!
+//! - [`contrast_aa`] — enforce WCAG 2.1 AA text contrast from
+//!   existing computed styles.
 //! - [`palette_conformance`] — flag computed colors that aren't on the
 //!   configured palette, measured by CIEDE2000 (ΔE00) in CIE Lab space.
 
+pub mod contrast_aa;
 pub mod palette_conformance;
 
 /// Computed-style properties this category inspects.

--- a/crates/plumb-core/src/rules/mod.rs
+++ b/crates/plumb-core/src/rules/mod.rs
@@ -84,6 +84,7 @@ pub trait Rule: Send + Sync {
 pub fn register_builtin() -> Vec<Box<dyn Rule>> {
     vec![
         Box::new(a11y::touch_target::TouchTarget),
+        Box::new(color::contrast_aa::ContrastAa),
         Box::new(color::palette_conformance::PaletteConformance),
         Box::new(edge::near_alignment::NearAlignment),
         Box::new(radius::scale_conformance::ScaleConformance),

--- a/crates/plumb-core/tests/golden_color_contrast_aa.rs
+++ b/crates/plumb-core/tests/golden_color_contrast_aa.rs
@@ -7,6 +7,7 @@
 //! - large 24px text that passes the relaxed 3.0:1 threshold,
 //! - bold 18px text that still counts as normal (below the 14pt-bold cutoff),
 //! - bold 19px text that counts as large,
+//! - bold 18.6px text that still counts as normal under the precise 14pt cutoff,
 //! - text inside a dark section whose nearest ancestor background is not white.
 
 use indexmap::IndexMap;
@@ -66,6 +67,17 @@ fn fixture_snapshot() -> PlumbSnapshot {
                 Some(rect(0, 140, 320, 30)),
                 1,
             ),
+            text_node(
+                9,
+                "html > body > div:nth-child(6)",
+                &[
+                    ("color", "rgb(148, 148, 148)"),
+                    ("font-size", "18.6px"),
+                    ("font-weight", "700"),
+                ],
+                Some(rect(0, 176, 320, 30)),
+                1,
+            ),
             section_node(),
             text_node(
                 8,
@@ -73,6 +85,13 @@ fn fixture_snapshot() -> PlumbSnapshot {
                 &[("color", "rgb(120, 120, 120)"), ("font-size", "16px")],
                 Some(rect(0, 212, 320, 24)),
                 7,
+            ),
+            text_node(
+                10,
+                "html > body > div:nth-child(7)",
+                &[("color", "rgb(110, 110, 110)"), ("font-size", "16px")],
+                Some(rect(0, 248, 320, 24)),
+                1,
             ),
         ],
     }
@@ -111,7 +130,7 @@ fn body_node() -> SnapshotNode {
         computed_styles,
         rect: Some(rect(0, 0, 1280, 800)),
         parent: Some(0),
-        children: vec![2, 3, 4, 5, 6, 7],
+        children: vec![2, 3, 4, 5, 6, 7, 9, 10],
     }
 }
 
@@ -176,4 +195,39 @@ fn color_contrast_aa_run_is_deterministic() -> Result<(), serde_json::Error> {
     assert_eq!(a, b);
     assert_eq!(b, c);
     Ok(())
+}
+
+#[test]
+fn color_contrast_aa_obeys_configured_min_ratio() {
+    let snapshot = fixture_snapshot();
+    assert!(
+        !run(&snapshot, &Config::default())
+            .into_iter()
+            .filter(|violation| violation.rule_id == "color/contrast-aa")
+            .map(|violation| violation.selector)
+            .any(|selector| selector == "html > body > div:nth-child(7)")
+    );
+
+    let mut config = Config::default();
+    config.a11y.min_contrast_ratio = Some(7.0);
+    assert!(
+        run(&snapshot, &config)
+            .into_iter()
+            .filter(|violation| violation.rule_id == "color/contrast-aa")
+            .map(|violation| violation.selector)
+            .any(|selector| selector == "html > body > div:nth-child(7)")
+    );
+}
+
+#[test]
+fn color_contrast_aa_uses_precise_bold_large_text_cutoff() {
+    let snapshot = fixture_snapshot();
+    let selectors: Vec<String> = run(&snapshot, &Config::default())
+        .into_iter()
+        .filter(|violation| violation.rule_id == "color/contrast-aa")
+        .map(|violation| violation.selector)
+        .collect();
+
+    assert!(selectors.contains(&"html > body > div:nth-child(6)".to_owned()));
+    assert!(!selectors.contains(&"html > body > div:nth-child(5)".to_owned()));
 }

--- a/crates/plumb-core/tests/golden_color_contrast_aa.rs
+++ b/crates/plumb-core/tests/golden_color_contrast_aa.rs
@@ -1,0 +1,179 @@
+//! Golden snapshot for the `color/contrast-aa` rule.
+//!
+//! The fixture covers the key WCAG AA branches:
+//!
+//! - normal 16px body text that passes comfortably,
+//! - normal 16px text that fails the 4.5:1 threshold,
+//! - large 24px text that passes the relaxed 3.0:1 threshold,
+//! - bold 18px text that still counts as normal (below the 14pt-bold cutoff),
+//! - bold 19px text that counts as large,
+//! - text inside a dark section whose nearest ancestor background is not white.
+
+use indexmap::IndexMap;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    PlumbSnapshot {
+        url: "plumb-fake://color-contrast-aa".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![
+            root_html(),
+            body_node(),
+            text_node(
+                2,
+                "html > body > div:nth-child(1)",
+                &[("color", "rgb(0, 0, 0)"), ("font-size", "16px")],
+                Some(rect(0, 0, 320, 24)),
+                1,
+            ),
+            text_node(
+                3,
+                "html > body > div:nth-child(2)",
+                &[("color", "rgb(119, 119, 119)"), ("font-size", "16px")],
+                Some(rect(0, 32, 320, 24)),
+                1,
+            ),
+            text_node(
+                4,
+                "html > body > div:nth-child(3)",
+                &[("color", "rgb(148, 148, 148)"), ("font-size", "24px")],
+                Some(rect(0, 64, 320, 32)),
+                1,
+            ),
+            text_node(
+                5,
+                "html > body > div:nth-child(4)",
+                &[
+                    ("color", "rgb(148, 148, 148)"),
+                    ("font-size", "18px"),
+                    ("font-weight", "700"),
+                ],
+                Some(rect(0, 104, 320, 28)),
+                1,
+            ),
+            text_node(
+                6,
+                "html > body > div:nth-child(5)",
+                &[
+                    ("color", "rgb(148, 148, 148)"),
+                    ("font-size", "19px"),
+                    ("font-weight", "700"),
+                ],
+                Some(rect(0, 140, 320, 30)),
+                1,
+            ),
+            section_node(),
+            text_node(
+                8,
+                "html > body > section > p",
+                &[("color", "rgb(120, 120, 120)"), ("font-size", "16px")],
+                Some(rect(0, 212, 320, 24)),
+                7,
+            ),
+        ],
+    }
+}
+
+const fn rect(x: i32, y: i32, width: u32, height: u32) -> Rect {
+    Rect {
+        x,
+        y,
+        width,
+        height,
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(rect(0, 0, 1280, 800)),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    computed_styles.insert("background-color".into(), "rgb(255, 255, 255)".into());
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect: Some(rect(0, 0, 1280, 800)),
+        parent: Some(0),
+        children: vec![2, 3, 4, 5, 6, 7],
+    }
+}
+
+fn section_node() -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    computed_styles.insert("background-color".into(), "rgb(34, 34, 34)".into());
+    SnapshotNode {
+        dom_order: 7,
+        selector: "html > body > section".into(),
+        tag: "section".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect: Some(rect(0, 180, 400, 80)),
+        parent: Some(1),
+        children: vec![8],
+    }
+}
+
+fn text_node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+    parent: u64,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (property, value) in styles {
+        computed_styles.insert((*property).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(parent),
+        children: Vec::new(),
+    }
+}
+
+#[test]
+fn color_contrast_aa_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = Config::default();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|violation| violation.rule_id == "color/contrast-aa")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("color_contrast_aa", json);
+    Ok(())
+}
+
+#[test]
+fn color_contrast_aa_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = Config::default();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/snapshots/golden_color_contrast_aa__color_contrast_aa.snap
+++ b/crates/plumb-core/tests/snapshots/golden_color_contrast_aa__color_contrast_aa.snap
@@ -1,0 +1,98 @@
+---
+source: crates/plumb-core/tests/golden_color_contrast_aa.rs
+assertion_line: 165
+expression: json
+---
+[
+  {
+    "rule_id": "color/contrast-aa",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` has contrast ratio 4.478:1; WCAG 2.1 AA requires at least 4.500:1 for normal text.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 32,
+      "width": 320,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Increase the foreground/background contrast to at least 4.500:1 for this normal text."
+      },
+      "description": "Raise `html > body > div:nth-child(2)` to the WCAG 2.1 AA contrast floor.",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+    "metadata": {
+      "contrast_ratio": 4.478,
+      "required_ratio": 4.5,
+      "font_size_px": 16.0,
+      "large_text": false,
+      "foreground_color": "rgb(119, 119, 119)"
+    }
+  },
+  {
+    "rule_id": "color/contrast-aa",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(4)` has contrast ratio 3.033:1; WCAG 2.1 AA requires at least 4.500:1 for normal text.",
+    "selector": "html > body > div:nth-child(4)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 104,
+      "width": 320,
+      "height": 28
+    },
+    "dom_order": 5,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Increase the foreground/background contrast to at least 4.500:1 for this normal text."
+      },
+      "description": "Raise `html > body > div:nth-child(4)` to the WCAG 2.1 AA contrast floor.",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+    "metadata": {
+      "contrast_ratio": 3.033,
+      "required_ratio": 4.5,
+      "font_size_px": 18.0,
+      "large_text": false,
+      "foreground_color": "rgb(148, 148, 148)",
+      "font_weight": "700"
+    }
+  },
+  {
+    "rule_id": "color/contrast-aa",
+    "severity": "warning",
+    "message": "`html > body > section > p` has contrast ratio 3.604:1; WCAG 2.1 AA requires at least 4.500:1 for normal text.",
+    "selector": "html > body > section > p",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 212,
+      "width": 320,
+      "height": 24
+    },
+    "dom_order": 8,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Increase the foreground/background contrast to at least 4.500:1 for this normal text."
+      },
+      "description": "Raise `html > body > section > p` to the WCAG 2.1 AA contrast floor.",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+    "metadata": {
+      "contrast_ratio": 3.604,
+      "required_ratio": 4.5,
+      "font_size_px": 16.0,
+      "large_text": false,
+      "foreground_color": "rgb(120, 120, 120)"
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_color_contrast_aa__color_contrast_aa.snap
+++ b/crates/plumb-core/tests/snapshots/golden_color_contrast_aa__color_contrast_aa.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/plumb-core/tests/golden_color_contrast_aa.rs
-assertion_line: 165
 expression: json
 ---
 [
@@ -60,6 +59,37 @@ expression: json
       "contrast_ratio": 3.033,
       "required_ratio": 4.5,
       "font_size_px": 18.0,
+      "large_text": false,
+      "foreground_color": "rgb(148, 148, 148)",
+      "font_weight": "700"
+    }
+  },
+  {
+    "rule_id": "color/contrast-aa",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(6)` has contrast ratio 3.033:1; WCAG 2.1 AA requires at least 4.500:1 for normal text.",
+    "selector": "html > body > div:nth-child(6)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 176,
+      "width": 320,
+      "height": 30
+    },
+    "dom_order": 9,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Increase the foreground/background contrast to at least 4.500:1 for this normal text."
+      },
+      "description": "Raise `html > body > div:nth-child(6)` to the WCAG 2.1 AA contrast floor.",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+    "metadata": {
+      "contrast_ratio": 3.033,
+      "required_ratio": 4.5,
+      "font_size_px": 18.6,
       "large_text": false,
       "foreground_color": "rgb(148, 148, 148)",
       "font_weight": "700"

--- a/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
@@ -27,6 +27,20 @@ expression: out
               }
             },
             {
+              "id": "color/contrast-aa",
+              "name": "color-contrast-aa",
+              "shortDescription": {
+                "text": "Flags text whose computed foreground/background contrast misses WCAG 2.1 AA."
+              },
+              "fullDescription": {
+                "text": "Flags text whose computed foreground/background contrast misses WCAG 2.1 AA."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
               "id": "color/palette-conformance",
               "name": "color-palette-conformance",
               "shortDescription": {
@@ -159,7 +173,7 @@ expression: out
           "properties": {
             "docUrl": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
           },
-          "ruleIndex": 5
+          "ruleIndex": 6
         }
       ]
     }

--- a/crates/plumb-mcp/src/explain.rs
+++ b/crates/plumb-mcp/src/explain.rs
@@ -34,6 +34,10 @@ pub(crate) const RULE_DOCS: &[RuleDoc] = &[
         markdown: include_str!("../../../docs/src/rules/a11y-touch-target.md"),
     },
     RuleDoc {
+        rule_id: "color/contrast-aa",
+        markdown: include_str!("../../../docs/src/rules/color-contrast-aa.md"),
+    },
+    RuleDoc {
         rule_id: "color/palette-conformance",
         markdown: include_str!("../../../docs/src/rules/color-palette-conformance.md"),
     },

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -32,6 +32,7 @@
 
 - [Overview](./rules/overview.md)
 - [a11y/touch-target](./rules/a11y-touch-target.md)
+- [color/contrast-aa](./rules/color-contrast-aa.md)
 - [color/palette-conformance](./rules/color-palette-conformance.md)
 - [edge/near-alignment](./rules/edge-near-alignment.md)
 - [radius/scale-conformance](./rules/radius-scale-conformance.md)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -126,8 +126,7 @@ delta_e_tolerance = 2.0
 | `tokens` | `{string => hex}` | `{}` | Named palette colors. Slash-delimited names group by prefix in diagnostics. |
 | `delta_e_tolerance` | `f32` | `2.0` | CIEDE2000 ΔE threshold for `color/palette-conformance`. |
 
-Consumed by `color/palette-conformance` (and the contrast rule, which
-reads `[a11y].min_contrast_ratio`).
+Consumed by `color/palette-conformance`.
 
 ## `[radius]`
 
@@ -173,11 +172,11 @@ min_height_px = 24
 
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
-| `min_contrast_ratio` | `f32?` | `null` | WCAG contrast ratio target. Set `4.5` for AA body text, `7.0` for AAA. |
+| `min_contrast_ratio` | `f32?` | `null` | Optional stricter global floor for `color/contrast-aa`. The rule still keeps WCAG AA's built-in `4.5:1` normal / `3.0:1` large defaults. |
 | `touch_target.min_width_px` | `u32` | `24` | Minimum touch-target width per WCAG 2.5.8. Raise to `44` for AAA. |
 | `touch_target.min_height_px` | `u32` | `24` | Minimum touch-target height. |
 
-Consumed by `a11y/touch-target` and the contrast rule.
+Consumed by `a11y/touch-target` and `color/contrast-aa`.
 
 ## `[rules."<category>/<id>"]`
 

--- a/docs/src/rules/color-contrast-aa.md
+++ b/docs/src/rules/color-contrast-aa.md
@@ -1,0 +1,131 @@
+# color/contrast-aa
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads these computed styles:
+
+- `color`
+- `font-size`
+- `font-weight` (optional; only needed for the bold large-text cutoff)
+- `background-color` on the node and its ancestors
+
+The rule parses the foreground color, resolves the node's effective
+background by compositing `background-color` layers up the DOM ancestor
+chain, then computes the WCAG contrast ratio from relative luminance.
+If the foreground itself has alpha, it is composited over the resolved
+background before the ratio is measured.
+
+WCAG 2.1 AA uses two floors:
+
+- normal text: `4.5:1`
+- large text: `3.0:1`
+
+Plumb classifies a node as large text when its computed `font-size` is
+at least `24px`, or at least `18.5px` with computed `font-weight >= 700`.
+That matches WCAG's 18pt regular / 14pt bold thresholds in CSS pixels.
+
+The rule MUST skip a node when:
+
+- `color` is missing, transparent, or not parseable as `rgb(...)`,
+  `rgba(...)`, `#rgb`, `#rrggbb`, `#rgba`, or `#rrggbbaa`;
+- `font-size` is missing, not parseable as a pixel value, or not
+  strictly positive;
+- the background chain contains unsupported color syntax only, in which
+  case the rule falls back to `#ffffff`, the User Agent default.
+
+At most one violation is emitted per node per viewport.
+
+## Why it matters
+
+Contrast failures are hard to spot in a token audit because the problem
+is relational: a text color can be valid on one surface and unreadable
+on another. WCAG AA is the baseline accessibility contract for body copy
+and large headings, and the large-text carveout matters because a ratio
+that fails 16px body text may still be readable at 24px.
+
+Using the nearest composited background keeps the rule grounded in what
+the user actually sees. A muted foreground over a white card is a
+different accessibility outcome from the same foreground over a dark
+panel.
+
+## Example violation
+
+```json
+{
+  "rule_id": "color/contrast-aa",
+  "severity": "warning",
+  "message": "`html > body > div:nth-child(2)` has contrast ratio 4.478:1; WCAG 2.1 AA requires at least 4.500:1 for normal text.",
+  "selector": "html > body > div:nth-child(2)",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "description",
+      "text": "Increase the foreground/background contrast to at least 4.500:1 for this normal text."
+    },
+    "description": "Raise `html > body > div:nth-child(2)` to the WCAG 2.1 AA contrast floor.",
+    "confidence": "low"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/color-contrast-aa",
+  "metadata": {
+    "contrast_ratio": 4.478,
+    "required_ratio": 4.5,
+    "font_size_px": 16.0,
+    "large_text": false,
+    "foreground_color": "rgb(119, 119, 119)"
+  }
+}
+```
+
+The `metadata` block carries the measured ratio, the active floor, and
+the size-class inputs so downstream tools can explain why the node was
+treated as normal or large text.
+
+## Configuration
+
+The rule has no required config. Its default behavior is fixed WCAG 2.1
+AA: `4.5:1` for normal text and `3.0:1` for large text.
+
+`a11y.min_contrast_ratio`, when set, acts as a stricter global floor.
+It can raise the threshold above the AA defaults; it does not lower them.
+
+```toml
+[a11y]
+min_contrast_ratio = 7.0
+```
+
+That example raises both normal and large text to `7.0:1`.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."color/contrast-aa"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."color/contrast-aa"]
+severity = "error"
+```
+
+`RuleOverride` accepts both `enabled` (default `true`) and an optional
+`severity` of `info`, `warning`, or `error`. Severity remapping is
+applied at the formatter layer.
+
+## See also
+
+- [`color/palette-conformance`](./color-palette-conformance.md) — checks
+  whether the colors themselves are on the configured palette.
+- [`type/scale-conformance`](./type-scale-conformance.md) — keeps text
+  size on the system scale.
+- [`a11y/touch-target`](./a11y-touch-target.md) — the other shipped
+  accessibility rule.
+- PRD §11.2 — built-in rule catalog.

--- a/docs/src/rules/color-contrast-aa.md
+++ b/docs/src/rules/color-contrast-aa.md
@@ -25,8 +25,8 @@ WCAG 2.1 AA uses two floors:
 - large text: `3.0:1`
 
 Plumb classifies a node as large text when its computed `font-size` is
-at least `24px`, or at least `18.5px` with computed `font-weight >= 700`.
-That matches WCAG's 18pt regular / 14pt bold thresholds in CSS pixels.
+at least `24px`, or at least `18.667px` with computed `font-weight >= 700`.
+That matches WCAG's `18pt` regular / `14pt` bold thresholds in CSS pixels.
 
 The rule MUST skip a node when:
 

--- a/docs/src/rules/overview.md
+++ b/docs/src/rules/overview.md
@@ -11,6 +11,8 @@ against each page snapshot. Every rule has:
 
 - [`a11y/touch-target`](./a11y-touch-target.md) — flags interactive
   elements smaller than `a11y.touch_target`.
+- [`color/contrast-aa`](./color-contrast-aa.md) — flags text whose
+  foreground/background contrast misses WCAG 2.1 AA.
 - [`color/palette-conformance`](./color-palette-conformance.md) —
   flags element colors that aren't members of the configured palette.
 - [`edge/near-alignment`](./edge-near-alignment.md) — flags element


### PR DESCRIPTION
## Spec

Closes #68

## Summary

- add `color/contrast-aa` in `plumb-core` with WCAG 2.1 AA thresholds, large-text classification, relative-luminance contrast math, and composited background resolution from existing computed styles only
- add a golden snapshot fixture plus rule-local unit tests that cover the 24px regular / 18.5px bold boundary and ancestor background resolution
- register the rule and wire its docs through the book index, summary, configuration reference, and MCP `explain_rule` table

## Validation

Confirmed in this environment:

- `cargo test -p plumb-core --test golden_color_contrast_aa --features test-fake -- --nocapture`
- `cargo test -p plumb-core --all-features`
- `cargo test -p plumb-mcp explain -- --nocapture`
- `cargo clippy -p plumb-core --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `git diff --check`

Environment blockers:

- `cargo test -p plumb-core` without `--all-features` fails in this repo because integration tests call `PlumbSnapshot::canned()`, which is gated behind `plumb-core/test-fake`
- `cargo xtask pre-release` fails here because Python lacks the `yaml` module required by the runbook validator
- `just validate` cannot run here because `just` is not installed

## Breaking change?

- [x] No
- [ ] Yes — describe the migration path

## Anything reviewers should double-check

- `a11y.min_contrast_ratio` now acts as a stricter global floor on top of WCAG AA defaults; the default behavior remains fixed at `4.5:1` for normal text and `3.0:1` for large text.
