### PR TITLE
feat(core): add baseline/rhythm rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- Rule `baseline/rhythm`: flags text elements whose typographic baselines miss the configured vertical-rhythm grid.
 - Per-crate README files and package metadata for crates.io publishing.
 - `release-please.yml` crates-io publish job now uses bottom-up interleaved dry-run + publish, `--locked`, GitHub environment protection, and `::group::` log folding.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/plumb-cdp/benches/cdp_benchmarks.rs
+++ b/crates/plumb-cdp/benches/cdp_benchmarks.rs
@@ -133,6 +133,7 @@ fn synthetic_snapshot(n: usize) -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes,
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -48,7 +48,7 @@
 
 use indexmap::IndexMap;
 use plumb_core::report::Rect;
-use plumb_core::snapshot::SnapshotNode;
+use plumb_core::snapshot::{SnapshotNode, TextBox};
 use plumb_core::{PlumbSnapshot, ViewportKey};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -863,12 +863,15 @@ fn flatten_snapshot(
     finalize_nodes(&mut nodes, &tags, &parents);
     nodes.sort_by_key(|n| n.dom_order);
 
+    let text_boxes = extract_text_boxes(document, &layout_view, &node_to_dom_order);
+
     Ok(PlumbSnapshot {
         url: target.url.clone(),
         viewport: target.viewport.clone(),
         viewport_width: target.width,
         viewport_height: target.height,
         nodes,
+        text_boxes,
     })
 }
 
@@ -1014,6 +1017,72 @@ fn finalize_nodes(
         }
         node.selector = build_selector(node.dom_order, tags, parents);
     }
+}
+
+/// Extract text boxes from `document.text_boxes`, mapping layout indices
+/// back to `dom_order` via the layout view and node-to-dom-order map.
+///
+/// Gracefully skips entries whose layout index is out of range or
+/// points to a non-element node. Returns sorted by `(dom_order, start)`.
+fn extract_text_boxes(
+    document: &DocumentSnapshot,
+    layout_view: &LayoutView<'_>,
+    node_to_dom_order: &[Option<u64>],
+) -> Vec<TextBox> {
+    let tb = &document.text_boxes;
+    let count = tb.layout_index.len();
+
+    // Parallel arrays must agree on length; if not, return empty rather
+    // than panic — the snapshot is still usable without text boxes.
+    if tb.bounds.len() != count || tb.start.len() != count || tb.length.len() != count {
+        return Vec::new();
+    }
+
+    let mut result: Vec<TextBox> = Vec::with_capacity(count);
+    for i in 0..count {
+        let layout_idx = tb.layout_index[i];
+        let Ok(layout_idx_usize) = usize::try_from(layout_idx) else {
+            continue;
+        };
+        if layout_idx_usize >= layout_view.len() {
+            continue;
+        }
+        // layout_view.node_index maps layout slot → CDP node index.
+        let Ok(cdp_node_idx) = layout_view.node_index(layout_idx_usize) else {
+            continue;
+        };
+        let Ok(cdp_node_idx_usize) = usize::try_from(cdp_node_idx) else {
+            continue;
+        };
+        if cdp_node_idx_usize >= node_to_dom_order.len() {
+            continue;
+        }
+        let Some(dom_order) = node_to_dom_order[cdp_node_idx_usize] else {
+            continue;
+        };
+
+        let bounds_inner = tb.bounds[i].inner();
+        if bounds_inner.len() != 4 {
+            continue;
+        }
+        let bounds = rect_from_bounds(bounds_inner);
+
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let start = tb.start[i].max(0) as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let length = tb.length[i].max(0) as u32;
+
+        result.push(TextBox {
+            dom_order,
+            bounds,
+            start,
+            length,
+        });
+    }
+
+    // Sort by (dom_order, start) for determinism.
+    result.sort_by_key(|tb| (tb.dom_order, tb.start));
+    result
 }
 
 fn lookup_string(strings: &[String], idx: i64) -> Result<&str, CdpError> {

--- a/crates/plumb-cli/src/commands/selector.rs
+++ b/crates/plumb-cli/src/commands/selector.rs
@@ -155,6 +155,7 @@ fn rewrite(snapshot: PlumbSnapshot, kept: &BTreeSet<u64>) -> PlumbSnapshot {
         viewport_width,
         viewport_height,
         nodes,
+        text_boxes,
     } = snapshot;
 
     let new_nodes: Vec<SnapshotNode> = nodes
@@ -171,12 +172,19 @@ fn rewrite(snapshot: PlumbSnapshot, kept: &BTreeSet<u64>) -> PlumbSnapshot {
         })
         .collect();
 
+    // Keep only text boxes whose owning node was retained.
+    let new_text_boxes = text_boxes
+        .into_iter()
+        .filter(|tb| kept.contains(&tb.dom_order))
+        .collect();
+
     PlumbSnapshot {
         url,
         viewport,
         viewport_width,
         viewport_height,
         nodes: new_nodes,
+        text_boxes: new_text_boxes,
     }
 }
 
@@ -303,6 +311,7 @@ mod tests {
                 node(6, "p", Some(5), vec![]),
                 node(7, "footer", Some(2), vec![]),
             ],
+            text_boxes: Vec::new(),
         }
     }
 

--- a/crates/plumb-core/src/config.rs
+++ b/crates/plumb-core/src/config.rs
@@ -232,7 +232,7 @@ pub struct OpacitySpec {
     pub scale: Vec<f32>,
 }
 
-/// Vertical-rhythm spec (schema/defaults only -- rule lands in #73).
+/// Vertical-rhythm spec.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::struct_field_names)]

--- a/crates/plumb-core/src/lib.rs
+++ b/crates/plumb-core/src/lib.rs
@@ -35,4 +35,4 @@ pub use report::{
     Confidence, Fix, FixKind, Rect, RunId, Severity, ViewportKey, Violation, ViolationSink,
 };
 pub use rules::{Rule, RuleMetadata, builtin_rule_metadata, register_builtin};
-pub use snapshot::{PlumbSnapshot, SnapshotCtx};
+pub use snapshot::{PlumbSnapshot, SnapshotCtx, TextBox};

--- a/crates/plumb-core/src/rules/baseline/mod.rs
+++ b/crates/plumb-core/src/rules/baseline/mod.rs
@@ -1,0 +1,3 @@
+//! Baseline-rhythm rules.
+
+pub mod rhythm;

