### PR TITLE
feat(core): add phase 7 small rules bundle

### DIFF
--- a/crates/plumb-core/src/config.rs
+++ b/crates/plumb-core/src/config.rs
@@ -43,6 +43,22 @@ pub struct Config {
     #[serde(default)]
     pub alignment: AlignmentSpec,
 
+    /// Box-shadow spec.
+    #[serde(default)]
+    pub shadow: ShadowSpec,
+
+    /// Z-index spec.
+    #[serde(default)]
+    pub z_index: ZIndexSpec,
+
+    /// Opacity spec.
+    #[serde(default)]
+    pub opacity: OpacitySpec,
+
+    /// Vertical rhythm spec.
+    #[serde(default)]
+    pub rhythm: RhythmSpec,
+
     /// Accessibility spec.
     #[serde(default)]
     pub a11y: A11ySpec,
@@ -184,6 +200,64 @@ impl Default for AlignmentSpec {
             grid_columns: None,
             gutter_px: None,
             tolerance_px: default_alignment_tolerance_px(),
+        }
+    }
+}
+
+/// Box-shadow spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ShadowSpec {
+    /// Allowed box-shadow values. Each entry is a complete shadow
+    /// expression as returned by `getComputedStyle`.
+    #[serde(default)]
+    pub scale: Vec<String>,
+}
+
+/// Z-index spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ZIndexSpec {
+    /// Allowed z-index values.
+    #[serde(default)]
+    pub scale: Vec<i32>,
+}
+
+/// Opacity spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct OpacitySpec {
+    /// Allowed opacity values in the range `[0.0, 1.0]`.
+    #[serde(default)]
+    pub scale: Vec<f32>,
+}
+
+/// Vertical-rhythm spec (schema/defaults only -- rule lands in #73).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_field_names)]
+pub struct RhythmSpec {
+    /// Base line-height in pixels.
+    #[serde(default)]
+    pub base_line_px: u32,
+    /// Tolerance in pixels for rhythm checks.
+    #[serde(default = "default_rhythm_tolerance_px")]
+    pub tolerance_px: u32,
+    /// Cap-height fallback in pixels when font metrics are unavailable.
+    #[serde(default)]
+    pub cap_height_fallback_px: u32,
+}
+
+fn default_rhythm_tolerance_px() -> u32 {
+    2
+}
+
+impl Default for RhythmSpec {
+    fn default() -> Self {
+        Self {
+            base_line_px: 0,
+            tolerance_px: default_rhythm_tolerance_px(),
+            cap_height_fallback_px: 0,
         }
     }
 }

--- a/crates/plumb-core/src/rules/mod.rs
+++ b/crates/plumb-core/src/rules/mod.rs
@@ -11,10 +11,13 @@
 pub mod a11y;
 pub mod color;
 pub mod edge;
+pub mod opacity;
 pub mod radius;
+pub mod shadow;
 pub mod sibling;
 pub mod spacing;
 pub mod type_;
+pub mod z;
 
 mod util;
 
@@ -87,11 +90,17 @@ pub fn register_builtin() -> Vec<Box<dyn Rule>> {
         Box::new(color::contrast_aa::ContrastAa),
         Box::new(color::palette_conformance::PaletteConformance),
         Box::new(edge::near_alignment::NearAlignment),
+        Box::new(opacity::scale_conformance::ScaleConformance),
         Box::new(radius::scale_conformance::ScaleConformance),
+        Box::new(shadow::scale_conformance::ScaleConformance),
         Box::new(sibling::height_consistency::HeightConsistency),
+        Box::new(sibling::padding_consistency::PaddingConsistency),
         Box::new(spacing::grid_conformance::GridConformance),
         Box::new(spacing::scale_conformance::ScaleConformance),
+        Box::new(type_::family_conformance::FamilyConformance),
         Box::new(type_::scale_conformance::ScaleConformance),
+        Box::new(type_::weight_conformance::WeightConformance),
+        Box::new(z::scale_conformance::ScaleConformance),
     ]
 }
 

--- a/crates/plumb-core/src/rules/opacity/mod.rs
+++ b/crates/plumb-core/src/rules/opacity/mod.rs
@@ -1,0 +1,8 @@
+//! Opacity rules.
+//!
+//! Currently exposes:
+//!
+//! - [`scale_conformance`] — `opacity` values must be members of
+//!   `opacity.scale`.
+
+pub mod scale_conformance;

--- a/crates/plumb-core/src/rules/opacity/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/opacity/scale_conformance.rs
@@ -1,0 +1,110 @@
+//! `opacity/scale-conformance` — flag `opacity` values that aren't in
+//! `opacity.scale`.
+
+use indexmap::IndexMap;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::snapshot::SnapshotCtx;
+
+/// The single property this rule inspects.
+const OPACITY: &str = "opacity";
+
+/// Tolerance for matching against scale values.
+const OPACITY_TOLERANCE: f64 = 0.005;
+
+/// Flags `opacity` values that aren't in `opacity.scale`.
+#[derive(Debug, Clone, Copy)]
+pub struct ScaleConformance;
+
+impl Rule for ScaleConformance {
+    fn id(&self) -> &'static str {
+        "opacity/scale-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags `opacity` values that aren't in `opacity.scale`."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let scale = &config.opacity.scale;
+        if scale.is_empty() {
+            return;
+        }
+
+        for node in ctx.nodes() {
+            let Some(raw) = node.computed_styles.get(OPACITY) else {
+                continue;
+            };
+            let Ok(value) = raw.trim().parse::<f64>() else {
+                continue;
+            };
+
+            let matches = scale
+                .iter()
+                .any(|&s| (value - f64::from(s)).abs() < OPACITY_TOLERANCE);
+            if matches {
+                continue;
+            }
+
+            let nearest = nearest_opacity(value, scale);
+
+            let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
+            metadata.insert(
+                "opacity".to_owned(),
+                serde_json::Value::from(value),
+            );
+            metadata.insert(
+                "nearest".to_owned(),
+                serde_json::Value::from(f64::from(nearest)),
+            );
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` has off-scale opacity {value}; expected a value from opacity.scale.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: ctx.rect_for(node.dom_order),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::CssPropertyReplace {
+                        property: OPACITY.to_owned(),
+                        from: raw.clone(),
+                        to: format!("{nearest}"),
+                    },
+                    description: format!(
+                        "Snap `opacity` to the nearest scale value ({nearest}).",
+                    ),
+                    confidence: Confidence::Medium,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/opacity-scale-conformance"
+                    .to_owned(),
+                metadata,
+            });
+        }
+    }
+}
+
+/// Find the nearest opacity in the scale. Ties: lower value wins.
+#[allow(clippy::float_cmp)]
+fn nearest_opacity(value: f64, scale: &[f32]) -> f32 {
+    let mut best = scale[0];
+    let mut best_delta = (value - f64::from(best)).abs();
+    for &candidate in &scale[1..] {
+        let delta = (value - f64::from(candidate)).abs();
+        if delta < best_delta || (delta == best_delta && candidate < best) {
+            best = candidate;
+            best_delta = delta;
+        }
+    }
+    best
+}

--- a/crates/plumb-core/src/rules/opacity/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/opacity/scale_conformance.rs
@@ -55,10 +55,7 @@ impl Rule for ScaleConformance {
             let nearest = nearest_opacity(value, scale);
 
             let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
-            metadata.insert(
-                "opacity".to_owned(),
-                serde_json::Value::from(value),
-            );
+            metadata.insert("opacity".to_owned(), serde_json::Value::from(value));
             metadata.insert(
                 "nearest".to_owned(),
                 serde_json::Value::from(f64::from(nearest)),

--- a/crates/plumb-core/src/rules/shadow/mod.rs
+++ b/crates/plumb-core/src/rules/shadow/mod.rs
@@ -1,0 +1,8 @@
+//! Box-shadow rules.
+//!
+//! Currently exposes:
+//!
+//! - [`scale_conformance`] — `box-shadow` values must match a token in
+//!   `shadow.scale`.
+
+pub mod scale_conformance;

--- a/crates/plumb-core/src/rules/shadow/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/shadow/scale_conformance.rs
@@ -1,0 +1,76 @@
+//! `shadow/scale-conformance` — flag `box-shadow` values that aren't
+//! in `shadow.scale`.
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::snapshot::SnapshotCtx;
+
+/// The single property this rule inspects.
+const BOX_SHADOW: &str = "box-shadow";
+
+/// Flags `box-shadow` values that aren't in `shadow.scale`.
+#[derive(Debug, Clone, Copy)]
+pub struct ScaleConformance;
+
+impl Rule for ScaleConformance {
+    fn id(&self) -> &'static str {
+        "shadow/scale-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags `box-shadow` values that aren't in `shadow.scale`."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let scale = &config.shadow.scale;
+        if scale.is_empty() {
+            return;
+        }
+
+        for node in ctx.nodes() {
+            let Some(raw) = node.computed_styles.get(BOX_SHADOW) else {
+                continue;
+            };
+            let trimmed = raw.trim();
+            if trimmed.eq_ignore_ascii_case("none") {
+                continue;
+            }
+
+            let matches = scale.iter().any(|s| s.trim() == trimmed);
+            if matches {
+                continue;
+            }
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` has off-scale box-shadow `{trimmed}`; expected a value from shadow.scale.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: ctx.rect_for(node.dom_order),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::Description {
+                        text: format!(
+                            "The box-shadow value `{trimmed}` is not in the allowed shadow scale.",
+                        ),
+                    },
+                    description: "Replace `box-shadow` with one of the allowed shadow tokens."
+                        .to_owned(),
+                    confidence: Confidence::Medium,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/shadow-scale-conformance"
+                    .to_owned(),
+                metadata: indexmap::IndexMap::new(),
+            });
+        }
+    }
+}

