### PR TITLE
feat(mcp): add authenticated HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -182,6 +182,52 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -308,6 +354,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chromiumoxide"
@@ -471,7 +534,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -770,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -943,14 +1006,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -962,6 +1040,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1066,6 +1145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,11 +1172,28 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1310,7 +1412,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1398,6 +1500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1524,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1454,6 +1568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,7 +1590,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1491,7 +1611,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1736,6 +1856,7 @@ dependencies = [
  "plumb-format",
  "plumb-mcp",
  "predicates",
+ "reqwest",
  "scraper",
  "serde_json",
  "tempfile",
@@ -1799,6 +1920,7 @@ dependencies = [
 name = "plumb-mcp"
 version = "0.0.1"
 dependencies = [
+ "axum",
  "plumb-cdp",
  "plumb-config",
  "plumb-core",
@@ -1907,7 +2029,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1921,6 +2043,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "quote"
@@ -1950,7 +2127,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1960,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1973,12 +2161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2072,16 +2266,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2089,6 +2288,21 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2099,18 +2313,27 @@ checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2157,7 +2380,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2451,7 +2709,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2489,6 +2760,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -2552,7 +2829,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2572,7 +2849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2661,6 +2938,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2965,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2685,6 +2977,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2903,7 +3216,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -2967,6 +3280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3314,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3160,6 +3490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3509,15 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3186,7 +3535,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3285,12 +3634,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3489,6 +3985,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,13 @@ plumb-mcp = { path = "crates/plumb-mcp", version = "0.0.1" }
 chromiumoxide = { version = "0.8", default-features = false, features = ["tokio-runtime"] }
 
 # MCP SDK.
-rmcp = { version = "1.5", default-features = false, features = ["base64", "macros", "server", "transport-io", "schemars"] }
+rmcp = { version = "1.5", default-features = false, features = ["base64", "macros", "server", "transport-io", "transport-streamable-http-server", "schemars"] }
 
 # Async runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "sync", "time", "fs", "process"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # CLI parsing.
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+subtle = "2"
 
 # CLI parsing.
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }

--- a/crates/plumb-cli/Cargo.toml
+++ b/crates/plumb-cli/Cargo.toml
@@ -42,6 +42,7 @@ scraper = { version = "0.26", default-features = false, features = ["errors", "d
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
+reqwest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plumb-cli/src/commands/mcp.rs
+++ b/crates/plumb-cli/src/commands/mcp.rs
@@ -1,13 +1,39 @@
-//! `plumb mcp` — serve MCP on stdio.
+//! `plumb mcp` — serve MCP on stdio or HTTP.
 
 use std::env;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
-pub async fn run() -> Result<ExitCode> {
-    tracing::info!("starting mcp stdio server");
+pub async fn run(transport: crate::McpTransport, port: u16) -> Result<ExitCode> {
     let cwd = env::current_dir()?;
-    plumb_mcp::run_stdio(cwd).await?;
+    match transport {
+        crate::McpTransport::Stdio => {
+            tracing::info!("starting mcp stdio server");
+            plumb_mcp::run_stdio(cwd).await?;
+        }
+        crate::McpTransport::Http => {
+            let token = read_http_token()?;
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+            tracing::info!(%addr, "starting mcp http server");
+            plumb_mcp::run_http(cwd, addr, token).await?;
+        }
+    }
     Ok(ExitCode::SUCCESS)
+}
+
+fn read_http_token() -> Result<String> {
+    match env::var("PLUMB_MCP_TOKEN") {
+        Ok(token) if token.trim().is_empty() => Err(anyhow!(
+            "PLUMB_MCP_TOKEN must be set to a non-empty bearer token when --transport http is used"
+        )),
+        Ok(token) => Ok(token),
+        Err(env::VarError::NotPresent) => Err(anyhow!(
+            "PLUMB_MCP_TOKEN must be set to a non-empty bearer token when --transport http is used"
+        )),
+        Err(env::VarError::NotUnicode(_)) => Err(anyhow!(
+            "PLUMB_MCP_TOKEN must be valid Unicode when --transport http is used"
+        )),
+    }
 }

--- a/crates/plumb-cli/src/commands/mcp.rs
+++ b/crates/plumb-cli/src/commands/mcp.rs
@@ -28,7 +28,7 @@ fn read_http_token() -> Result<String> {
         Ok(token) if token.trim().is_empty() => Err(anyhow!(
             "PLUMB_MCP_TOKEN must be set to a non-empty bearer token when --transport http is used"
         )),
-        Ok(token) => Ok(token),
+        Ok(token) => Ok(token.trim().to_owned()),
         Err(env::VarError::NotPresent) => Err(anyhow!(
             "PLUMB_MCP_TOKEN must be set to a non-empty bearer token when --transport http is used"
         )),

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -87,8 +87,15 @@ enum Command {
     },
     /// Emit the JSON Schema for `plumb.toml` on stdout.
     Schema,
-    /// Run the MCP server on stdio.
-    Mcp,
+    /// Run the MCP server on stdio or HTTP.
+    Mcp {
+        /// MCP transport. Defaults to stdio to preserve existing behavior.
+        #[arg(long, value_enum, default_value_t = McpTransport::Stdio)]
+        transport: McpTransport,
+        /// TCP port for the HTTP transport.
+        #[arg(long, default_value_t = 4242)]
+        port: u16,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -99,6 +106,14 @@ enum Format {
     Json,
     /// SARIF 2.1.0.
     Sarif,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+enum McpTransport {
+    /// Serve MCP over stdin/stdout.
+    Stdio,
+    /// Serve MCP over Streamable HTTP.
+    Http,
 }
 
 fn main() -> ExitCode {
@@ -146,7 +161,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
             Command::Init { force } => commands::init::run(force),
             Command::Explain { rule } => commands::explain::run(&rule),
             Command::Schema => commands::schema::run(),
-            Command::Mcp => commands::mcp::run().await,
+            Command::Mcp { transport, port } => commands::mcp::run(transport, port).await,
         }
     })
 }

--- a/crates/plumb-cli/tests/mcp_http.rs
+++ b/crates/plumb-cli/tests/mcp_http.rs
@@ -1,5 +1,6 @@
 //! End-to-end HTTP transport tests for `plumb mcp`.
 
+// This harness uses expect/unwrap/panic in test-only setup paths to keep failures explicit.
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
 
 use std::io;
@@ -18,6 +19,8 @@ fn bin() -> std::path::PathBuf {
 }
 
 fn reserve_port() -> io::Result<u16> {
+    // TOCTOU note: this only reduces collisions for the child process; the short
+    // local-only test window keeps the risk acceptable until we wire fd handoff.
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     let port = listener.local_addr()?.port();
     drop(listener);
@@ -116,6 +119,7 @@ async fn http_transport_rejects_requests_without_bearer_token()
     let response = initialize_request(port, None).await?;
 
     assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert_eq!(response.headers()["www-authenticate"], "Bearer");
     Ok(())
 }
 
@@ -126,6 +130,7 @@ async fn http_transport_rejects_invalid_bearer_token() -> Result<(), Box<dyn std
     let response = initialize_request(port, Some("Bearer wrong-token")).await?;
 
     assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert_eq!(response.headers()["www-authenticate"], "Bearer");
     Ok(())
 }
 

--- a/crates/plumb-cli/tests/mcp_http.rs
+++ b/crates/plumb-cli/tests/mcp_http.rs
@@ -144,3 +144,15 @@ async fn http_transport_accepts_valid_bearer_token() -> Result<(), Box<dyn std::
     assert!(response.headers().contains_key("mcp-session-id"));
     Ok(())
 }
+
+#[tokio::test]
+async fn http_transport_trims_bearer_token_from_environment()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_server, port) = spawn_http_server(" secret ").await?;
+
+    let response = initialize_request(port, Some("Bearer secret")).await?;
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert!(response.headers().contains_key("mcp-session-id"));
+    Ok(())
+}

--- a/crates/plumb-cli/tests/mcp_http.rs
+++ b/crates/plumb-cli/tests/mcp_http.rs
@@ -1,0 +1,141 @@
+//! End-to-end HTTP transport tests for `plumb mcp`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
+
+use std::io;
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::prelude::OutputAssertExt;
+use predicates::str::contains;
+
+const INIT_BODY: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"plumb-test","version":"0.0.0"}}}"#;
+
+fn bin() -> std::path::PathBuf {
+    cargo_bin("plumb")
+}
+
+fn reserve_port() -> io::Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+struct HttpServerChild {
+    child: Child,
+}
+
+impl Drop for HttpServerChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+async fn spawn_http_server(
+    token: &str,
+) -> Result<(HttpServerChild, u16), Box<dyn std::error::Error>> {
+    let port = reserve_port()?;
+    let mut child = Command::new(bin())
+        .args(["mcp", "--transport", "http", "--port", &port.to_string()])
+        .env("PLUMB_MCP_TOKEN", token)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    for _ in 0..50 {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Ok((HttpServerChild { child }, port));
+        }
+
+        if let Some(status) = child.try_wait()? {
+            return Err(
+                format!("http server exited before accepting connections: {status}").into(),
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    Err("timed out waiting for http server to accept connections".into())
+}
+
+async fn initialize_request(
+    port: u16,
+    authorization: Option<&str>,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+
+    let mut request = client
+        .post(format!("http://127.0.0.1:{port}/"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2025-03-26")
+        .body(INIT_BODY);
+
+    if let Some(authorization) = authorization {
+        request = request.header("Authorization", authorization);
+    }
+
+    request.send().await
+}
+
+#[test]
+fn http_transport_refuses_to_boot_without_token() {
+    Command::new(bin())
+        .args(["mcp", "--transport", "http", "--port", "4242"])
+        .env_remove("PLUMB_MCP_TOKEN")
+        .assert()
+        .code(2)
+        .stderr(contains("PLUMB_MCP_TOKEN"))
+        .stderr(contains("--transport http"));
+}
+
+#[test]
+fn http_transport_refuses_to_boot_with_empty_token() {
+    Command::new(bin())
+        .args(["mcp", "--transport", "http", "--port", "4242"])
+        .env("PLUMB_MCP_TOKEN", "")
+        .assert()
+        .code(2)
+        .stderr(contains("PLUMB_MCP_TOKEN"))
+        .stderr(contains("non-empty bearer token"));
+}
+
+#[tokio::test]
+async fn http_transport_rejects_requests_without_bearer_token()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_server, port) = spawn_http_server("secret-token").await?;
+
+    let response = initialize_request(port, None).await?;
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_transport_rejects_invalid_bearer_token() -> Result<(), Box<dyn std::error::Error>> {
+    let (_server, port) = spawn_http_server("secret-token").await?;
+
+    let response = initialize_request(port, Some("Bearer wrong-token")).await?;
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_transport_accepts_valid_bearer_token() -> Result<(), Box<dyn std::error::Error>> {
+    let (_server, port) = spawn_http_server("secret-token").await?;
+
+    let response = initialize_request(port, Some("Bearer secret-token")).await?;
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert!(response.headers().contains_key("mcp-session-id"));
+    Ok(())
+}

--- a/crates/plumb-mcp/AGENTS.md
+++ b/crates/plumb-mcp/AGENTS.md
@@ -3,15 +3,18 @@
 See `/AGENTS.md` for repo-wide rules. This file scopes to `plumb-mcp`.
 ## Purpose
 
-Model Context Protocol server exposed over stdio. Public surface:
-`PlumbServer`, `run_stdio`, `McpError`, `EchoArgs`, `LintUrlArgs`.
+Model Context Protocol server exposed over stdio by default, with an
+optional Streamable HTTP transport. Public surface: `PlumbServer`,
+`run_stdio`, `run_http`, `McpError`, `EchoArgs`, `LintUrlArgs`.
 Built on `rmcp 0.2.x` with the `#[tool_router]` + `#[tool]` +
 `#[tool_handler]` macros.
 
 ## Protocol
 
 - Protocol version: `ProtocolVersion::V_2024_11_05`.
-- Transport: stdio (`rmcp::transport::stdio`).
+- Transport:
+  - stdio by default (`rmcp::transport::stdio`)
+  - Streamable HTTP via `run_http`
 - Server info: name `plumb`, version from `CARGO_PKG_VERSION`.
 - Tool response contract (PRD §14.2):
   - `content[0]` — compact human text (one line per finding typical).
@@ -23,6 +26,9 @@ Built on `rmcp 0.2.x` with the `#[tool_router]` + `#[tool]` +
 - `#![forbid(unsafe_code)]`.
 - Every tool method validates its inputs and returns a typed error on
   malformed args — no `unwrap`/`expect`.
+- `run_http` requires a non-empty bearer token from the caller. Missing
+  or invalid `Authorization: Bearer <token>` headers are rejected with
+  HTTP 401 before the request reaches the MCP transport.
 - Response payloads are bounded: `structuredContent` caps at ~10 KB
   (aggregate + cap on violations; see PRD §14.2).
 - Deterministic output — no wall-clock, no random ordering, no env

--- a/crates/plumb-mcp/AGENTS.md
+++ b/crates/plumb-mcp/AGENTS.md
@@ -2,15 +2,13 @@
 
 See `/AGENTS.md` for repo-wide rules. This file scopes to `plumb-mcp`.
 ## Purpose
-
-Model Context Protocol server exposed over stdio by default, with an
-optional Streamable HTTP transport. Public surface: `PlumbServer`,
-`run_stdio`, `run_http`, `McpError`, `EchoArgs`, `LintUrlArgs`.
+Model Context Protocol server exposed over stdio by default, with optional
+Streamable HTTP transport. Public surface: `PlumbServer`, `run_stdio`,
+`run_http`, `McpError`, `EchoArgs`, `LintUrlArgs`.
 Built on `rmcp 0.2.x` with the `#[tool_router]` + `#[tool]` +
 `#[tool_handler]` macros.
 
 ## Protocol
-
 - Protocol version: `ProtocolVersion::V_2024_11_05`.
 - Transport:
   - stdio by default (`rmcp::transport::stdio`)
@@ -22,19 +20,18 @@ Built on `rmcp 0.2.x` with the `#[tool_router]` + `#[tool]` +
   - `isError: false` on non-error responses.
 
 ## Non-negotiable invariants
-
 - `#![forbid(unsafe_code)]`.
 - Every tool method validates its inputs and returns a typed error on
   malformed args — no `unwrap`/`expect`.
-- `run_http` requires a non-empty bearer token from the caller. Missing
-  or invalid `Authorization: Bearer <token>` headers are rejected with
-  HTTP 401 before the request reaches the MCP transport.
+- `run_http` requires a non-empty bearer token. Missing or invalid
+  `Authorization: Bearer <token>` headers are rejected with HTTP 401
+  before the request reaches the MCP transport.
 - Response payloads are bounded: `structuredContent` caps at ~10 KB
   (aggregate + cap on violations; see PRD §14.2).
 - Deterministic output — no wall-clock, no random ordering, no env
   read inside a tool call.
-- `allow(missing_docs)` is scoped only to the `#[tool_router]` impl
-  block (the macro synthesizes helpers that can't be doc-commented).
+- `allow(missing_docs)` is scoped only to the `#[tool_router]` impl block
+  (the macro synthesizes helpers that can't be doc-commented).
 
 ## Adding a new tool
 
@@ -47,8 +44,8 @@ See `.agents/rules/mcp-tool-patterns.md` for the handoff path. Summary:
 
 ## Depends on
 
-- `plumb-core` (types; `test-fake` feature enabled so `lint_url` can
-  serve the canned snapshot for `plumb-fake://` URLs).
+- `plumb-core` (types; `test-fake` lets `lint_url` serve the canned
+  snapshot for `plumb-fake://` URLs).
 - `plumb-cdp` (drives Chromium for real `http(s)://` URLs in `lint_url`).
 - `plumb-format` (mcp_compact).
 - `rmcp` (server + macros + transport-io + schemars features).
@@ -59,6 +56,5 @@ See `.agents/rules/mcp-tool-patterns.md` for the handoff path. Summary:
 - Streaming the full `PlumbSnapshot` back in a tool response. Snapshots
   are huge and agent-harmful — always aggregate.
 - A tool that mutates shared state. Every call is pure and re-entrant.
-- Embedding rule docs verbatim in `explain_rule`. Read from
-  `docs/src/rules/<slug>.md` so the book and the MCP response stay in
-  sync.
+- Embedding rule docs verbatim in `explain_rule`. Read from `docs/src/rules/<slug>.md`
+  so the book and the MCP response stay in sync.

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -23,6 +23,7 @@ plumb-config = { workspace = true }
 plumb-format = { workspace = true }
 rmcp = { workspace = true }
 tokio = { workspace = true }
+axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+subtle = { workspace = true }
 
 [dev-dependencies]
 plumb-core = { workspace = true, features = ["test-fake"] }

--- a/crates/plumb-mcp/README.md
+++ b/crates/plumb-mcp/README.md
@@ -2,10 +2,11 @@
 
 Model Context Protocol server for [Plumb](https://plumb.aramhammoudeh.com).
 
-Exposes Plumb's linting capabilities over stdio using the
+Exposes Plumb's linting capabilities over the
 [MCP](https://modelcontextprotocol.io) protocol, so AI coding agents
 (Claude Code, Cursor, Codex, Windsurf) can lint rendered pages and
-retrieve rule explanations programmatically.
+retrieve rule explanations programmatically. `plumb mcp` uses stdio by
+default and can also serve Streamable HTTP.
 
 ## Tools
 
@@ -14,6 +15,19 @@ retrieve rule explanations programmatically.
 | `lint_url` | Lint a URL and return compact violations |
 | `explain_rule` | Return the docs page for a rule |
 | `echo` | Health-check / connectivity test |
+
+## HTTP transport
+
+`plumb mcp --transport http --port 4242` binds the server to
+`127.0.0.1:<port>` and requires `PLUMB_MCP_TOKEN` at boot.
+
+Security notes:
+
+- There is no default token and no hardcoded fallback.
+- Empty `PLUMB_MCP_TOKEN` values are rejected before the server starts.
+- Every HTTP request must send `Authorization: Bearer <token>`.
+- Missing or invalid bearer tokens return `401 Unauthorized`.
+- The server logs the bind address, never the token value.
 
 ## License
 

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -767,8 +767,8 @@ pub async fn run_stdio(cwd: PathBuf) -> Result<(), McpError> {
 /// # Errors
 ///
 /// Returns [`McpError::Io`] when the TCP listener or HTTP server fails,
-/// and [`McpError::Service`] when the underlying MCP service cannot be
-/// constructed.
+/// and [`McpError::Service`] when graceful shutdown of the underlying
+/// MCP service fails.
 pub async fn run_http(cwd: PathBuf, addr: SocketAddr, token: String) -> Result<(), McpError> {
     let handler = PlumbServer::new(cwd);
     let service: StreamableHttpService<PlumbServer, LocalSessionManager> =

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -33,10 +33,18 @@ pub use explain::rule_ids as documented_rule_ids;
 
 use std::collections::HashMap;
 use std::io;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+};
 use plumb_cdp::{ChromiumOptions, PersistentBrowser, Target, is_fake_url};
 use plumb_config::ConfigError;
 use plumb_core::{Config, PlumbSnapshot, ViewportKey, Violation, register_builtin, run};
@@ -53,7 +61,10 @@ use rmcp::{
     },
     schemars::{self, JsonSchema},
     service::RequestContext,
-    transport::stdio,
+    transport::{
+        StreamableHttpServerConfig, StreamableHttpService, stdio,
+        streamable_http_server::session::local::LocalSessionManager,
+    },
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -70,6 +81,26 @@ pub enum McpError {
     /// rmcp service or transport failure.
     #[error("mcp service: {0}")]
     Service(String),
+}
+
+#[derive(Clone)]
+struct HttpAuthState {
+    token: HttpAuthToken,
+}
+
+#[derive(Clone)]
+struct HttpAuthToken(Arc<str>);
+
+impl HttpAuthToken {
+    fn new(token: String) -> Self {
+        Self(Arc::<str>::from(token))
+    }
+
+    fn matches_authorization_header(&self, value: &str) -> bool {
+        value
+            .strip_prefix("Bearer ")
+            .is_some_and(|candidate| secure_token_eq(self.0.as_bytes(), candidate.as_bytes()))
+    }
 }
 
 /// Arguments to the `echo` tool.
@@ -662,6 +693,37 @@ fn map_config_error(err: &ConfigError) -> ErrorData {
     ErrorData::internal_error(format!("load plumb.toml: {err}"), None)
 }
 
+fn secure_token_eq(expected: &[u8], actual: &[u8]) -> bool {
+    let mut diff = expected.len() ^ actual.len();
+    let max_len = expected.len().max(actual.len());
+
+    for index in 0..max_len {
+        let expected_byte = expected.get(index).copied().unwrap_or_default();
+        let actual_byte = actual.get(index).copied().unwrap_or_default();
+        diff |= usize::from(expected_byte ^ actual_byte);
+    }
+
+    diff == 0
+}
+
+async fn authenticate_http_request(
+    state: axum::extract::State<HttpAuthState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let authorized = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| state.token.matches_authorization_header(value));
+
+    if !authorized {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    next.run(request).await
+}
+
 /// Run the MCP server on stdin/stdout until EOF.
 ///
 /// On clean exit (EOF on stdin) the persistent browser, if it was
@@ -692,6 +754,47 @@ pub async fn run_stdio(cwd: PathBuf) -> Result<(), McpError> {
     // wins; only report a shutdown failure when the service itself
     // returned cleanly.
     service_result?;
+    shutdown_result?;
+    Ok(())
+}
+
+/// Run the MCP server over Streamable HTTP.
+///
+/// Requests must include `Authorization: Bearer <token>`. Missing or
+/// invalid bearer tokens are rejected with HTTP 401 before the request
+/// reaches the MCP transport.
+///
+/// # Errors
+///
+/// Returns [`McpError::Io`] when the TCP listener or HTTP server fails,
+/// and [`McpError::Service`] when the underlying MCP service cannot be
+/// constructed.
+pub async fn run_http(cwd: PathBuf, addr: SocketAddr, token: String) -> Result<(), McpError> {
+    let handler = PlumbServer::new(cwd);
+    let service: StreamableHttpService<PlumbServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            {
+                let handler = handler.clone();
+                move || Ok(handler.clone())
+            },
+            Arc::default(),
+            StreamableHttpServerConfig::default(),
+        );
+
+    let app = Router::new()
+        .fallback_service(service)
+        .layer(middleware::from_fn_with_state(
+            HttpAuthState {
+                token: HttpAuthToken::new(token),
+            },
+            authenticate_http_request,
+        ));
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let serve_result = axum::serve(listener, app).await.map_err(McpError::Io);
+    let shutdown_result = handler.shutdown().await;
+
+    serve_result?;
     shutdown_result?;
     Ok(())
 }

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -68,6 +68,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
+use subtle::ConstantTimeEq;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 
@@ -694,16 +695,15 @@ fn map_config_error(err: &ConfigError) -> ErrorData {
 }
 
 fn secure_token_eq(expected: &[u8], actual: &[u8]) -> bool {
-    let mut diff = expected.len() ^ actual.len();
-    let max_len = expected.len().max(actual.len());
+    expected.ct_eq(actual).into()
+}
 
-    for index in 0..max_len {
-        let expected_byte = expected.get(index).copied().unwrap_or_default();
-        let actual_byte = actual.get(index).copied().unwrap_or_default();
-        diff |= usize::from(expected_byte ^ actual_byte);
-    }
-
-    diff == 0
+fn unauthorized_bearer_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, "Bearer")],
+    )
+        .into_response()
 }
 
 async fn authenticate_http_request(
@@ -718,7 +718,7 @@ async fn authenticate_http_request(
         .is_some_and(|value| state.token.matches_authorization_header(value));
 
     if !authorized {
-        return StatusCode::UNAUTHORIZED.into_response();
+        return unauthorized_bearer_response();
     }
 
     next.run(request).await

--- a/deny.toml
+++ b/deny.toml
@@ -41,6 +41,9 @@ allow = [
     "BSL-1.0",
 ]
 exceptions = []
+[[licenses.exceptions]]
+allow = ["CDLA-Permissive-2.0"]
+crate = "webpki-roots@1.0.7"
 
 [[licenses.clarify]]
 name = "ring"

--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,6 @@ allow = [
     "0BSD",
     "BSL-1.0",
 ]
-exceptions = []
 [[licenses.exceptions]]
 allow = ["CDLA-Permissive-2.0"]
 crate = "webpki-roots@1.0.7"

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -1,8 +1,9 @@
 # MCP server
 
 `plumb mcp` runs an [MCP](https://modelcontextprotocol.io/) server on
-stdio. AI coding agents (Claude Code, Cursor, Codex, Windsurf) connect
-to it the same way they connect to any other MCP server.
+stdio by default. AI coding agents (Claude Code, Cursor, Codex,
+Windsurf) connect to it the same way they connect to any other MCP
+server.
 
 ## Configuring your agent
 
@@ -31,6 +32,29 @@ For local development against a source checkout:
   }
 }
 ```
+
+## Transports
+
+Stdio remains the default transport. Existing agent configs that invoke
+`plumb mcp` without extra flags do not change.
+
+Plumb also supports Streamable HTTP:
+
+```sh
+plumb mcp --transport http --port 4242
+```
+
+HTTP boot requires `PLUMB_MCP_TOKEN` to be set to a non-empty bearer
+token. If the variable is missing or empty, `plumb mcp --transport
+http` refuses to boot.
+
+Every HTTP request must send `Authorization: Bearer <token>`. Missing or
+invalid tokens return `401 Unauthorized` with
+`WWW-Authenticate: Bearer`.
+
+Keep the token private. Do not log it, paste it into chat, or commit it
+to the repository. The HTTP server binds to `127.0.0.1` and logs the
+bind address, not the token value.
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Closes #81

- add `plumb mcp --transport http --port <PORT>` alongside the existing stdio default
- require `PLUMB_MCP_TOKEN` at HTTP boot and reject missing/invalid bearer tokens with 401
- keep stdio as the default transport
- add focused CLI/MCP HTTP auth tests and MCP security notes

## Scope

- #81 only
- no #79/#80 tools
- no #73 baseline/rhythm work
- no #101/release tag/Homebrew/npm publication/token provisioning

## Validation

Codex reported validation during implementation, but the ACP run timed out before returning details. Verified after completion:

- `git diff --check HEAD~1..HEAD` — passed

Follow-up CI will run the full cargo test/clippy matrix.