--- a/crates/plumb-core/src/rules/baseline/rhythm.rs
+++ b/crates/plumb-core/src/rules/baseline/rhythm.rs
@@ -135,7 +135,10 @@ impl Rule for Rhythm {
             let mut metadata = IndexMap::new();
             metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
             metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
-            metadata.insert("distance_px".to_owned(), JsonValue::from(distance));
+            metadata.insert(
+                "distance_px".to_owned(),
+                JsonValue::from((distance * 100.0).round() / 100.0),
+            );
 
             sink.push(Violation {
                 rule_id: self.id().to_owned(),

--- a/crates/plumb-core/src/rules/baseline/rhythm.rs
+++ b/crates/plumb-core/src/rules/baseline/rhythm.rs
@@ -129,52 +129,124 @@ impl Rule for Rhythm {
                 text_boxes.iter().map(|tb| f64::from(tb.bounds.y)).collect()
             };
 
-            for y_origin in y_origins {
-                // Approximate baseline Y position.
-                let baseline_y = y_origin + half_leading + cap_height;
-
-                // Distance to nearest grid line.
-                let nearest_grid_y = (baseline_y / base_line_f).round() * base_line_f;
-                let distance = (baseline_y - nearest_grid_y).abs();
-
-                if distance <= tolerance_f {
-                    continue;
-                }
-
-                let mut metadata = IndexMap::new();
-                metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
-                metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
-                metadata.insert(
-                    "distance_px".to_owned(),
-                    JsonValue::from((distance * 100.0).round() / 100.0),
-                );
-
-                sink.push(Violation {
-                    rule_id: self.id().to_owned(),
-                    severity: self.default_severity(),
-                    message: format!(
-                        "`{selector}` baseline at {baseline_y:.1}px is {distance:.1}px off the {base_line}px rhythm grid.",
-                        selector = node.selector,
-                    ),
-                    selector: node.selector.clone(),
-                    viewport: ctx.snapshot().viewport.clone(),
-                    rect: Some(rect),
-                    dom_order: node.dom_order,
-                    fix: Some(Fix {
-                        kind: FixKind::Description {
-                            text: format!(
-                                "Adjust line-height or margin-top so the baseline aligns to the nearest {base_line}px grid line ({nearest_grid_y:.0}px).",
-                            ),
-                        },
-                        description: format!(
-                            "Shift baseline from {baseline_y:.1}px to {nearest_grid_y:.0}px to restore vertical rhythm.",
-                        ),
-                        confidence: Confidence::Low,
-                    }),
-                    doc_url: "https://plumb.aramhammoudeh.com/rules/baseline-rhythm".to_owned(),
-                    metadata,
-                });
+            let off_grid_lines = collect_off_grid(
+                &y_origins,
+                half_leading,
+                cap_height,
+                base_line_f,
+                tolerance_f,
+            );
+            if off_grid_lines.is_empty() {
+                continue;
             }
+
+            sink.push(build_violation(
+                *self,
+                node,
+                ctx,
+                rect,
+                base_line,
+                &y_origins,
+                &off_grid_lines,
+            ));
         }
+    }
+}
+
+/// Collect `(baseline_y, nearest_grid_y, distance)` for each off-grid line.
+fn collect_off_grid(
+    y_origins: &[f64],
+    half_leading: f64,
+    cap_height: f64,
+    base_line_f: f64,
+    tolerance_f: f64,
+) -> Vec<(f64, f64, f64)> {
+    let mut result = Vec::new();
+    for &y_origin in y_origins {
+        let baseline_y = y_origin + half_leading + cap_height;
+        let nearest_grid_y = (baseline_y / base_line_f).round() * base_line_f;
+        let distance = (baseline_y - nearest_grid_y).abs();
+        if distance > tolerance_f {
+            result.push((baseline_y, nearest_grid_y, distance));
+        }
+    }
+    result
+}
+
+/// Build the aggregated violation for a single node.
+fn build_violation(
+    rule: Rhythm,
+    node: &crate::snapshot::SnapshotNode,
+    ctx: &SnapshotCtx<'_>,
+    rect: crate::report::Rect,
+    base_line: u32,
+    y_origins: &[f64],
+    off_grid_lines: &[(f64, f64, f64)],
+) -> Violation {
+    // Worst = largest distance. Caller guarantees non-empty.
+    let &(baseline_y, nearest_grid_y, distance) = off_grid_lines
+        .iter()
+        .max_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+        .unwrap_or(&off_grid_lines[0]);
+
+    let total_lines = y_origins.len();
+    let off_count = off_grid_lines.len();
+
+    let message = if off_count > 1 {
+        format!(
+            "`{selector}` has {off_count}/{total_lines} lines off the {base_line}px rhythm grid (worst: {distance:.1}px at {baseline_y:.1}px).",
+            selector = node.selector,
+        )
+    } else {
+        format!(
+            "`{selector}` baseline at {baseline_y:.1}px is {distance:.1}px off the {base_line}px rhythm grid.",
+            selector = node.selector,
+        )
+    };
+
+    let mut metadata = IndexMap::new();
+    metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
+    metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
+    metadata.insert(
+        "distance_px".to_owned(),
+        JsonValue::from((distance * 100.0).round() / 100.0),
+    );
+    metadata.insert(
+        "off_grid_lines".to_owned(),
+        JsonValue::Array(
+            off_grid_lines
+                .iter()
+                .map(|&(by, ngy, d)| {
+                    serde_json::json!({
+                        "baseline_y": by,
+                        "nearest_grid_y": ngy,
+                        "distance_px": (d * 100.0).round() / 100.0,
+                    })
+                })
+                .collect(),
+        ),
+    );
+
+    Violation {
+        rule_id: rule.id().to_owned(),
+        severity: rule.default_severity(),
+        message,
+        selector: node.selector.clone(),
+        viewport: ctx.snapshot().viewport.clone(),
+        rect: Some(rect),
+        dom_order: node.dom_order,
+        fix: Some(Fix {
+            kind: FixKind::Description {
+                text: format!(
+                    "Adjust line-height or margin-top so the baseline aligns to the nearest {base_line}px grid line ({nearest_grid_y:.0}px).",
+                ),
+            },
+            description: format!(
+                "Shift baseline from {baseline_y:.1}px to {nearest_grid_y:.0}px to restore vertical rhythm.",
+            ),
+            confidence: Confidence::Low,
+        }),
+        doc_url: "https://plumb.aramhammoudeh.com/rules/baseline-rhythm".to_owned(),
+        metadata,
     }
 }

--- a/crates/plumb-core/src/rules/baseline/rhythm.rs
+++ b/crates/plumb-core/src/rules/baseline/rhythm.rs
@@ -1,0 +1,167 @@
+//! `baseline/rhythm` — flag text elements whose baselines miss the
+//! configured vertical-rhythm grid.
+//!
+//! For each text-bearing element with a `font-size` and a bounding
+//! rect, the rule computes an approximate baseline position and checks
+//! whether it falls on a multiple of `rhythm.base_line_px` (within
+//! `rhythm.tolerance_px`).
+
+use indexmap::IndexMap;
+use serde_json::Value as JsonValue;
+
+use crate::config::Config;
+use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
+use crate::rules::Rule;
+use crate::rules::util::parse_px;
+use crate::snapshot::SnapshotCtx;
+
+/// Tags considered text-bearing for the purpose of this rule.
+const TEXT_TAGS: &[&str] = &[
+    "p",
+    "span",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "a",
+    "li",
+    "td",
+    "th",
+    "label",
+    "button",
+    "input",
+    "textarea",
+    "select",
+    "summary",
+    "dt",
+    "dd",
+    "figcaption",
+    "blockquote",
+    "cite",
+    "code",
+    "pre",
+    "em",
+    "strong",
+    "small",
+    "b",
+    "i",
+    "u",
+    "mark",
+    "time",
+    "abbr",
+];
+
+/// Typical Latin cap-height ratio (cap-height / font-size).
+const CAP_HEIGHT_RATIO: f64 = 0.7;
+
+/// Default line-height multiplier when the value is `normal` or missing.
+const DEFAULT_LINE_HEIGHT_RATIO: f64 = 1.2;
+
+/// Flags text elements whose baselines don't align to the rhythm grid.
+#[derive(Debug, Clone, Copy)]
+pub struct Rhythm;
+
+impl Rule for Rhythm {
+    fn id(&self) -> &'static str {
+        "baseline/rhythm"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn summary(&self) -> &'static str {
+        "Flags text elements whose baselines miss the vertical-rhythm grid."
+    }
+
+    fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
+        let base_line = config.rhythm.base_line_px;
+        if base_line == 0 {
+            return;
+        }
+        let base_line_f = f64::from(base_line);
+        let tolerance_f = f64::from(config.rhythm.tolerance_px);
+        let cap_fallback = config.rhythm.cap_height_fallback_px;
+
+        for node in ctx.nodes() {
+            if !TEXT_TAGS.contains(&node.tag.as_str()) {
+                continue;
+            }
+
+            let Some(rect) = ctx.rect_for(node.dom_order) else {
+                continue;
+            };
+
+            let Some(font_size_raw) = node.computed_styles.get("font-size") else {
+                continue;
+            };
+            let Some(font_size) = parse_px(font_size_raw) else {
+                continue;
+            };
+            if font_size <= 0.0 {
+                continue;
+            }
+
+            // Cap-height approximation.
+            let cap_height = if cap_fallback > 0 {
+                f64::from(cap_fallback)
+            } else {
+                font_size * CAP_HEIGHT_RATIO
+            };
+
+            // Line-height: parse from computed styles, fall back to 1.2 * font_size.
+            let line_height = node
+                .computed_styles
+                .get("line-height")
+                .and_then(|v| parse_px(v))
+                .unwrap_or(font_size * DEFAULT_LINE_HEIGHT_RATIO);
+
+            // half_leading = (line_height - font_size) / 2
+            let half_leading = (line_height - font_size) / 2.0;
+
+            // Approximate baseline Y position.
+            let baseline_y = f64::from(rect.y) + half_leading + cap_height;
+
+            // Distance to nearest grid line.
+            let nearest_grid_y = (baseline_y / base_line_f).round() * base_line_f;
+            let distance = (baseline_y - nearest_grid_y).abs();
+
+            if distance <= tolerance_f {
+                continue;
+            }
+
+            let mut metadata = IndexMap::new();
+            metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
+            metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
+            metadata.insert("distance_px".to_owned(), JsonValue::from(distance));
+
+            sink.push(Violation {
+                rule_id: self.id().to_owned(),
+                severity: self.default_severity(),
+                message: format!(
+                    "`{selector}` baseline at {baseline_y:.1}px is {distance:.1}px off the {base_line}px rhythm grid.",
+                    selector = node.selector,
+                ),
+                selector: node.selector.clone(),
+                viewport: ctx.snapshot().viewport.clone(),
+                rect: Some(rect),
+                dom_order: node.dom_order,
+                fix: Some(Fix {
+                    kind: FixKind::Description {
+                        text: format!(
+                            "Adjust line-height or margin-top so the baseline aligns to the nearest {base_line}px grid line ({nearest_grid_y:.0}px).",
+                        ),
+                    },
+                    description: format!(
+                        "Shift baseline from {baseline_y:.1}px to {nearest_grid_y:.0}px to restore vertical rhythm.",
+                    ),
+                    confidence: Confidence::Low,
+                }),
+                doc_url: "https://plumb.aramhammoudeh.com/rules/baseline-rhythm".to_owned(),
+                metadata,
+            });
+        }
+    }
+}

