### PR TITLE
fix(ci): skip Claude review on dependabot/renovate PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,15 @@ concurrency:
 jobs:
   review:
     name: Claude review
-    if: github.event.pull_request.draft == false
+    # Skip on dependabot / renovate PRs. Bot PRs run with reduced
+    # permissions, so the action's GitHub App token request fails fast
+    # with an "internal error: directory mismatch" before any review can
+    # happen. This is the pattern recommended by Anthropic's security
+    # docs for handling automated bot PRs alongside Claude review.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
- Skip the `Claude review` job when `github.actor` is `dependabot[bot]` or `renovate[bot]`.
- Per Anthropic's claude-code-action security docs, this is the recommended pattern for handling automated bot PRs.

## Why
Bot PRs run with reduced permissions, so the action's GitHub App token request fails fast with `Internal error: directory mismatch ... fd 4` before any review can happen. The failure is non-actionable on our side — it's an upstream permissions boundary.

The dependency / CI bumps already get full coverage from determinism, MSRV, three-OS test matrix, cargo-deny, coverage, and the readiness matrix.

## Test plan
- [ ] CI green on this PR (Claude review runs as normal — non-bot actor).
- [ ] After merge, dependabot PRs no longer fail the Claude review check.