--- a/crates/plumb-core/src/rules/sibling/mod.rs
+++ b/crates/plumb-core/src/rules/sibling/mod.rs
@@ -4,5 +4,8 @@
 //!
 //! - [`height_consistency`] — sibling elements that share a visual row
 //!   should also share a height.
+//! - [`padding_consistency`] — sibling elements should share consistent
+//!   padding values.
 
 pub mod height_consistency;
+pub mod padding_consistency;

--- a/crates/plumb-core/src/rules/sibling/padding_consistency.rs
+++ b/crates/plumb-core/src/rules/sibling/padding_consistency.rs
@@ -93,10 +93,7 @@ impl Rule for PaddingConsistency {
                         "sibling_median_px".to_owned(),
                         serde_json::Value::from(median),
                     );
-                    metadata.insert(
-                        "deviation_px".to_owned(),
-                        serde_json::Value::from(dev_u32),
-                    );
+                    metadata.insert("deviation_px".to_owned(), serde_json::Value::from(dev_u32));
 
                     sink.push(Violation {
                         rule_id: self.id().to_owned(),

--- a/crates/plumb-core/src/rules/sibling/padding_consistency.rs
+++ b/crates/plumb-core/src/rules/sibling/padding_consistency.rs
@@ -1,0 +1,147 @@
+//! `sibling/padding-consistency` — flag sibling elements with
+//! inconsistent padding.
+
+use indexmap::IndexMap;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::rules::util::parse_px;
+use crate::snapshot::SnapshotCtx;
+
+/// The padding longhands checked for consistency.
+const PADDING_PROPERTIES: &[&str] = &[
+    "padding-top",
+    "padding-right",
+    "padding-bottom",
+    "padding-left",
+];
+
+/// Padding this far from the sibling median (in CSS pixels) triggers a
+/// violation.
+const PADDING_DEVIATION_PX: u32 = 4;
+
+/// Flags sibling elements with inconsistent padding.
+#[derive(Debug, Clone, Copy)]
+pub struct PaddingConsistency;
+
+impl Rule for PaddingConsistency {
+    fn id(&self) -> &'static str {
+        "sibling/padding-consistency"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Info
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags sibling elements with inconsistent padding."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, _config: &Config, sink: &mut ViolationSink<'_>) {
+        // Group nodes by parent dom_order.
+        let mut groups: IndexMap<u64, Vec<usize>> = IndexMap::new();
+        for (idx, node) in ctx.snapshot().nodes.iter().enumerate() {
+            let Some(parent) = node.parent else { continue };
+            groups.entry(parent).or_default().push(idx);
+        }
+
+        let nodes = &ctx.snapshot().nodes;
+
+        for siblings in groups.values() {
+            if siblings.len() < 2 {
+                continue;
+            }
+
+            for prop in PADDING_PROPERTIES {
+                // Collect (index, parsed px value) for siblings that have
+                // the property and it parses.
+                let parsed: Vec<(usize, f64)> = siblings
+                    .iter()
+                    .filter_map(|&idx| {
+                        let raw = nodes[idx].computed_styles.get(*prop)?;
+                        let val = parse_px(raw)?;
+                        Some((idx, val))
+                    })
+                    .collect();
+
+                if parsed.len() < 2 {
+                    continue;
+                }
+
+                let median = median_f64(&parsed.iter().map(|(_, v)| *v).collect::<Vec<_>>());
+
+                for &(idx, val) in &parsed {
+                    let dev = (val - median).abs();
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let dev_u32 = dev.round() as u32;
+                    if dev_u32 <= PADDING_DEVIATION_PX {
+                        continue;
+                    }
+
+                    let node = &nodes[idx];
+                    let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
+                    metadata.insert(
+                        "property".to_owned(),
+                        serde_json::Value::String((*prop).to_owned()),
+                    );
+                    metadata.insert(
+                        "rendered_padding_px".to_owned(),
+                        serde_json::Value::from(val),
+                    );
+                    metadata.insert(
+                        "sibling_median_px".to_owned(),
+                        serde_json::Value::from(median),
+                    );
+                    metadata.insert(
+                        "deviation_px".to_owned(),
+                        serde_json::Value::from(dev_u32),
+                    );
+
+                    sink.push(Violation {
+                        rule_id: self.id().to_owned(),
+                        severity: self.default_severity(),
+                        message: format!(
+                            "`{selector}` has {prop} {val}px; sibling median is {median}px ({dev_u32}px drift).",
+                            selector = node.selector,
+                        ),
+                        selector: node.selector.clone(),
+                        viewport: ctx.snapshot().viewport.clone(),
+                        rect: ctx.rect_for(node.dom_order),
+                        dom_order: node.dom_order,
+                        fix: Some(Fix {
+                            kind: FixKind::Description {
+                                text: format!(
+                                    "Match sibling {prop} ({median}px) to keep padding consistent. Drift: {dev_u32}px.",
+                                ),
+                            },
+                            description: format!(
+                                "Bring `{selector}` {prop} in line with its siblings ({median}px).",
+                                selector = node.selector,
+                            ),
+                            confidence: Confidence::Low,
+                        }),
+                        doc_url: "https://plumb.aramhammoudeh.com/rules/sibling-padding-consistency"
+                            .to_owned(),
+                        metadata,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Median of a slice of f64 values.
+///
+/// For even counts, the lower of the two middle values wins (same
+/// deterministic tie-break as `sibling/height-consistency`).
+fn median_f64(values: &[f64]) -> f64 {
+    let mut sorted: Vec<f64> = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        sorted[mid - 1]
+    } else {
+        sorted[mid]
+    }
+}

--- a/crates/plumb-core/src/rules/type_/family_conformance.rs
+++ b/crates/plumb-core/src/rules/type_/family_conformance.rs
@@ -60,21 +60,26 @@ impl Rule for FamilyConformance {
                 .collect();
 
             // Check if ANY family in the list matches ANY allowed entry (case-insensitive).
-            let has_match = families.iter().any(|family| {
-                allowed
-                    .iter()
-                    .any(|a| a.eq_ignore_ascii_case(family))
-            });
+            let has_match = families
+                .iter()
+                .any(|family| allowed.iter().any(|a| a.eq_ignore_ascii_case(family)));
 
             if has_match {
                 continue;
             }
 
-            let allowed_json =
-                serde_json::Value::Array(allowed.iter().map(|s| serde_json::Value::String(s.clone())).collect());
+            let allowed_json = serde_json::Value::Array(
+                allowed
+                    .iter()
+                    .map(|s| serde_json::Value::String(s.clone()))
+                    .collect(),
+            );
 
             let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
-            metadata.insert("font_family".to_owned(), serde_json::Value::String(raw.clone()));
+            metadata.insert(
+                "font_family".to_owned(),
+                serde_json::Value::String(raw.clone()),
+            );
             metadata.insert("allowed_families".to_owned(), allowed_json);
 
             sink.push(Violation {

--- a/crates/plumb-core/src/rules/type_/family_conformance.rs
+++ b/crates/plumb-core/src/rules/type_/family_conformance.rs
@@ -1,0 +1,109 @@
+//! `type/family-conformance` — flag elements whose `font-family` is
+//! not in `type.families`.
+
+use indexmap::IndexMap;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::snapshot::SnapshotCtx;
+
+/// The single property this rule inspects.
+const FONT_FAMILY: &str = "font-family";
+
+/// Flags elements whose `font-family` is not in `type.families`.
+#[derive(Debug, Clone, Copy)]
+pub struct FamilyConformance;
+
+impl Rule for FamilyConformance {
+    fn id(&self) -> &'static str {
+        "type/family-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags elements whose `font-family` is not in `type.families`."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let allowed = &config.type_scale.families;
+        if allowed.is_empty() {
+            return;
+        }
+
+        for node in ctx.nodes() {
+            let Some(raw) = node.computed_styles.get(FONT_FAMILY) else {
+                continue;
+            };
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            // Parse comma-separated families, strip outer quotes.
+            let families: Vec<&str> = trimmed
+                .split(',')
+                .map(|f| {
+                    let s = f.trim();
+                    // Strip outer quotes (both " and ')
+                    if (s.starts_with('"') && s.ends_with('"'))
+                        || (s.starts_with('\'') && s.ends_with('\''))
+                    {
+                        &s[1..s.len() - 1]
+                    } else {
+                        s
+                    }
+                })
+                .collect();
+
+            // Check if ANY family in the list matches ANY allowed entry (case-insensitive).
+            let has_match = families.iter().any(|family| {
+                allowed
+                    .iter()
+                    .any(|a| a.eq_ignore_ascii_case(family))
+            });
+
+            if has_match {
+                continue;
+            }
+
+            let allowed_json =
+                serde_json::Value::Array(allowed.iter().map(|s| serde_json::Value::String(s.clone())).collect());
+
+            let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
+            metadata.insert("font_family".to_owned(), serde_json::Value::String(raw.clone()));
+            metadata.insert("allowed_families".to_owned(), allowed_json);
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` uses font-family `{raw}` which is not in type.families.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: ctx.rect_for(node.dom_order),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::Description {
+                        text: format!(
+                            "Use one of the allowed font families: {}.",
+                            allowed.join(", "),
+                        ),
+                    },
+                    description: format!(
+                        "Replace `font-family` with one of the allowed families ({}).",
+                        allowed.join(", "),
+                    ),
+                    confidence: Confidence::Medium,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/type-family-conformance".to_owned(),
+                metadata,
+            });
+        }
+    }
+}

--- a/crates/plumb-core/src/rules/type_/mod.rs
+++ b/crates/plumb-core/src/rules/type_/mod.rs
@@ -2,10 +2,16 @@
 //!
 //! Currently exposes:
 //!
+//! - [`family_conformance`] — `font-family` values must be members of
+//!   `type.families`.
 //! - [`scale_conformance`] — `font-size` values must be members of
 //!   `type.scale`.
+//! - [`weight_conformance`] — `font-weight` values must be members of
+//!   `type.weights`.
 //!
 //! `type` is a Rust keyword, so the module is `type_`. The rule id
-//! retains the canonical `type/scale-conformance` shape.
+//! retains the canonical `type/<id>` shape.
 
+pub mod family_conformance;
 pub mod scale_conformance;
+pub mod weight_conformance;

--- a/crates/plumb-core/src/rules/type_/weight_conformance.rs
+++ b/crates/plumb-core/src/rules/type_/weight_conformance.rs
@@ -1,0 +1,96 @@
+//! `type/weight-conformance` — flag elements whose `font-weight` is
+//! not in `type.weights`.
+
+use indexmap::IndexMap;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::snapshot::SnapshotCtx;
+
+/// The single property this rule inspects.
+const FONT_WEIGHT: &str = "font-weight";
+
+/// Flags elements whose `font-weight` is not in `type.weights`.
+#[derive(Debug, Clone, Copy)]
+pub struct WeightConformance;
+
+impl Rule for WeightConformance {
+    fn id(&self) -> &'static str {
+        "type/weight-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags elements whose `font-weight` is not in `type.weights`."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let weights = &config.type_scale.weights;
+        if weights.is_empty() {
+            return;
+        }
+
+        for node in ctx.nodes() {
+            let Some(raw) = node.computed_styles.get(FONT_WEIGHT) else {
+                continue;
+            };
+            let Ok(value) = raw.trim().parse::<u16>() else {
+                continue;
+            };
+
+            if weights.contains(&value) {
+                continue;
+            }
+
+            let nearest = nearest_weight(value, weights);
+
+            let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
+            metadata.insert("font_weight".to_owned(), serde_json::Value::from(value));
+            metadata.insert("nearest".to_owned(), serde_json::Value::from(nearest));
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` has off-scale font-weight {value}; expected a value from type.weights.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: ctx.rect_for(node.dom_order),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::CssPropertyReplace {
+                        property: FONT_WEIGHT.to_owned(),
+                        from: raw.clone(),
+                        to: nearest.to_string(),
+                    },
+                    description: format!(
+                        "Snap `font-weight` to the nearest type-scale weight ({nearest}).",
+                    ),
+                    confidence: Confidence::Medium,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/type-weight-conformance".to_owned(),
+                metadata,
+            });
+        }
+    }
+}
+
+/// Find the nearest weight in the scale. Ties: lower wins.
+fn nearest_weight(value: u16, scale: &[u16]) -> u16 {
+    let mut best = scale[0];
+    let mut best_delta = value.abs_diff(best);
+    for &candidate in &scale[1..] {
+        let delta = value.abs_diff(candidate);
+        if delta < best_delta || (delta == best_delta && candidate < best) {
+            best = candidate;
+            best_delta = delta;
+        }
+    }
+    best
+}

--- a/crates/plumb-core/src/rules/z/mod.rs
+++ b/crates/plumb-core/src/rules/z/mod.rs
@@ -1,0 +1,8 @@
+//! Z-index rules.
+//!
+//! Currently exposes:
+//!
+//! - [`scale_conformance`] — `z-index` values must be members of
+//!   `z_index.scale`.
+
+pub mod scale_conformance;

--- a/crates/plumb-core/src/rules/z/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/z/scale_conformance.rs
@@ -1,0 +1,107 @@
+//! `z/scale-conformance` — flag `z-index` values that aren't in
+//! `z_index.scale`.
+
+use indexmap::IndexMap;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::snapshot::SnapshotCtx;
+
+/// The single property this rule inspects.
+const Z_INDEX: &str = "z-index";
+
+/// Flags `z-index` values that aren't in `z_index.scale`.
+#[derive(Debug, Clone, Copy)]
+pub struct ScaleConformance;
+
+impl Rule for ScaleConformance {
+    fn id(&self) -> &'static str {
+        "z/scale-conformance"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags `z-index` values that aren't in `z_index.scale`."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let scale = &config.z_index.scale;
+        if scale.is_empty() {
+            return;
+        }
+
+        for node in ctx.nodes() {
+            let Some(raw) = node.computed_styles.get(Z_INDEX) else {
+                continue;
+            };
+            let trimmed = raw.trim();
+            if trimmed.eq_ignore_ascii_case("auto") {
+                continue;
+            }
+            let Ok(value) = trimmed.parse::<i32>() else {
+                continue;
+            };
+
+            if scale.contains(&value) {
+                continue;
+            }
+
+            let nearest = nearest_z(value, scale);
+
+            let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
+            metadata.insert("z_index".to_owned(), serde_json::Value::from(value));
+            metadata.insert("nearest".to_owned(), serde_json::Value::from(nearest));
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` has off-scale z-index {value}; expected a value from z_index.scale.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: ctx.rect_for(node.dom_order),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::CssPropertyReplace {
+                        property: Z_INDEX.to_owned(),
+                        from: raw.clone(),
+                        to: nearest.to_string(),
+                    },
+                    description: format!(
+                        "Snap `z-index` to the nearest scale value ({nearest}).",
+                    ),
+                    confidence: Confidence::Medium,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/z-scale-conformance".to_owned(),
+                metadata,
+            });
+        }
+    }
+}
+
+/// Find the nearest z-index in the scale.
+///
+/// Ties: toward lower absolute value, then toward the value closer to zero.
+fn nearest_z(value: i32, scale: &[i32]) -> i32 {
+    let mut best = scale[0];
+    let mut best_delta = value.abs_diff(best);
+    for &candidate in &scale[1..] {
+        let delta = value.abs_diff(candidate);
+        if delta < best_delta
+            || (delta == best_delta && candidate.unsigned_abs() < best.unsigned_abs())
+            || (delta == best_delta
+                && candidate.unsigned_abs() == best.unsigned_abs()
+                && candidate > best)
+        {
+            best = candidate;
+            best_delta = delta;
+        }
+    }
+    best
+}

--- a/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
@@ -1,0 +1,121 @@
+//! Golden snapshot for the `opacity/scale-conformance` rule.
+//!
+//! Three elements: one on-scale, one off-scale, one fully opaque
+//! (`1` — on-scale).
+
+use indexmap::IndexMap;
+use plumb_core::config::OpacitySpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let on_scale = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("opacity", "0.5")],
+        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+    );
+    let off_scale = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("opacity", "0.35")],
+        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+    );
+    let opaque = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[("opacity", "1")],
+        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://opacity-scale".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), on_scale, off_scale, opaque],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        opacity: OpacitySpec {
+            scale: vec![0.0, 0.25, 0.5, 0.75, 1.0],
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn opacity_scale_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "opacity/scale-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("opacity_scale_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn opacity_scale_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
@@ -14,19 +14,34 @@ fn fixture_snapshot() -> PlumbSnapshot {
         2,
         "html > body > div:nth-child(1)",
         &[("opacity", "0.5")],
-        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
     );
     let off_scale = node(
         3,
         "html > body > div:nth-child(2)",
         &[("opacity", "0.35")],
-        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
     );
     let opaque = node(
         4,
         "html > body > div:nth-child(3)",
         &[("opacity", "1")],
-        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
     );
 
     PlumbSnapshot {
@@ -45,7 +60,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -58,7 +78,12 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2, 3, 4],
     }

--- a/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
@@ -14,19 +14,34 @@ fn fixture_snapshot() -> PlumbSnapshot {
         2,
         "html > body > div:nth-child(1)",
         &[("box-shadow", "0px 2px 4px rgba(0, 0, 0, 0.1)")],
-        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
     );
     let off_scale = node(
         3,
         "html > body > div:nth-child(2)",
         &[("box-shadow", "0px 8px 24px rgba(0, 0, 0, 0.3)")],
-        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
     );
     let none_shadow = node(
         4,
         "html > body > div:nth-child(3)",
         &[("box-shadow", "none")],
-        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
     );
 
     PlumbSnapshot {
@@ -45,7 +60,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -58,7 +78,12 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2, 3, 4],
     }

--- a/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
@@ -1,0 +1,125 @@
+//! Golden snapshot for the `shadow/scale-conformance` rule.
+//!
+//! Three elements: one with an on-scale shadow, one off-scale, one
+//! with `none` (skipped).
+
+use indexmap::IndexMap;
+use plumb_core::config::ShadowSpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let on_scale = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("box-shadow", "0px 2px 4px rgba(0, 0, 0, 0.1)")],
+        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+    );
+    let off_scale = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("box-shadow", "0px 8px 24px rgba(0, 0, 0, 0.3)")],
+        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+    );
+    let none_shadow = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[("box-shadow", "none")],
+        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://shadow-scale".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), on_scale, off_scale, none_shadow],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        shadow: ShadowSpec {
+            scale: vec![
+                "0px 1px 2px rgba(0, 0, 0, 0.05)".to_owned(),
+                "0px 2px 4px rgba(0, 0, 0, 0.1)".to_owned(),
+                "0px 4px 8px rgba(0, 0, 0, 0.15)".to_owned(),
+            ],
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn shadow_scale_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "shadow/scale-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("shadow_scale_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn shadow_scale_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
+++ b/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
@@ -15,7 +15,12 @@ fn fixture_snapshot() -> PlumbSnapshot {
         tag: "div".into(),
         attrs: IndexMap::from_iter([("class".into(), "cards".into())]),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 800, height: 200 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 200,
+        }),
         parent: Some(1),
         children: vec![3, 4, 5],
     };
@@ -23,20 +28,35 @@ fn fixture_snapshot() -> PlumbSnapshot {
         3,
         2,
         "html > body > div.cards > div:nth-child(1)",
-        &[("padding-top", "16px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+        &[
+            ("padding-top", "16px"),
+            ("padding-right", "16px"),
+            ("padding-bottom", "16px"),
+            ("padding-left", "16px"),
+        ],
     );
     let child_b = node(
         4,
         2,
         "html > body > div.cards > div:nth-child(2)",
-        &[("padding-top", "16px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+        &[
+            ("padding-top", "16px"),
+            ("padding-right", "16px"),
+            ("padding-bottom", "16px"),
+            ("padding-left", "16px"),
+        ],
     );
     // Drifts: padding-top 28px vs median 16px = 12px drift
     let child_c = node(
         5,
         2,
         "html > body > div.cards > div:nth-child(3)",
-        &[("padding-top", "28px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+        &[
+            ("padding-top", "28px"),
+            ("padding-right", "16px"),
+            ("padding-bottom", "16px"),
+            ("padding-left", "16px"),
+        ],
     );
 
     PlumbSnapshot {
@@ -55,7 +75,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -68,18 +93,18 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2],
     }
 }
 
-fn node(
-    dom_order: u64,
-    parent: u64,
-    selector: &str,
-    styles: &[(&str, &str)],
-) -> SnapshotNode {
+fn node(dom_order: u64, parent: u64, selector: &str, styles: &[(&str, &str)]) -> SnapshotNode {
     let mut computed_styles = IndexMap::new();
     for (prop, value) in styles {
         computed_styles.insert((*prop).to_owned(), (*value).to_owned());
@@ -90,7 +115,12 @@ fn node(
         tag: "div".into(),
         attrs: IndexMap::new(),
         computed_styles,
-        rect: Some(Rect { x: 0, y: 0, width: 200, height: 100 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+        }),
         parent: Some(parent),
         children: Vec::new(),
     }

--- a/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
+++ b/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
@@ -1,0 +1,122 @@
+//! Golden snapshot for the `sibling/padding-consistency` rule.
+//!
+//! Three sibling divs under a parent: two share padding, one drifts
+//! by more than the 4px threshold.
+
+use indexmap::IndexMap;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let parent = SnapshotNode {
+        dom_order: 2,
+        selector: "html > body > div.cards".into(),
+        tag: "div".into(),
+        attrs: IndexMap::from_iter([("class".into(), "cards".into())]),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 800, height: 200 }),
+        parent: Some(1),
+        children: vec![3, 4, 5],
+    };
+    let child_a = node(
+        3,
+        2,
+        "html > body > div.cards > div:nth-child(1)",
+        &[("padding-top", "16px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+    );
+    let child_b = node(
+        4,
+        2,
+        "html > body > div.cards > div:nth-child(2)",
+        &[("padding-top", "16px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+    );
+    // Drifts: padding-top 28px vs median 16px = 12px drift
+    let child_c = node(
+        5,
+        2,
+        "html > body > div.cards > div:nth-child(3)",
+        &[("padding-top", "28px"), ("padding-right", "16px"), ("padding-bottom", "16px"), ("padding-left", "16px")],
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://sibling-padding".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), parent, child_a, child_b, child_c],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    parent: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect: Some(Rect { x: 0, y: 0, width: 200, height: 100 }),
+        parent: Some(parent),
+        children: Vec::new(),
+    }
+}
+
+#[test]
+fn sibling_padding_consistency_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = Config::default();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "sibling/padding-consistency")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("sibling_padding_consistency", json);
+    Ok(())
+}
+
+#[test]
+fn sibling_padding_consistency_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = Config::default();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_type_family_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_family_conformance.rs
@@ -1,0 +1,124 @@
+//! Golden snapshot for the `type/family-conformance` rule.
+//!
+//! Three elements: one uses an allowed family, one uses a disallowed
+//! family, one has no `font-family` at all.
+
+use indexmap::IndexMap;
+use plumb_core::config::TypeScaleSpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let allowed = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("font-family", "\"Inter\", sans-serif")],
+        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+    );
+    let disallowed = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("font-family", "\"Comic Sans MS\", cursive")],
+        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+    );
+    let missing = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[],
+        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://type-family".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), allowed, disallowed, missing],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        type_scale: TypeScaleSpec {
+            families: vec!["Inter".to_owned(), "sans-serif".to_owned()],
+            weights: Vec::new(),
+            scale: Vec::new(),
+            tokens: IndexMap::new(),
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn type_family_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "type/family-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("type_family_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn type_family_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_type_family_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_family_conformance.rs
@@ -14,19 +14,34 @@ fn fixture_snapshot() -> PlumbSnapshot {
         2,
         "html > body > div:nth-child(1)",
         &[("font-family", "\"Inter\", sans-serif")],
-        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
     );
     let disallowed = node(
         3,
         "html > body > div:nth-child(2)",
         &[("font-family", "\"Comic Sans MS\", cursive")],
-        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
     );
     let missing = node(
         4,
         "html > body > div:nth-child(3)",
         &[],
-        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
     );
 
     PlumbSnapshot {
@@ -45,7 +60,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -58,7 +78,12 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2, 3, 4],
     }

--- a/crates/plumb-core/tests/golden_type_weight_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_weight_conformance.rs
@@ -14,19 +14,34 @@ fn fixture_snapshot() -> PlumbSnapshot {
         2,
         "html > body > div:nth-child(1)",
         &[("font-weight", "400")],
-        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
     );
     let off_scale = node(
         3,
         "html > body > div:nth-child(2)",
         &[("font-weight", "450")],
-        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
     );
     let non_numeric = node(
         4,
         "html > body > div:nth-child(3)",
         &[("font-weight", "bold")],
-        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
     );
 
     PlumbSnapshot {
@@ -45,7 +60,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -58,7 +78,12 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2, 3, 4],
     }

--- a/crates/plumb-core/tests/golden_type_weight_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_weight_conformance.rs
@@ -1,0 +1,124 @@
+//! Golden snapshot for the `type/weight-conformance` rule.
+//!
+//! Three elements with `font-weight`: one on-scale, one off-scale,
+//! one with a non-numeric weight (skipped).
+
+use indexmap::IndexMap;
+use plumb_core::config::TypeScaleSpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let on_scale = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("font-weight", "400")],
+        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+    );
+    let off_scale = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("font-weight", "450")],
+        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+    );
+    let non_numeric = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[("font-weight", "bold")],
+        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://type-weight".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), on_scale, off_scale, non_numeric],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        type_scale: TypeScaleSpec {
+            families: Vec::new(),
+            weights: vec![100, 300, 400, 500, 700, 900],
+            scale: Vec::new(),
+            tokens: IndexMap::new(),
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn type_weight_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "type/weight-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("type_weight_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn type_weight_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_z_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_z_scale_conformance.rs
@@ -1,0 +1,121 @@
+//! Golden snapshot for the `z/scale-conformance` rule.
+//!
+//! Three elements: one on-scale, one off-scale, one with `auto`
+//! (skipped).
+
+use indexmap::IndexMap;
+use plumb_core::config::ZIndexSpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    let on_scale = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[("z-index", "10")],
+        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+    );
+    let off_scale = node(
+        3,
+        "html > body > div:nth-child(2)",
+        &[("z-index", "15")],
+        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+    );
+    let auto_z = node(
+        4,
+        "html > body > div:nth-child(3)",
+        &[("z-index", "auto")],
+        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+    );
+
+    PlumbSnapshot {
+        url: "plumb-fake://z-scale".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), on_scale, off_scale, auto_z],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn node(
+    dom_order: u64,
+    selector: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: "div".into(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        z_index: ZIndexSpec {
+            scale: vec![0, 10, 20, 30, 50, 100],
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn z_scale_conformance_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "z/scale-conformance")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("z_scale_conformance", json);
+    Ok(())
+}
+
+#[test]
+fn z_scale_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_z_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_z_scale_conformance.rs
@@ -14,19 +14,34 @@ fn fixture_snapshot() -> PlumbSnapshot {
         2,
         "html > body > div:nth-child(1)",
         &[("z-index", "10")],
-        Some(Rect { x: 0, y: 0, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 24,
+        }),
     );
     let off_scale = node(
         3,
         "html > body > div:nth-child(2)",
         &[("z-index", "15")],
-        Some(Rect { x: 0, y: 24, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 24,
+            width: 200,
+            height: 24,
+        }),
     );
     let auto_z = node(
         4,
         "html > body > div:nth-child(3)",
         &[("z-index", "auto")],
-        Some(Rect { x: 0, y: 48, width: 200, height: 24 }),
+        Some(Rect {
+            x: 0,
+            y: 48,
+            width: 200,
+            height: 24,
+        }),
     );
 
     PlumbSnapshot {
@@ -45,7 +60,12 @@ fn root_html() -> SnapshotNode {
         tag: "html".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: None,
         children: vec![1],
     }
@@ -58,7 +78,12 @@ fn body_node() -> SnapshotNode {
         tag: "body".into(),
         attrs: IndexMap::new(),
         computed_styles: IndexMap::new(),
-        rect: Some(Rect { x: 0, y: 0, width: 1280, height: 800 }),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
         parent: Some(0),
         children: vec![2, 3, 4],
     }

--- a/crates/plumb-core/tests/snapshots/golden_opacity_scale_conformance__opacity_scale_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_opacity_scale_conformance__opacity_scale_conformance.snap
@@ -1,0 +1,35 @@
+---
+source: crates/plumb-core/tests/golden_opacity_scale_conformance.rs
+expression: json
+---
+[
+  {
+    "rule_id": "opacity/scale-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` has off-scale opacity 0.35; expected a value from opacity.scale.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 24,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "css_property_replace",
+        "property": "opacity",
+        "from": "0.35",
+        "to": "0.25"
+      },
+      "description": "Snap `opacity` to the nearest scale value (0.25).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/opacity-scale-conformance",
+    "metadata": {
+      "opacity": 0.35,
+      "nearest": 0.25
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_shadow_scale_conformance__shadow_scale_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_shadow_scale_conformance__shadow_scale_conformance.snap
@@ -1,0 +1,29 @@
+---
+source: crates/plumb-core/tests/golden_shadow_scale_conformance.rs
+expression: json
+---
+[
+  {
+    "rule_id": "shadow/scale-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` has off-scale box-shadow `0px 8px 24px rgba(0, 0, 0, 0.3)`; expected a value from shadow.scale.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 24,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "The box-shadow value `0px 8px 24px rgba(0, 0, 0, 0.3)` is not in the allowed shadow scale."
+      },
+      "description": "Replace `box-shadow` with one of the allowed shadow tokens.",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/shadow-scale-conformance"
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_sibling_padding_consistency__sibling_padding_consistency.snap
+++ b/crates/plumb-core/tests/snapshots/golden_sibling_padding_consistency__sibling_padding_consistency.snap
@@ -1,0 +1,35 @@
+---
+source: crates/plumb-core/tests/golden_sibling_padding_consistency.rs
+expression: json
+---
+[
+  {
+    "rule_id": "sibling/padding-consistency",
+    "severity": "info",
+    "message": "`html > body > div.cards > div:nth-child(3)` has padding-top 28px; sibling median is 16px (12px drift).",
+    "selector": "html > body > div.cards > div:nth-child(3)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 0,
+      "width": 200,
+      "height": 100
+    },
+    "dom_order": 5,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Match sibling padding-top (16px) to keep padding consistent. Drift: 12px."
+      },
+      "description": "Bring `html > body > div.cards > div:nth-child(3)` padding-top in line with its siblings (16px).",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/sibling-padding-consistency",
+    "metadata": {
+      "property": "padding-top",
+      "rendered_padding_px": 28.0,
+      "sibling_median_px": 16.0,
+      "deviation_px": 12
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_type_family_conformance__type_family_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_type_family_conformance__type_family_conformance.snap
@@ -1,0 +1,36 @@
+---
+source: crates/plumb-core/tests/golden_type_family_conformance.rs
+expression: json
+---
+[
+  {
+    "rule_id": "type/family-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` uses font-family `\"Comic Sans MS\", cursive` which is not in type.families.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 24,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Use one of the allowed font families: Inter, sans-serif."
+      },
+      "description": "Replace `font-family` with one of the allowed families (Inter, sans-serif).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/type-family-conformance",
+    "metadata": {
+      "font_family": "\"Comic Sans MS\", cursive",
+      "allowed_families": [
+        "Inter",
+        "sans-serif"
+      ]
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_type_weight_conformance__type_weight_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_type_weight_conformance__type_weight_conformance.snap
@@ -1,0 +1,35 @@
+---
+source: crates/plumb-core/tests/golden_type_weight_conformance.rs
+expression: json
+---
+[
+  {
+    "rule_id": "type/weight-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` has off-scale font-weight 450; expected a value from type.weights.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 24,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "css_property_replace",
+        "property": "font-weight",
+        "from": "450",
+        "to": "400"
+      },
+      "description": "Snap `font-weight` to the nearest type-scale weight (400).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/type-weight-conformance",
+    "metadata": {
+      "font_weight": 450,
+      "nearest": 400
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_z_scale_conformance__z_scale_conformance.snap
+++ b/crates/plumb-core/tests/snapshots/golden_z_scale_conformance__z_scale_conformance.snap
@@ -1,0 +1,35 @@
+---
+source: crates/plumb-core/tests/golden_z_scale_conformance.rs
+expression: json
+---
+[
+  {
+    "rule_id": "z/scale-conformance",
+    "severity": "warning",
+    "message": "`html > body > div:nth-child(2)` has off-scale z-index 15; expected a value from z_index.scale.",
+    "selector": "html > body > div:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 24,
+      "width": 200,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "css_property_replace",
+        "property": "z-index",
+        "from": "15",
+        "to": "10"
+      },
+      "description": "Snap `z-index` to the nearest scale value (10).",
+      "confidence": "medium"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/z-scale-conformance",
+    "metadata": {
+      "z_index": 15,
+      "nearest": 10
+    }
+  }
+]

--- a/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/plumb-format/tests/format_snapshots.rs
+assertion_line: 94
 expression: out
 ---
 {
@@ -69,6 +70,20 @@ expression: out
               }
             },
             {
+              "id": "opacity/scale-conformance",
+              "name": "opacity-scale-conformance",
+              "shortDescription": {
+                "text": "Flags `opacity` values that aren't in `opacity.scale`."
+              },
+              "fullDescription": {
+                "text": "Flags `opacity` values that aren't in `opacity.scale`."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/opacity-scale-conformance",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
               "id": "radius/scale-conformance",
               "name": "radius-scale-conformance",
               "shortDescription": {
@@ -83,6 +98,20 @@ expression: out
               }
             },
             {
+              "id": "shadow/scale-conformance",
+              "name": "shadow-scale-conformance",
+              "shortDescription": {
+                "text": "Flags `box-shadow` values that aren't in `shadow.scale`."
+              },
+              "fullDescription": {
+                "text": "Flags `box-shadow` values that aren't in `shadow.scale`."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/shadow-scale-conformance",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
               "id": "sibling/height-consistency",
               "name": "sibling-height-consistency",
               "shortDescription": {
@@ -92,6 +121,20 @@ expression: out
                 "text": "Flags sibling elements in the same visual row whose heights drift from the row's median."
               },
               "helpUri": "https://plumb.aramhammoudeh.com/rules/sibling-height-consistency",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "sibling/padding-consistency",
+              "name": "sibling-padding-consistency",
+              "shortDescription": {
+                "text": "Flags sibling elements with inconsistent padding."
+              },
+              "fullDescription": {
+                "text": "Flags sibling elements with inconsistent padding."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/sibling-padding-consistency",
               "defaultConfiguration": {
                 "level": "note"
               }
@@ -125,6 +168,20 @@ expression: out
               }
             },
             {
+              "id": "type/family-conformance",
+              "name": "type-family-conformance",
+              "shortDescription": {
+                "text": "Flags elements whose `font-family` is not in `type.families`."
+              },
+              "fullDescription": {
+                "text": "Flags elements whose `font-family` is not in `type.families`."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/type-family-conformance",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
               "id": "type/scale-conformance",
               "name": "type-scale-conformance",
               "shortDescription": {
@@ -134,6 +191,34 @@ expression: out
                 "text": "Flags `font-size` values that aren't members of `type.scale`."
               },
               "helpUri": "https://plumb.aramhammoudeh.com/rules/type-scale-conformance",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "type/weight-conformance",
+              "name": "type-weight-conformance",
+              "shortDescription": {
+                "text": "Flags elements whose `font-weight` is not in `type.weights`."
+              },
+              "fullDescription": {
+                "text": "Flags elements whose `font-weight` is not in `type.weights`."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/type-weight-conformance",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "z/scale-conformance",
+              "name": "z-scale-conformance",
+              "shortDescription": {
+                "text": "Flags `z-index` values that aren't in `z_index.scale`."
+              },
+              "fullDescription": {
+                "text": "Flags `z-index` values that aren't in `z_index.scale`."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/z-scale-conformance",
               "defaultConfiguration": {
                 "level": "warning"
               }
@@ -173,7 +258,7 @@ expression: out
           "properties": {
             "docUrl": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
           },
-          "ruleIndex": 6
+          "ruleIndex": 9
         }
       ]
     }

--- a/crates/plumb-mcp/src/explain.rs
+++ b/crates/plumb-mcp/src/explain.rs
@@ -46,12 +46,24 @@ pub(crate) const RULE_DOCS: &[RuleDoc] = &[
         markdown: include_str!("../../../docs/src/rules/edge-near-alignment.md"),
     },
     RuleDoc {
+        rule_id: "opacity/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/opacity-scale-conformance.md"),
+    },
+    RuleDoc {
         rule_id: "radius/scale-conformance",
         markdown: include_str!("../../../docs/src/rules/radius-scale-conformance.md"),
     },
     RuleDoc {
+        rule_id: "shadow/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/shadow-scale-conformance.md"),
+    },
+    RuleDoc {
         rule_id: "sibling/height-consistency",
         markdown: include_str!("../../../docs/src/rules/sibling-height-consistency.md"),
+    },
+    RuleDoc {
+        rule_id: "sibling/padding-consistency",
+        markdown: include_str!("../../../docs/src/rules/sibling-padding-consistency.md"),
     },
     RuleDoc {
         rule_id: "spacing/grid-conformance",
@@ -62,8 +74,20 @@ pub(crate) const RULE_DOCS: &[RuleDoc] = &[
         markdown: include_str!("../../../docs/src/rules/spacing-scale-conformance.md"),
     },
     RuleDoc {
+        rule_id: "type/family-conformance",
+        markdown: include_str!("../../../docs/src/rules/type-family-conformance.md"),
+    },
+    RuleDoc {
         rule_id: "type/scale-conformance",
         markdown: include_str!("../../../docs/src/rules/type-scale-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "type/weight-conformance",
+        markdown: include_str!("../../../docs/src/rules/type-weight-conformance.md"),
+    },
+    RuleDoc {
+        rule_id: "z/scale-conformance",
+        markdown: include_str!("../../../docs/src/rules/z-scale-conformance.md"),
     },
 ];
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,11 +35,17 @@
 - [color/contrast-aa](./rules/color-contrast-aa.md)
 - [color/palette-conformance](./rules/color-palette-conformance.md)
 - [edge/near-alignment](./rules/edge-near-alignment.md)
+- [opacity/scale-conformance](./rules/opacity-scale-conformance.md)
 - [radius/scale-conformance](./rules/radius-scale-conformance.md)
+- [shadow/scale-conformance](./rules/shadow-scale-conformance.md)
 - [sibling/height-consistency](./rules/sibling-height-consistency.md)
+- [sibling/padding-consistency](./rules/sibling-padding-consistency.md)
 - [spacing/grid-conformance](./rules/spacing-grid-conformance.md)
 - [spacing/scale-conformance](./rules/spacing-scale-conformance.md)
+- [type/family-conformance](./rules/type-family-conformance.md)
 - [type/scale-conformance](./rules/type-scale-conformance.md)
+- [type/weight-conformance](./rules/type-weight-conformance.md)
+- [z/scale-conformance](./rules/z-scale-conformance.md)
 
 # Performance
 

--- a/docs/src/rules/opacity-scale-conformance.md
+++ b/docs/src/rules/opacity-scale-conformance.md
@@ -1,0 +1,86 @@
+# opacity/scale-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads the computed `opacity`
+value and parses it as an `f64`. A violation fires when no entry in
+`opacity.scale` is within 0.005 of the parsed value.
+
+The rule MUST skip a node when:
+
+- the node has no computed `opacity` value;
+- the value does not parse as an `f64`;
+- or `opacity.scale` is empty (the rule is a no-op).
+
+## Why it matters
+
+Opacity values define the transparency vocabulary of a design system.
+Arbitrary values like `0.35` or `0.87` create visual inconsistency
+across hover states, disabled elements, and overlays. A defined scale
+(e.g. 0, 0.25, 0.5, 0.75, 1.0) keeps transparency intentional.
+
+## Example violation
+
+```json
+{
+  "rule_id": "opacity/scale-conformance",
+  "severity": "warning",
+  "message": "`html > body > div.overlay` has off-scale opacity 0.35; expected a value from opacity.scale.",
+  "selector": "html > body > div.overlay",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "css_property_replace",
+      "property": "opacity",
+      "from": "0.35",
+      "to": "0.25"
+    },
+    "description": "Snap `opacity` to the nearest scale value (0.25).",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/opacity-scale-conformance"
+}
+```
+
+## Configuration
+
+`opacity.scale` is the list of allowed opacity values in `[0.0, 1.0]`.
+Default is empty (the rule is a no-op).
+
+```toml
+[opacity]
+scale = [0.0, 0.25, 0.5, 0.75, 1.0]
+```
+
+The tolerance for matching is 0.005 — values within half a percent
+of a scale entry pass. The fix suggests the nearest scale value by
+absolute delta. Ties resolve to the lower value.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."opacity/scale-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."opacity/scale-conformance"]
+severity = "info"
+```
+
+## See also
+
+- [`z/scale-conformance`](./z-scale-conformance.md) — the sibling
+  rule for z-index tokens.
+- [`shadow/scale-conformance`](./shadow-scale-conformance.md) — the
+  sibling rule for box-shadow tokens.
+- PRD §11 — rule catalog.

--- a/docs/src/rules/overview.md
+++ b/docs/src/rules/overview.md
@@ -17,19 +17,26 @@ against each page snapshot. Every rule has:
   flags element colors that aren't members of the configured palette.
 - [`edge/near-alignment`](./edge-near-alignment.md) — flags element
   edges that almost-but-not-quite line up with sibling edges.
+- [`opacity/scale-conformance`](./opacity-scale-conformance.md) —
+  flags opacity values that aren't members of `opacity.scale`.
 - [`radius/scale-conformance`](./radius-scale-conformance.md) — flags
   border-radius values that aren't members of `radius.scale`.
+- [`shadow/scale-conformance`](./shadow-scale-conformance.md) —
+  flags box-shadow values that aren't in `shadow.scale`.
 - [`sibling/height-consistency`](./sibling-height-consistency.md) —
   flags sibling elements in the same visual row whose heights drift
   from the row's median.
+- [`sibling/padding-consistency`](./sibling-padding-consistency.md) —
+  flags sibling elements whose padding drifts from the group median.
 - [`spacing/grid-conformance`](./spacing-grid-conformance.md) — flags
   spacing values that aren't multiples of `spacing.base_unit`.
 - [`spacing/scale-conformance`](./spacing-scale-conformance.md) —
   flags spacing values that aren't members of `spacing.scale`.
+- [`type/family-conformance`](./type-family-conformance.md) — flags
+  `font-family` values that aren't in `type.families`.
 - [`type/scale-conformance`](./type-scale-conformance.md) — flags
   `font-size` values that aren't members of `type.scale`.
-
-## Coming soon
-
-The PRD lists more rules in the initial set; each will land with its
-own docs page and a golden snapshot test.
+- [`type/weight-conformance`](./type-weight-conformance.md) — flags
+  `font-weight` values that aren't in `type.weights`.
+- [`z/scale-conformance`](./z-scale-conformance.md) — flags z-index
+  values that aren't in `z_index.scale`.

--- a/docs/src/rules/shadow-scale-conformance.md
+++ b/docs/src/rules/shadow-scale-conformance.md
@@ -1,0 +1,89 @@
+# shadow/scale-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads the computed
+`box-shadow` value and compares it against the entries in
+`shadow.scale`. The comparison is an exact string match (after
+trimming whitespace). A violation fires when the computed value does
+not match any scale entry.
+
+The rule MUST skip a node when:
+
+- the node has no computed `box-shadow` value;
+- the value is `none` (case-insensitive);
+- or `shadow.scale` is empty (the rule is a no-op).
+
+## Why it matters
+
+Box shadows are one of the most visually inconsistent properties in
+a design system. Different blur radii, spread values, and color
+opacities create a muddy visual hierarchy. Restricting shadows to a
+named set of tokens keeps elevation consistent across components.
+
+## Example violation
+
+```json
+{
+  "rule_id": "shadow/scale-conformance",
+  "severity": "warning",
+  "message": "`html > body > div.card` has off-scale box-shadow `0px 8px 24px rgba(0, 0, 0, 0.3)`; expected a value from shadow.scale.",
+  "selector": "html > body > div.card",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "description",
+      "text": "The box-shadow value `0px 8px 24px rgba(0, 0, 0, 0.3)` is not in the allowed shadow scale."
+    },
+    "description": "Replace `box-shadow` with one of the allowed shadow tokens.",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/shadow-scale-conformance"
+}
+```
+
+## Configuration
+
+`shadow.scale` is the list of allowed `box-shadow` expressions as
+returned by `getComputedStyle`. Default is empty (the rule is a
+no-op).
+
+```toml
+[shadow]
+scale = [
+  "0px 1px 2px rgba(0, 0, 0, 0.05)",
+  "0px 2px 4px rgba(0, 0, 0, 0.1)",
+  "0px 4px 8px rgba(0, 0, 0, 0.15)",
+]
+```
+
+Each entry should match the exact computed-style output from
+Chromium. Use `getComputedStyle(el).boxShadow` in DevTools to get
+the canonical form.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."shadow/scale-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."shadow/scale-conformance"]
+severity = "info"
+```
+
+## See also
+
+- [`opacity/scale-conformance`](./opacity-scale-conformance.md) —
+  the sibling rule for opacity tokens.
+- PRD §11 — rule catalog.

--- a/docs/src/rules/sibling-padding-consistency.md
+++ b/docs/src/rules/sibling-padding-consistency.md
@@ -1,0 +1,86 @@
+# sibling/padding-consistency
+
+**Status:** active
+
+**Default severity:** `info`
+
+## What it checks
+
+The rule groups nodes by their parent `dom_order` and, within each
+group of two or more siblings, checks the four padding longhands
+(`padding-top`, `padding-right`, `padding-bottom`, `padding-left`)
+independently. For each property, it computes the median value among
+siblings that have a parseable pixel value for that property. Any
+sibling whose value deviates from the median by more than 4 CSS
+pixels fires a violation.
+
+The rule MUST skip:
+
+- sibling groups smaller than 2 (nothing to compare);
+- siblings where the property value does not parse as a pixel length.
+
+Even-count medians pick the lower of the two middle values, matching
+the tie-break used by `sibling/height-consistency`.
+
+## Why it matters
+
+Card grids, nav bars, and list items that share a parent but disagree
+on padding look sloppy. The 4px threshold catches real mismatches
+(12px vs 24px) while ignoring subpixel rendering differences. The
+fix is emitted at `confidence: low` because Plumb cannot know whether
+to change the outlier or update the siblings.
+
+## Example violation
+
+```json
+{
+  "rule_id": "sibling/padding-consistency",
+  "severity": "info",
+  "message": "`html > body > div.cards > div:nth-child(3)` has padding-top 28px; sibling median is 16px (12px drift).",
+  "selector": "html > body > div.cards > div:nth-child(3)",
+  "viewport": "desktop",
+  "dom_order": 5,
+  "fix": {
+    "kind": {
+      "kind": "description",
+      "text": "Match sibling padding-top (16px) to keep padding consistent. Drift: 12px."
+    },
+    "description": "Bring `html > body > div.cards > div:nth-child(3)` padding-top in line with its siblings (16px).",
+    "confidence": "low"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/sibling-padding-consistency",
+  "metadata": {
+    "property": "padding-top",
+    "rendered_padding_px": 28.0,
+    "sibling_median_px": 16.0,
+    "deviation_px": 12
+  }
+}
+```
+
+## Configuration
+
+The rule has no `plumb.toml` knobs today. The deviation threshold
+(4 CSS px) is baked into the rule and pinned by a unit test.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."sibling/padding-consistency"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."sibling/padding-consistency"]
+severity = "warning"
+```
+
+## See also
+
+- [`sibling/height-consistency`](./sibling-height-consistency.md) —
+  the sibling rule for row-height drift.
+- PRD §11.6 — sibling-relationship rules.

--- a/docs/src/rules/type-family-conformance.md
+++ b/docs/src/rules/type-family-conformance.md
@@ -1,0 +1,86 @@
+# type/family-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads the computed
+`font-family` value and splits it into a comma-separated list of
+family names. Outer quotes are stripped from each entry. A violation
+fires when none of the parsed families match any entry in
+`type.families` (case-insensitive comparison).
+
+The rule MUST skip a node when:
+
+- the node has no computed `font-family` value;
+- the computed value is empty or whitespace-only;
+- or `type.families` is empty (the rule is a no-op).
+
+## Why it matters
+
+A type system defines which font families belong in a product. Using
+an off-brand family (a system default fallback, a debug font, a
+copy-pasted Google Fonts import that was never removed) undermines
+visual consistency. This rule catches those before they ship.
+
+## Example violation
+
+```json
+{
+  "rule_id": "type/family-conformance",
+  "severity": "warning",
+  "message": "`html > body > p` uses font-family `\"Comic Sans MS\", cursive` which is not in type.families.",
+  "selector": "html > body > p",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "description",
+      "text": "Use one of the allowed font families: Inter, sans-serif."
+    },
+    "description": "Replace `font-family` with one of the allowed families (Inter, sans-serif).",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/type-family-conformance"
+}
+```
+
+## Configuration
+
+`type.families` is the list of allowed font-family names. Default is
+empty (the rule is a no-op).
+
+```toml
+[type]
+families = ["Inter", "sans-serif"]
+```
+
+Matching is case-insensitive. If any family in the element's
+`font-family` stack matches any entry in `type.families`, the element
+passes.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."type/family-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."type/family-conformance"]
+severity = "info"
+```
+
+## See also
+
+- [`type/scale-conformance`](./type-scale-conformance.md) — the
+  sibling rule for font-size tokens.
+- [`type/weight-conformance`](./type-weight-conformance.md) — the
+  sibling rule for font-weight tokens.
+- PRD §11.3 — type rules.

--- a/docs/src/rules/type-weight-conformance.md
+++ b/docs/src/rules/type-weight-conformance.md
@@ -1,0 +1,88 @@
+# type/weight-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads the computed
+`font-weight` value and parses it as a `u16`. A violation fires when
+the parsed weight is not present in `type.weights`.
+
+The rule MUST skip a node when:
+
+- the node has no computed `font-weight` value;
+- the value does not parse as a `u16` (e.g. `bold`, `normal`);
+- or `type.weights` is empty (the rule is a no-op).
+
+Chromium resolves keyword weights (`bold` → `700`, `normal` → `400`)
+in `getComputedStyle`, so in practice the rule sees numeric values.
+
+## Why it matters
+
+Design systems restrict font weights to a small set (often 400 and
+700, or a wider range for variable fonts). An off-scale weight like
+`450` or `550` may render differently across browsers and fonts,
+creating inconsistency that is hard to spot by eye.
+
+## Example violation
+
+```json
+{
+  "rule_id": "type/weight-conformance",
+  "severity": "warning",
+  "message": "`html > body > span` has off-scale font-weight 450; expected a value from type.weights.",
+  "selector": "html > body > span",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "css_property_replace",
+      "property": "font-weight",
+      "from": "450",
+      "to": "400"
+    },
+    "description": "Snap `font-weight` to the nearest type-scale weight (400).",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/type-weight-conformance"
+}
+```
+
+## Configuration
+
+`type.weights` is the list of allowed font-weight values. Default is
+empty (the rule is a no-op).
+
+```toml
+[type]
+weights = [100, 300, 400, 500, 700, 900]
+```
+
+The fix suggests the nearest allowed weight by absolute delta. Ties
+resolve to the lower weight.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."type/weight-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."type/weight-conformance"]
+severity = "info"
+```
+
+## See also
+
+- [`type/family-conformance`](./type-family-conformance.md) — the
+  sibling rule for font-family tokens.
+- [`type/scale-conformance`](./type-scale-conformance.md) — the
+  sibling rule for font-size tokens.
+- PRD §11.3 — type rules.

--- a/docs/src/rules/z-scale-conformance.md
+++ b/docs/src/rules/z-scale-conformance.md
@@ -1,0 +1,84 @@
+# z/scale-conformance
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every node in the snapshot, the rule reads the computed `z-index`
+value and parses it as an `i32`. A violation fires when the parsed
+value is not present in `z_index.scale`.
+
+The rule MUST skip a node when:
+
+- the node has no computed `z-index` value;
+- the value is `auto` (case-insensitive);
+- the value does not parse as an `i32`;
+- or `z_index.scale` is empty (the rule is a no-op).
+
+## Why it matters
+
+Uncontrolled z-index values lead to stacking-context wars: one
+component uses `z-index: 999`, another uses `9999`, and the
+escalation never ends. A defined scale (e.g. 0, 10, 20, 50, 100)
+keeps layering intentional and predictable.
+
+## Example violation
+
+```json
+{
+  "rule_id": "z/scale-conformance",
+  "severity": "warning",
+  "message": "`html > body > div.modal` has off-scale z-index 15; expected a value from z_index.scale.",
+  "selector": "html > body > div.modal",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "css_property_replace",
+      "property": "z-index",
+      "from": "15",
+      "to": "10"
+    },
+    "description": "Snap `z-index` to the nearest scale value (10).",
+    "confidence": "medium"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/z-scale-conformance"
+}
+```
+
+## Configuration
+
+`z_index.scale` is the list of allowed z-index values. Default is
+empty (the rule is a no-op).
+
+```toml
+[z_index]
+scale = [0, 10, 20, 30, 50, 100]
+```
+
+The fix suggests the nearest scale value. Ties resolve toward lower
+absolute value, then toward zero.
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."z/scale-conformance"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."z/scale-conformance"]
+severity = "info"
+```
+
+## See also
+
+- [`opacity/scale-conformance`](./opacity-scale-conformance.md) —
+  the sibling rule for opacity tokens.
+- PRD §11 — rule catalog.

--- a/schemas/plumb.toml.json
+++ b/schemas/plumb.toml.json
@@ -55,6 +55,36 @@
         "tolerance_px": 3
       }
     },
+    "shadow": {
+      "description": "Box-shadow spec.",
+      "$ref": "#/$defs/ShadowSpec",
+      "default": {
+        "scale": []
+      }
+    },
+    "z_index": {
+      "description": "Z-index spec.",
+      "$ref": "#/$defs/ZIndexSpec",
+      "default": {
+        "scale": []
+      }
+    },
+    "opacity": {
+      "description": "Opacity spec.",
+      "$ref": "#/$defs/OpacitySpec",
+      "default": {
+        "scale": []
+      }
+    },
+    "rhythm": {
+      "description": "Vertical rhythm spec.",
+      "$ref": "#/$defs/RhythmSpec",
+      "default": {
+        "base_line_px": 0,
+        "tolerance_px": 2,
+        "cap_height_fallback_px": 0
+      }
+    },
     "a11y": {
       "description": "Accessibility spec.",
       "$ref": "#/$defs/A11ySpec",
@@ -254,6 +284,81 @@
           "format": "uint32",
           "minimum": 0,
           "default": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "ShadowSpec": {
+      "description": "Box-shadow spec.",
+      "type": "object",
+      "properties": {
+        "scale": {
+          "description": "Allowed box-shadow values. Each entry is a complete shadow\nexpression as returned by `getComputedStyle`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "ZIndexSpec": {
+      "description": "Z-index spec.",
+      "type": "object",
+      "properties": {
+        "scale": {
+          "description": "Allowed z-index values.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpacitySpec": {
+      "description": "Opacity spec.",
+      "type": "object",
+      "properties": {
+        "scale": {
+          "description": "Allowed opacity values in the range `[0.0, 1.0]`.",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "float"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "RhythmSpec": {
+      "description": "Vertical-rhythm spec (schema/defaults only -- rule lands in #73).",
+      "type": "object",
+      "properties": {
+        "base_line_px": {
+          "description": "Base line-height in pixels.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 0
+        },
+        "tolerance_px": {
+          "description": "Tolerance in pixels for rhythm checks.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 2
+        },
+        "cap_height_fallback_px": {
+          "description": "Cap-height fallback in pixels when font metrics are unavailable.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 0
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Add 6 new design-system rules: `type/family-conformance`, `type/weight-conformance`, `shadow/scale-conformance`, `sibling/padding-consistency`, `z/scale-conformance`, `opacity/scale-conformance`
- Add config/schema/defaults for `shadow.scale`, `z_index.scale`, `opacity.scale`, and `RhythmSpec` (schema only — rule in #73)
- Each rule has golden snapshot test, determinism test, and docs page

Closes #66, closes #67, closes #69, closes #70, closes #71, closes #72

## Rules added

| Rule ID | What it flags | Config key |
|---------|--------------|------------|
| `type/family-conformance` | `font-family` not in allowed list | `type.families` |
| `type/weight-conformance` | `font-weight` not in allowed list | `type.weights` |
| `shadow/scale-conformance` | `box-shadow` not matching a named token | `shadow.scale` |
| `sibling/padding-consistency` | Sibling elements with >4px padding drift from median | (none — threshold baked in) |
| `z/scale-conformance` | `z-index` not in allowed scale | `z_index.scale` |
| `opacity/scale-conformance` | `opacity` not in allowed scale | `opacity.scale` |

## Validations

- [x] `git diff --check` — no whitespace errors
- [x] All 6 rules registered in `register_builtin()` in sorted order
- [x] All 6 golden snapshot tests with determinism assertions
- [x] All 6 docs pages in `docs/src/rules/` with correct shape
- [x] `SUMMARY.md` and `overview.md` updated
- [x] Config structs: `ShadowSpec`, `ZIndexSpec`, `OpacitySpec`, `RhythmSpec` with serde defaults
- [x] No `unwrap`/`expect`/`todo!`/`dbg!` in library code
- [ ] CI: `cargo check`, `cargo nextest`, `cargo clippy` (pending CI run)

## Test plan

- [ ] CI passes all gates (build, clippy, nextest, determinism)
- [ ] `cargo test --test golden_opacity_scale_conformance`
- [ ] `cargo test --test golden_shadow_scale_conformance`
- [ ] `cargo test --test golden_sibling_padding_consistency`
- [ ] `cargo test --test golden_type_family_conformance`
- [ ] `cargo test --test golden_type_weight_conformance`
- [ ] `cargo test --test golden_z_scale_conformance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)