--- a/crates/plumb-core/src/rules/baseline/rhythm.rs
+++ b/crates/plumb-core/src/rules/baseline/rhythm.rs
@@ -121,50 +121,60 @@ impl Rule for Rhythm {
             // half_leading = (line_height - font_size) / 2
             let half_leading = (line_height - font_size) / 2.0;
 
-            // Approximate baseline Y position.
-            let baseline_y = f64::from(rect.y) + half_leading + cap_height;
+            // Prefer text boxes (per-line fragments) over element rect.
+            let text_boxes = ctx.text_boxes_for(node.dom_order);
+            let y_origins: Vec<f64> = if text_boxes.is_empty() {
+                vec![f64::from(rect.y)]
+            } else {
+                text_boxes.iter().map(|tb| f64::from(tb.bounds.y)).collect()
+            };
 
-            // Distance to nearest grid line.
-            let nearest_grid_y = (baseline_y / base_line_f).round() * base_line_f;
-            let distance = (baseline_y - nearest_grid_y).abs();
+            for y_origin in y_origins {
+                // Approximate baseline Y position.
+                let baseline_y = y_origin + half_leading + cap_height;
 
-            if distance <= tolerance_f {
-                continue;
-            }
+                // Distance to nearest grid line.
+                let nearest_grid_y = (baseline_y / base_line_f).round() * base_line_f;
+                let distance = (baseline_y - nearest_grid_y).abs();
 
-            let mut metadata = IndexMap::new();
-            metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
-            metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
-            metadata.insert(
-                "distance_px".to_owned(),
-                JsonValue::from((distance * 100.0).round() / 100.0),
-            );
+                if distance <= tolerance_f {
+                    continue;
+                }
 
-            sink.push(Violation {
-                rule_id: self.id().to_owned(),
-                severity: self.default_severity(),
-                message: format!(
-                    "`{selector}` baseline at {baseline_y:.1}px is {distance:.1}px off the {base_line}px rhythm grid.",
-                    selector = node.selector,
-                ),
-                selector: node.selector.clone(),
-                viewport: ctx.snapshot().viewport.clone(),
-                rect: Some(rect),
-                dom_order: node.dom_order,
-                fix: Some(Fix {
-                    kind: FixKind::Description {
-                        text: format!(
-                            "Adjust line-height or margin-top so the baseline aligns to the nearest {base_line}px grid line ({nearest_grid_y:.0}px).",
-                        ),
-                    },
-                    description: format!(
-                        "Shift baseline from {baseline_y:.1}px to {nearest_grid_y:.0}px to restore vertical rhythm.",
+                let mut metadata = IndexMap::new();
+                metadata.insert("baseline_y".to_owned(), JsonValue::from(baseline_y));
+                metadata.insert("nearest_grid_y".to_owned(), JsonValue::from(nearest_grid_y));
+                metadata.insert(
+                    "distance_px".to_owned(),
+                    JsonValue::from((distance * 100.0).round() / 100.0),
+                );
+
+                sink.push(Violation {
+                    rule_id: self.id().to_owned(),
+                    severity: self.default_severity(),
+                    message: format!(
+                        "`{selector}` baseline at {baseline_y:.1}px is {distance:.1}px off the {base_line}px rhythm grid.",
+                        selector = node.selector,
                     ),
-                    confidence: Confidence::Low,
-                }),
-                doc_url: "https://plumb.aramhammoudeh.com/rules/baseline-rhythm".to_owned(),
-                metadata,
-            });
+                    selector: node.selector.clone(),
+                    viewport: ctx.snapshot().viewport.clone(),
+                    rect: Some(rect),
+                    dom_order: node.dom_order,
+                    fix: Some(Fix {
+                        kind: FixKind::Description {
+                            text: format!(
+                                "Adjust line-height or margin-top so the baseline aligns to the nearest {base_line}px grid line ({nearest_grid_y:.0}px).",
+                            ),
+                        },
+                        description: format!(
+                            "Shift baseline from {baseline_y:.1}px to {nearest_grid_y:.0}px to restore vertical rhythm.",
+                        ),
+                        confidence: Confidence::Low,
+                    }),
+                    doc_url: "https://plumb.aramhammoudeh.com/rules/baseline-rhythm".to_owned(),
+                    metadata,
+                });
+            }
         }
     }
 }

--- a/crates/plumb-core/src/rules/mod.rs
+++ b/crates/plumb-core/src/rules/mod.rs
@@ -9,6 +9,7 @@
 //! 4. Document it at `docs/src/rules/<rule-id>.md`.
 
 pub mod a11y;
+pub mod baseline;
 pub mod color;
 pub mod edge;
 pub mod opacity;
@@ -87,6 +88,7 @@ pub trait Rule: Send + Sync {
 pub fn register_builtin() -> Vec<Box<dyn Rule>> {
     vec![
         Box::new(a11y::touch_target::TouchTarget),
+        Box::new(baseline::rhythm::Rhythm),
         Box::new(color::contrast_aa::ContrastAa),
         Box::new(color::palette_conformance::PaletteConformance),
         Box::new(edge::near_alignment::NearAlignment),

--- a/crates/plumb-core/src/snapshot.rs
+++ b/crates/plumb-core/src/snapshot.rs
@@ -9,6 +9,23 @@ use serde::{Deserialize, Serialize};
 
 use crate::report::{Rect, ViewportKey};
 
+/// A single post-layout text box within a node.
+///
+/// CDP returns one text box per rendered line fragment. Multi-line text
+/// generates multiple boxes for the same `dom_order`. The bounds are
+/// absolute viewport coordinates for that line fragment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextBox {
+    /// `dom_order` of the owning element node.
+    pub dom_order: u64,
+    /// Absolute bounding rect of this text fragment.
+    pub bounds: Rect,
+    /// Starting character index (UTF-16 code units).
+    pub start: u32,
+    /// Character count (UTF-16 code units).
+    pub length: u32,
+}
+
 /// A single DOM node as the engine sees it.
 ///
 /// This is intentionally a narrow view: just enough to identify the element
@@ -48,6 +65,8 @@ pub struct PlumbSnapshot {
     pub viewport_height: u32,
     /// All nodes, ordered by `dom_order`.
     pub nodes: Vec<SnapshotNode>,
+    /// Post-layout text boxes, sorted by `(dom_order, start)` for determinism.
+    pub text_boxes: Vec<TextBox>,
 }
 
 impl PlumbSnapshot {
@@ -83,6 +102,7 @@ impl PlumbSnapshot {
             viewport: ViewportKey::new("desktop"),
             viewport_width: 1280,
             viewport_height: 800,
+            text_boxes: Vec::new(),
             nodes: vec![
                 SnapshotNode {
                     dom_order: 0,
@@ -139,6 +159,8 @@ pub struct SnapshotCtx<'a> {
     snapshot: &'a PlumbSnapshot,
     viewports: Vec<ViewportKey>,
     rects_by_dom_order: IndexMap<u64, Rect>,
+    /// Maps `dom_order` → `(start_index, count)` into `snapshot.text_boxes`.
+    text_box_ranges: IndexMap<u64, (usize, usize)>,
 }
 
 impl<'a> SnapshotCtx<'a> {
@@ -160,6 +182,7 @@ impl<'a> SnapshotCtx<'a> {
             snapshot,
             viewports: viewports.into_iter().collect(),
             rects_by_dom_order: rect_index(snapshot),
+            text_box_ranges: text_box_index(snapshot),
         }
     }
 
@@ -181,6 +204,17 @@ impl<'a> SnapshotCtx<'a> {
         self.rects_by_dom_order.get(&dom_order).copied()
     }
 
+    /// Return text boxes for a node by document-order index.
+    ///
+    /// Returns an empty slice when no text boxes exist for `dom_order`.
+    #[must_use]
+    pub fn text_boxes_for(&self, dom_order: u64) -> &[TextBox] {
+        match self.text_box_ranges.get(&dom_order) {
+            Some(&(start, count)) => &self.snapshot.text_boxes[start..start + count],
+            None => &[],
+        }
+    }
+
     /// Iterate nodes in document order.
     pub fn nodes(&self) -> impl Iterator<Item = &SnapshotNode> {
         self.snapshot.nodes.iter()
@@ -193,4 +227,22 @@ fn rect_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, Rect> {
         .iter()
         .filter_map(|node| node.rect.map(|rect| (node.dom_order, rect)))
         .collect()
+}
+
+/// Build a `(dom_order → (start_idx, count))` index over text boxes.
+///
+/// Requires `text_boxes` to be sorted by `(dom_order, start)`.
+fn text_box_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, (usize, usize)> {
+    let mut index: IndexMap<u64, (usize, usize)> = IndexMap::new();
+    let boxes = &snapshot.text_boxes;
+    let mut i = 0;
+    while i < boxes.len() {
+        let dom_order = boxes[i].dom_order;
+        let start = i;
+        while i < boxes.len() && boxes[i].dom_order == dom_order {
+            i += 1;
+        }
+        index.insert(dom_order, (start, i - start));
+    }
+    index
 }

--- a/crates/plumb-core/src/snapshot.rs
+++ b/crates/plumb-core/src/snapshot.rs
@@ -233,6 +233,13 @@ fn rect_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, Rect> {
 ///
 /// Requires `text_boxes` to be sorted by `(dom_order, start)`.
 fn text_box_index(snapshot: &PlumbSnapshot) -> IndexMap<u64, (usize, usize)> {
+    debug_assert!(
+        snapshot
+            .text_boxes
+            .windows(2)
+            .all(|w| { (w[0].dom_order, w[0].start) <= (w[1].dom_order, w[1].start) }),
+        "text_boxes must be sorted by (dom_order, start)"
+    );
     let mut index: IndexMap<u64, (usize, usize)> = IndexMap::new();
     let boxes = &snapshot.text_boxes;
     let mut i = 0;

--- a/crates/plumb-core/tests/dogfood_phase_gate.rs
+++ b/crates/plumb-core/tests/dogfood_phase_gate.rs
@@ -213,6 +213,7 @@ fn dogfood_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes,
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_a11y_touch_target.rs
+++ b/crates/plumb-core/tests/golden_a11y_touch_target.rs
@@ -101,6 +101,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes,
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_baseline_rhythm.rs
+++ b/crates/plumb-core/tests/golden_baseline_rhythm.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use plumb_core::config::RhythmSpec;
 use plumb_core::report::Rect;
 use plumb_core::snapshot::SnapshotNode;
-use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+use plumb_core::{Config, PlumbSnapshot, TextBox, ViewportKey, run};
 
 fn fixture_snapshot() -> PlumbSnapshot {
     // Node on-grid: font-size 16px, line-height 24px, rect.y = 0.
@@ -80,6 +80,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), on_grid, off_grid, non_text],
+        text_boxes: Vec::new(),
     }
 }
 
@@ -251,6 +252,7 @@ fn baseline_rhythm_falls_back_on_line_height_normal() {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), node_no_lh],
+        text_boxes: Vec::new(),
     };
     let config = Config {
         rhythm: RhythmSpec {
@@ -273,5 +275,163 @@ fn baseline_rhythm_falls_back_on_line_height_normal() {
         violations[0].message.contains("12.8px"),
         "baseline should use 1.2× fallback: {}",
         violations[0].message,
+    );
+}
+
+#[test]
+fn baseline_rhythm_multiline_text_boxes() {
+    // One <p> with two text box lines at different Y positions.
+    // font_size=16, line_height=24, half_leading=4, cap_height=11.2.
+    //
+    // Line 1: text_box y=9 → baseline_y = 9+4+11.2 = 24.2 → nearest 24 → dist 0.2 < 2 (on-grid).
+    // Line 2: text_box y=38 → baseline_y = 38+4+11.2 = 53.2 → nearest 48 → dist 5.2 > 2 (off-grid!).
+    let node = text_node(
+        2,
+        "html > body > p:nth-child(1)",
+        "p",
+        &[("font-size", "16px"), ("line-height", "24px")],
+        Some(Rect {
+            x: 0,
+            y: 9,
+            width: 600,
+            height: 60,
+        }),
+    );
+    let snapshot = PlumbSnapshot {
+        url: "plumb-fake://baseline-rhythm-multiline".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), node],
+        text_boxes: vec![
+            TextBox {
+                dom_order: 2,
+                bounds: Rect {
+                    x: 0,
+                    y: 9,
+                    width: 500,
+                    height: 24,
+                },
+                start: 0,
+                length: 40,
+            },
+            TextBox {
+                dom_order: 2,
+                bounds: Rect {
+                    x: 0,
+                    y: 38,
+                    width: 500,
+                    height: 24,
+                },
+                start: 40,
+                length: 35,
+            },
+        ],
+    };
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+    // Only line 2 is off-grid; line 1 is within tolerance.
+    assert_eq!(
+        violations.len(),
+        1,
+        "multi-line: only the off-grid line should produce a violation",
+    );
+    assert!(
+        violations[0].message.contains("53.2px"),
+        "violation should reference the second line's baseline: {}",
+        violations[0].message,
+    );
+}
+
+#[test]
+fn baseline_rhythm_multifont_text_boxes() {
+    // Two <p> nodes with different font sizes, each with a text box.
+    // Config: base_line_px=24, tolerance_px=2.
+    //
+    // Node A: font_size=16, line_height=24, text_box y=9.
+    //   half_leading=(24-16)/2=4, cap_height=16*0.7=11.2
+    //   baseline_y = 9+4+11.2 = 24.2 → nearest 24 → dist 0.2 < 2 (on-grid).
+    //
+    // Node B: font_size=20, line_height=28, text_box y=50.
+    //   half_leading=(28-20)/2=4, cap_height=20*0.7=14
+    //   baseline_y = 50+4+14 = 68.0 → nearest 72 → dist 4.0 > 2 (off-grid!).
+    let node_a = text_node(
+        2,
+        "html > body > p:nth-child(1)",
+        "p",
+        &[("font-size", "16px"), ("line-height", "24px")],
+        Some(Rect {
+            x: 0,
+            y: 9,
+            width: 600,
+            height: 24,
+        }),
+    );
+    let node_b = text_node(
+        3,
+        "html > body > h2:nth-child(2)",
+        "h2",
+        &[("font-size", "20px"), ("line-height", "28px")],
+        Some(Rect {
+            x: 0,
+            y: 50,
+            width: 600,
+            height: 28,
+        }),
+    );
+    let snapshot = PlumbSnapshot {
+        url: "plumb-fake://baseline-rhythm-multifont".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), node_a, node_b],
+        text_boxes: vec![
+            TextBox {
+                dom_order: 2,
+                bounds: Rect {
+                    x: 0,
+                    y: 9,
+                    width: 500,
+                    height: 24,
+                },
+                start: 0,
+                length: 30,
+            },
+            TextBox {
+                dom_order: 3,
+                bounds: Rect {
+                    x: 0,
+                    y: 50,
+                    width: 500,
+                    height: 28,
+                },
+                start: 0,
+                length: 20,
+            },
+        ],
+    };
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+    // Only node B (h2, 20px font) should be off-grid.
+    assert_eq!(
+        violations.len(),
+        1,
+        "multi-font: only the off-grid node should produce a violation",
+    );
+    assert!(
+        violations[0].message.contains("68.0px"),
+        "violation should reference the h2 baseline: {}",
+        violations[0].message,
+    );
+    assert!(
+        violations[0].selector.contains("h2"),
+        "violation should be on the h2 node: {}",
+        violations[0].selector,
     );
 }

--- a/crates/plumb-core/tests/golden_baseline_rhythm.rs
+++ b/crates/plumb-core/tests/golden_baseline_rhythm.rs
@@ -1,0 +1,179 @@
+//! Golden snapshot for the `baseline/rhythm` rule.
+//!
+//! Hand-built fixture with three nodes:
+//! - A `<p>` ON the 24px rhythm grid (no violation).
+//! - A `<p>` OFF the 24px rhythm grid (violation expected).
+//! - A `<div>` (non-text element, skipped).
+
+use indexmap::IndexMap;
+use plumb_core::config::RhythmSpec;
+use plumb_core::report::Rect;
+use plumb_core::snapshot::SnapshotNode;
+use plumb_core::{Config, PlumbSnapshot, ViewportKey, run};
+
+fn fixture_snapshot() -> PlumbSnapshot {
+    // Node on-grid: font-size 16px, line-height 24px, rect.y = 0.
+    // cap_height = 16 * 0.7 = 11.2
+    // half_leading = (24 - 16) / 2 = 4
+    // baseline_y = 0 + 4 + 11.2 = 15.2
+    // nearest grid = round(15.2 / 24) * 24 = 1 * 24 = 24
+    // distance = |15.2 - 24| = 8.8 ... that's off-grid.
+    //
+    // To get ON grid: we need baseline_y to be a multiple of 24 within
+    // tolerance 2. Let's set rect.y = 9 so baseline_y = 9 + 4 + 11.2 = 24.2.
+    // distance = |24.2 - 24| = 0.2 < tolerance 2. On-grid.
+    let on_grid = text_node(
+        2,
+        "html > body > p:nth-child(1)",
+        "p",
+        &[("font-size", "16px"), ("line-height", "24px")],
+        Some(Rect {
+            x: 0,
+            y: 9,
+            width: 600,
+            height: 24,
+        }),
+    );
+
+    // Node off-grid: font-size 16px, line-height 24px, rect.y = 5.
+    // baseline_y = 5 + 4 + 11.2 = 20.2
+    // nearest grid = round(20.2 / 24) * 24 = 1 * 24 = 24
+    // distance = |20.2 - 24| = 3.8 > tolerance 2. Off-grid!
+    let off_grid = text_node(
+        3,
+        "html > body > p:nth-child(2)",
+        "p",
+        &[("font-size", "16px"), ("line-height", "24px")],
+        Some(Rect {
+            x: 0,
+            y: 5,
+            width: 600,
+            height: 24,
+        }),
+    );
+
+    // Non-text node (div) — should be skipped entirely.
+    let non_text = SnapshotNode {
+        dom_order: 4,
+        selector: "html > body > div".to_owned(),
+        tag: "div".to_owned(),
+        attrs: IndexMap::new(),
+        computed_styles: {
+            let mut s = IndexMap::new();
+            s.insert("font-size".to_owned(), "16px".to_owned());
+            s.insert("line-height".to_owned(), "24px".to_owned());
+            s
+        },
+        rect: Some(Rect {
+            x: 0,
+            y: 5,
+            width: 600,
+            height: 24,
+        }),
+        parent: Some(1),
+        children: Vec::new(),
+    };
+
+    PlumbSnapshot {
+        url: "plumb-fake://baseline-rhythm".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), on_grid, off_grid, non_text],
+    }
+}
+
+fn root_html() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 0,
+        selector: "html".into(),
+        tag: "html".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: None,
+        children: vec![1],
+    }
+}
+
+fn body_node() -> SnapshotNode {
+    SnapshotNode {
+        dom_order: 1,
+        selector: "html > body".into(),
+        tag: "body".into(),
+        attrs: IndexMap::new(),
+        computed_styles: IndexMap::new(),
+        rect: Some(Rect {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 800,
+        }),
+        parent: Some(0),
+        children: vec![2, 3, 4],
+    }
+}
+
+fn text_node(
+    dom_order: u64,
+    selector: &str,
+    tag: &str,
+    styles: &[(&str, &str)],
+    rect: Option<Rect>,
+) -> SnapshotNode {
+    let mut computed_styles = IndexMap::new();
+    for (prop, value) in styles {
+        computed_styles.insert((*prop).to_owned(), (*value).to_owned());
+    }
+    SnapshotNode {
+        dom_order,
+        selector: selector.to_owned(),
+        tag: tag.to_owned(),
+        attrs: IndexMap::new(),
+        computed_styles,
+        rect,
+        parent: Some(1),
+        children: Vec::new(),
+    }
+}
+
+fn fixture_config() -> Config {
+    Config {
+        rhythm: RhythmSpec {
+            base_line_px: 24,
+            tolerance_px: 2,
+            cap_height_fallback_px: 0,
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn baseline_rhythm_golden() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+    let json = serde_json::to_string_pretty(&violations)?;
+    insta::assert_snapshot!("baseline_rhythm", json);
+    Ok(())
+}
+
+#[test]
+fn baseline_rhythm_run_is_deterministic() -> Result<(), serde_json::Error> {
+    let snapshot = fixture_snapshot();
+    let config = fixture_config();
+    let a = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let b = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    let c = serde_json::to_string_pretty(&run(&snapshot, &config))?;
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    Ok(())
+}

--- a/crates/plumb-core/tests/golden_baseline_rhythm.rs
+++ b/crates/plumb-core/tests/golden_baseline_rhythm.rs
@@ -435,3 +435,88 @@ fn baseline_rhythm_multifont_text_boxes() {
         violations[0].selector,
     );
 }
+
+#[test]
+fn baseline_rhythm_multiline_both_off_grid() {
+    // One <p> with two text box lines, BOTH off the 24px grid.
+    // font_size=16, line_height=24, half_leading=4, cap_height=11.2.
+    //
+    // Line 1: text_box y=0 → baseline_y = 0+4+11.2 = 15.2 → nearest 24 → dist 8.8 > 2 (off-grid!)
+    // Line 2: text_box y=38 → baseline_y = 38+4+11.2 = 53.2 → nearest 48 → dist 5.2 > 2 (off-grid!)
+    //
+    // Expect exactly ONE aggregated violation with the multi-line message format.
+    let node = text_node(
+        2,
+        "html > body > p:nth-child(1)",
+        "p",
+        &[("font-size", "16px"), ("line-height", "24px")],
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 600,
+            height: 62,
+        }),
+    );
+    let snapshot = PlumbSnapshot {
+        url: "plumb-fake://baseline-rhythm-both-off".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), node],
+        text_boxes: vec![
+            TextBox {
+                dom_order: 2,
+                bounds: Rect {
+                    x: 0,
+                    y: 0,
+                    width: 500,
+                    height: 24,
+                },
+                start: 0,
+                length: 40,
+            },
+            TextBox {
+                dom_order: 2,
+                bounds: Rect {
+                    x: 0,
+                    y: 38,
+                    width: 500,
+                    height: 24,
+                },
+                start: 40,
+                length: 35,
+            },
+        ],
+    };
+    let config = fixture_config();
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+
+    assert_eq!(
+        violations.len(),
+        1,
+        "both off-grid lines must produce exactly one aggregated violation",
+    );
+    assert!(
+        violations[0].message.contains("has 2/2 lines off"),
+        "message should use aggregated format: {}",
+        violations[0].message,
+    );
+    // Worst distance is 8.8 (line 1), so that's the primary metadata.
+    assert!(
+        violations[0].message.contains("8.8px"),
+        "message should reference worst distance: {}",
+        violations[0].message,
+    );
+    // Metadata should contain off_grid_lines array with 2 entries.
+    let off_grid_lines = violations[0]
+        .metadata
+        .get("off_grid_lines")
+        .expect("metadata must contain off_grid_lines");
+    let arr = off_grid_lines
+        .as_array()
+        .expect("off_grid_lines must be an array");
+    assert_eq!(arr.len(), 2, "off_grid_lines must have 2 entries");
+}

--- a/crates/plumb-core/tests/golden_baseline_rhythm.rs
+++ b/crates/plumb-core/tests/golden_baseline_rhythm.rs
@@ -177,3 +177,101 @@ fn baseline_rhythm_run_is_deterministic() -> Result<(), serde_json::Error> {
     assert_eq!(b, c);
     Ok(())
 }
+
+#[test]
+fn baseline_rhythm_skips_when_base_line_px_is_zero() {
+    let snapshot = fixture_snapshot();
+    let config = Config {
+        rhythm: RhythmSpec {
+            base_line_px: 0,
+            tolerance_px: 2,
+            cap_height_fallback_px: 0,
+        },
+        ..Config::default()
+    };
+    assert!(
+        !run(&snapshot, &config)
+            .into_iter()
+            .any(|v| v.rule_id == "baseline/rhythm"),
+        "base_line_px=0 must skip the rule entirely"
+    );
+}
+
+#[test]
+fn baseline_rhythm_uses_cap_height_fallback() {
+    // With cap_height_fallback_px = 12, cap_height = 12 (not 16*0.7=11.2).
+    // off_grid node: rect.y=5, half_leading=(24-16)/2=4, baseline_y=5+4+12=21.
+    // nearest_grid = round(21/24)*24 = 24, distance = 3 > tolerance 2 → violation.
+    let snapshot = fixture_snapshot();
+    let config = Config {
+        rhythm: RhythmSpec {
+            base_line_px: 24,
+            tolerance_px: 2,
+            cap_height_fallback_px: 12,
+        },
+        ..Config::default()
+    };
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+    assert_eq!(
+        violations.len(),
+        1,
+        "cap_height_fallback_px=12 must still flag the off-grid node"
+    );
+    assert!(
+        violations[0].message.contains("21.0px"),
+        "baseline should use fallback cap-height: {}",
+        violations[0].message,
+    );
+}
+
+#[test]
+fn baseline_rhythm_falls_back_on_line_height_normal() {
+    // Node with no line-height style → falls back to font_size * 1.2.
+    // font_size=16, line_height=16*1.2=19.2, half_leading=(19.2-16)/2=1.6
+    // cap_height=16*0.7=11.2, baseline_y=0+1.6+11.2=12.8
+    // nearest_grid = round(12.8/24)*24 = 24, distance=11.2 > tolerance → violation.
+    let node_no_lh = text_node(
+        2,
+        "html > body > p:nth-child(1)",
+        "p",
+        &[("font-size", "16px")],
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 600,
+            height: 20,
+        }),
+    );
+    let snapshot = PlumbSnapshot {
+        url: "plumb-fake://baseline-rhythm-lh-normal".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html(), body_node(), node_no_lh],
+    };
+    let config = Config {
+        rhythm: RhythmSpec {
+            base_line_px: 24,
+            tolerance_px: 2,
+            cap_height_fallback_px: 0,
+        },
+        ..Config::default()
+    };
+    let violations: Vec<plumb_core::Violation> = run(&snapshot, &config)
+        .into_iter()
+        .filter(|v| v.rule_id == "baseline/rhythm")
+        .collect();
+    assert_eq!(
+        violations.len(),
+        1,
+        "missing line-height must fall back to 1.2×font-size"
+    );
+    assert!(
+        violations[0].message.contains("12.8px"),
+        "baseline should use 1.2× fallback: {}",
+        violations[0].message,
+    );
+}

--- a/crates/plumb-core/tests/golden_color_contrast_aa.rs
+++ b/crates/plumb-core/tests/golden_color_contrast_aa.rs
@@ -94,6 +94,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
                 1,
             ),
         ],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_color_palette_conformance.rs
+++ b/crates/plumb-core/tests/golden_color_palette_conformance.rs
@@ -88,6 +88,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
             off_palette,
             translucent,
         ],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_edge_near_alignment.rs
+++ b/crates/plumb-core/tests/golden_edge_near_alignment.rs
@@ -36,6 +36,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), card_a, card_b, card_c],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_opacity_scale_conformance.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), on_scale, off_scale, opaque],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_radius_scale.rs
+++ b/crates/plumb-core/tests/golden_radius_scale.rs
@@ -70,6 +70,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), in_scale, off_scale_a, off_scale_b],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_shadow_scale_conformance.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), on_scale, off_scale, none_shadow],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_sibling_height_consistency.rs
+++ b/crates/plumb-core/tests/golden_sibling_height_consistency.rs
@@ -104,6 +104,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
             stack_btn_b,
             stack_btn_c,
         ],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
+++ b/crates/plumb-core/tests/golden_sibling_padding_consistency.rs
@@ -65,6 +65,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), parent, child_a, child_b, child_c],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_spacing_grid.rs
+++ b/crates/plumb-core/tests/golden_spacing_grid.rs
@@ -97,6 +97,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
             off_grid_a,
             off_grid_b,
         ],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_spacing_scale.rs
+++ b/crates/plumb-core/tests/golden_spacing_scale.rs
@@ -92,6 +92,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), in_scale, off_scale_a, off_scale_b],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_type_family_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_family_conformance.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), allowed, disallowed, missing],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_type_scale.rs
+++ b/crates/plumb-core/tests/golden_type_scale.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), in_scale, off_scale_a, off_scale_b],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_type_weight_conformance.rs
+++ b/crates/plumb-core/tests/golden_type_weight_conformance.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), on_scale, off_scale, non_numeric],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/golden_z_scale_conformance.rs
+++ b/crates/plumb-core/tests/golden_z_scale_conformance.rs
@@ -50,6 +50,7 @@ fn fixture_snapshot() -> PlumbSnapshot {
         viewport_width: 1280,
         viewport_height: 800,
         nodes: vec![root_html(), body_node(), on_scale, off_scale, auto_z],
+        text_boxes: Vec::new(),
     }
 }
 

--- a/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
+++ b/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
@@ -1,0 +1,35 @@
+---
+source: crates/plumb-core/tests/golden_baseline_rhythm.rs
+assertion_line: 165
+expression: json
+---
+[
+  {
+    "rule_id": "baseline/rhythm",
+    "severity": "warning",
+    "message": "`html > body > p:nth-child(2)` baseline at 20.2px is 3.8px off the 24px rhythm grid.",
+    "selector": "html > body > p:nth-child(2)",
+    "viewport": "desktop",
+    "rect": {
+      "x": 0,
+      "y": 5,
+      "width": 600,
+      "height": 24
+    },
+    "dom_order": 3,
+    "fix": {
+      "kind": {
+        "kind": "description",
+        "text": "Adjust line-height or margin-top so the baseline aligns to the nearest 24px grid line (24px)."
+      },
+      "description": "Shift baseline from 20.2px to 24px to restore vertical rhythm.",
+      "confidence": "low"
+    },
+    "doc_url": "https://plumb.aramhammoudeh.com/rules/baseline-rhythm",
+    "metadata": {
+      "baseline_y": 20.2,
+      "nearest_grid_y": 24.0,
+      "distance_px": 3.8000000000000007
+    }
+  }
+]

--- a/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
+++ b/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
@@ -29,7 +29,14 @@ expression: json
     "metadata": {
       "baseline_y": 20.2,
       "nearest_grid_y": 24.0,
-      "distance_px": 3.8
+      "distance_px": 3.8,
+      "off_grid_lines": [
+        {
+          "baseline_y": 20.2,
+          "nearest_grid_y": 24.0,
+          "distance_px": 3.8
+        }
+      ]
     }
   }
 ]

--- a/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
+++ b/crates/plumb-core/tests/snapshots/golden_baseline_rhythm__baseline_rhythm.snap
@@ -29,7 +29,7 @@ expression: json
     "metadata": {
       "baseline_y": 20.2,
       "nearest_grid_y": 24.0,
-      "distance_px": 3.8000000000000007
+      "distance_px": 3.8
     }
   }
 ]

--- a/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__sarif.snap
@@ -28,6 +28,20 @@ expression: out
               }
             },
             {
+              "id": "baseline/rhythm",
+              "name": "baseline-rhythm",
+              "shortDescription": {
+                "text": "Flags text elements whose baselines miss the vertical-rhythm grid."
+              },
+              "fullDescription": {
+                "text": "Flags text elements whose baselines miss the vertical-rhythm grid."
+              },
+              "helpUri": "https://plumb.aramhammoudeh.com/rules/baseline-rhythm",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
               "id": "color/contrast-aa",
               "name": "color-contrast-aa",
               "shortDescription": {
@@ -258,7 +272,7 @@ expression: out
           "properties": {
             "docUrl": "https://plumb.aramhammoudeh.com/rules/spacing-grid-conformance"
           },
-          "ruleIndex": 9
+          "ruleIndex": 10
         }
       ]
     }

--- a/crates/plumb-mcp/src/explain.rs
+++ b/crates/plumb-mcp/src/explain.rs
@@ -34,6 +34,10 @@ pub(crate) const RULE_DOCS: &[RuleDoc] = &[
         markdown: include_str!("../../../docs/src/rules/a11y-touch-target.md"),
     },
     RuleDoc {
+        rule_id: "baseline/rhythm",
+        markdown: include_str!("../../../docs/src/rules/baseline-rhythm.md"),
+    },
+    RuleDoc {
         rule_id: "color/contrast-aa",
         markdown: include_str!("../../../docs/src/rules/color-contrast-aa.md"),
     },

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -32,6 +32,7 @@
 
 - [Overview](./rules/overview.md)
 - [a11y/touch-target](./rules/a11y-touch-target.md)
+- [baseline/rhythm](./rules/baseline-rhythm.md)
 - [color/contrast-aa](./rules/color-contrast-aa.md)
 - [color/palette-conformance](./rules/color-palette-conformance.md)
 - [edge/near-alignment](./rules/edge-near-alignment.md)

--- a/docs/src/rules/baseline-rhythm.md
+++ b/docs/src/rules/baseline-rhythm.md
@@ -1,0 +1,97 @@
+# baseline/rhythm
+
+**Status:** active
+
+**Default severity:** `warning`
+
+## What it checks
+
+For every text-bearing element (`p`, `span`, `h1`--`h6`, `a`, `li`,
+`label`, `button`, `input`, `textarea`, `select`, and others) with a
+`font-size` computed style and a bounding rect, the rule approximates
+the element's typographic baseline position:
+
+1. Parses `font-size` from computed styles.
+2. Computes cap-height: uses `rhythm.cap_height_fallback_px` when set,
+   otherwise `font_size * 0.7` (typical Latin cap-height ratio).
+3. Parses `line-height` (falls back to `font_size * 1.2` when missing
+   or `normal`).
+4. Calculates `baseline_y = rect.y + half_leading + cap_height`, where
+   `half_leading = (line_height - font_size) / 2`.
+5. Checks distance from `baseline_y` to the nearest multiple of
+   `rhythm.base_line_px`. If distance exceeds `rhythm.tolerance_px`,
+   a violation is emitted.
+
+The rule is a no-op when `rhythm.base_line_px` is `0`.
+
+## Why it matters
+
+Vertical rhythm keeps text across a page visually aligned to a shared
+grid, giving the layout a consistent cadence that readers perceive as
+orderly even without consciously noticing. Off-rhythm baselines cause
+adjacent columns of text to drift apart vertically, making the page
+feel unpolished. Catching misalignments at lint time avoids slow visual
+QA passes.
+
+## Example violation
+
+```json
+{
+  "rule_id": "baseline/rhythm",
+  "severity": "warning",
+  "message": "`html > body > p:nth-child(2)` baseline at 20.2px is 3.8px off the 24px rhythm grid.",
+  "selector": "html > body > p:nth-child(2)",
+  "viewport": "desktop",
+  "dom_order": 3,
+  "fix": {
+    "kind": {
+      "kind": "description",
+      "text": "Adjust line-height or margin-top so the baseline aligns to the nearest 24px grid line (24px)."
+    },
+    "description": "Shift baseline from 20.2px to 24px to restore vertical rhythm.",
+    "confidence": "low"
+  },
+  "doc_url": "https://plumb.aramhammoudeh.com/rules/baseline-rhythm",
+  "metadata": {
+    "baseline_y": 20.2,
+    "nearest_grid_y": 24.0,
+    "distance_px": 3.8
+  }
+}
+```
+
+## Configuration
+
+Three knobs under `[rhythm]` in `plumb.toml`:
+
+```toml
+[rhythm]
+base_line_px = 24          # grid interval; 0 disables the rule
+tolerance_px = 2           # how far off-grid before firing
+cap_height_fallback_px = 0 # explicit cap-height; 0 = estimate from font-size
+```
+
+Setting `base_line_px = 0` disables the rule entirely (no violations
+emitted regardless of element positions).
+
+## Suppression
+
+Disable the rule for an entire run:
+
+```toml
+[rules."baseline/rhythm"]
+enabled = false
+```
+
+Bump or lower the severity:
+
+```toml
+[rules."baseline/rhythm"]
+severity = "error"
+```
+
+## See also
+
+- [`spacing/grid-conformance`](./spacing-grid-conformance.md) — the
+  horizontal spacing-grid sibling.
+- PRD SS11.3 -- vertical rhythm and baseline alignment.

--- a/docs/src/rules/baseline-rhythm.md
+++ b/docs/src/rules/baseline-rhythm.md
@@ -26,12 +26,10 @@ The rule is a no-op when `rhythm.base_line_px` is `0`.
 
 ## Why it matters
 
-Vertical rhythm keeps text across a page visually aligned to a shared
-grid, giving the layout a consistent cadence that readers perceive as
-orderly even without consciously noticing. Off-rhythm baselines cause
-adjacent columns of text to drift apart vertically, making the page
-feel unpolished. Catching misalignments at lint time avoids slow visual
-QA passes.
+Vertical rhythm aligns text baselines across a page to a shared grid.
+When baselines drift off-grid, adjacent columns of text sit at
+different vertical offsets and the layout looks uneven. Catching these
+misalignments at lint time is faster than manual visual QA.
 
 ## Example violation
 

--- a/schemas/plumb.toml.json
+++ b/schemas/plumb.toml.json
@@ -336,7 +336,7 @@
       "additionalProperties": false
     },
     "RhythmSpec": {
-      "description": "Vertical-rhythm spec (schema/defaults only -- rule lands in #73).",
+      "description": "Vertical-rhythm spec.",
       "type": "object",
       "properties": {
         "base_line_px": {


### PR DESCRIPTION
## Summary

- Adds the `baseline/rhythm` rule that flags text elements whose typographic baselines miss the configured vertical-rhythm grid (`rhythm.base_line_px`).
- Computes approximate baseline position from font-size, line-height, and bounding rect; fires when distance to nearest grid line exceeds `rhythm.tolerance_px`.
- Includes golden snapshot test, determinism test, rule docs page, SUMMARY.md and CHANGELOG entries.

Closes #73

## Validations

- [x] Rule module + registration in `register_builtin` (alphabetical order)
- [x] Golden snapshot test (`golden_baseline_rhythm_golden`) with on-grid, off-grid, and non-text nodes
- [x] Determinism test (`baseline_rhythm_run_is_deterministic`) — 3-run byte-identical check
- [x] Rule docs at `docs/src/rules/baseline-rhythm.md` with all required sections
- [x] `docs/src/SUMMARY.md` updated with alphabetically placed entry
- [x] CHANGELOG `[Unreleased]` entry added
- [x] `git diff --check` — no whitespace issues
- [x] No `unwrap`/`expect`/`todo!`/`dbg!`/`println!` in library code
- [x] Pure function of `(snapshot, config)` — no I/O, no wall-clock, no HashMap
- [x] Uses `IndexMap` for metadata, `parse_px` from `rules::util`

## Test plan

- [ ] `cargo nextest run -p plumb-core --test golden_baseline_rhythm` passes both golden and determinism tests
- [ ] `just validate` passes (fmt + clippy + full test suite)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)