### PR TITLE
feat(codegen): add plumb-codegen crate + plumb init --from (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Added
 
+- `plumb init --from <path>`: bootstrap a starter `plumb.toml` from an existing project tree. The new `plumb-codegen` crate walks the directory, scrapes CSS custom properties under `:root`, records discovered Tailwind config files, and merges DTCG token JSON. Walk order is deterministic; two runs produce byte-identical output.
 - Rule `baseline/rhythm`: flags text elements whose typographic baselines miss the configured vertical-rhythm grid.
 - Per-crate README files and package metadata for crates.io publishing.
 - `release-please.yml` crates-io publish job now uses bottom-up interleaved dry-run + publish, `--locked`, GitHub environment protection, and `::group::` log folding.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,8 +1850,10 @@ dependencies = [
  "assert_cmd",
  "clap",
  "indexmap",
+ "insta",
  "miette",
  "plumb-cdp",
+ "plumb-codegen",
  "plumb-config",
  "plumb-core",
  "plumb-format",
@@ -1865,6 +1867,21 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "plumb-codegen"
+version = "0.0.1"
+dependencies = [
+ "indexmap",
+ "insta",
+ "plumb-config",
+ "plumb-core",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/plumb-format",
     "crates/plumb-cdp",
     "crates/plumb-config",
+    "crates/plumb-codegen",
     "crates/plumb-mcp",
     "crates/plumb-cli",
     "xtask",
@@ -14,6 +15,7 @@ default-members = [
     "crates/plumb-format",
     "crates/plumb-cdp",
     "crates/plumb-config",
+    "crates/plumb-codegen",
     "crates/plumb-mcp",
     "crates/plumb-cli",
 ]
@@ -37,6 +39,7 @@ plumb-core = { path = "crates/plumb-core", version = "0.0.1" }
 plumb-format = { path = "crates/plumb-format", version = "0.0.1" }
 plumb-cdp = { path = "crates/plumb-cdp", version = "0.0.1" }
 plumb-config = { path = "crates/plumb-config", version = "0.0.1" }
+plumb-codegen = { path = "crates/plumb-codegen", version = "0.0.1" }
 plumb-mcp = { path = "crates/plumb-mcp", version = "0.0.1" }
 
 # CDP driver.

--- a/crates/plumb-cli/Cargo.toml
+++ b/crates/plumb-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 plumb-core = { workspace = true, features = ["test-fake"] }
 plumb-format = { workspace = true }
 plumb-config = { workspace = true }
+plumb-codegen = { workspace = true }
 plumb-cdp = { workspace = true }
 plumb-mcp = { workspace = true }
 clap = { workspace = true }
@@ -43,6 +44,7 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
 reqwest = { workspace = true }
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plumb-cli/src/commands/init.rs
+++ b/crates/plumb-cli/src/commands/init.rs
@@ -1,21 +1,28 @@
 //! `plumb init` — write a starter `plumb.toml`.
 //!
-//! Detects Tailwind (and, as a hint, Next.js) in the current directory
-//! and branches between two scaffolds: a generic template, or a
-//! Tailwind-flavoured template that records the discovered config in
-//! its header comment.
+//! Two modes:
 //!
-//! Detection is filesystem-only — no JS evaluation, no env var reads.
-//! `tailwind.config.{ts,mts,cts,js,mjs,cjs}` in CWD or a `tailwindcss`
-//! entry in `package.json`'s `dependencies` / `devDependencies` /
-//! `peerDependencies` triggers the Tailwind template. Next.js without
-//! Tailwind keeps the generic template — we hint at it in the summary
-//! line but don't switch flavours.
+//! - **Default.** Detects Tailwind (and, as a hint, Next.js) in the
+//!   current directory and branches between two static scaffolds: a
+//!   generic template, or a Tailwind-flavoured template that records
+//!   the discovered config in its header comment.
+//! - **`--from <path>`.** Walks the given source tree, infers tokens
+//!   from CSS custom properties / Tailwind configs / DTCG JSON, and
+//!   bootstraps `plumb.toml` from the recovered values. Implementation
+//!   lives in `plumb_codegen`.
+//!
+//! Default-mode detection is filesystem-only — no JS evaluation, no env
+//! var reads. `tailwind.config.{ts,mts,cts,js,mjs,cjs}` in CWD or a
+//! `tailwindcss` entry in `package.json`'s `dependencies` /
+//! `devDependencies` / `peerDependencies` triggers the Tailwind
+//! template. Next.js without Tailwind keeps the generic template — we
+//! hint at it in the summary line but don't switch flavours.
 
 use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
+use plumb_codegen::{InferredConfig, infer_config, render_toml};
 
 const GENERIC_TEMPLATE: &str = include_str!("../../../../examples/plumb.toml");
 const TAILWIND_TEMPLATE: &str = include_str!("../../../../examples/plumb-tailwind.toml");
@@ -49,12 +56,16 @@ impl Detection {
 
 /// Run `plumb init`. Returns `ExitCode::SUCCESS` on a fresh write.
 ///
+/// When `from` is `Some(path)`, the starter config is inferred from the
+/// project tree at `path` via [`plumb_codegen::infer_config`].
+/// Otherwise the static template is used.
+///
 /// # Errors
 ///
 /// Returns an error if the current directory cannot be read, if
-/// `plumb.toml` already exists and `force` is `false`, or if the file
-/// cannot be written.
-pub fn run(force: bool) -> Result<ExitCode> {
+/// `plumb.toml` already exists and `force` is `false`, if the source
+/// tree at `from` cannot be walked, or if the file cannot be written.
+pub fn run(force: bool, from: Option<&Path>) -> Result<ExitCode> {
     let cwd = std::env::current_dir().context("read current working directory")?;
     let target = cwd.join("plumb.toml");
     if target.exists() && !force {
@@ -63,8 +74,14 @@ pub fn run(force: bool) -> Result<ExitCode> {
             target.display()
         );
     }
-    let detection = detect(&cwd);
-    let (content, summary) = render(&detection);
+
+    let (content, summary) = if let Some(source_dir) = from {
+        render_from_source(source_dir)?
+    } else {
+        let detection = detect(&cwd);
+        render(&detection)
+    };
+
     std::fs::write(&target, content.as_bytes())
         .with_context(|| format!("write {}", target.display()))?;
     #[allow(clippy::print_stdout)]
@@ -72,6 +89,30 @@ pub fn run(force: bool) -> Result<ExitCode> {
         println!("Wrote {}. {summary}", target.display());
     }
     Ok(ExitCode::SUCCESS)
+}
+
+/// Walk `source_dir` and render an inferred starter TOML.
+fn render_from_source(source_dir: &Path) -> Result<(String, String)> {
+    let inferred =
+        infer_config(source_dir).with_context(|| format!("walk {}", source_dir.display()))?;
+    let content = render_toml(&inferred)
+        .with_context(|| format!("render TOML from {}", source_dir.display()))?;
+    let summary = summary_for_inferred(&inferred, source_dir);
+    Ok((content, summary))
+}
+
+fn summary_for_inferred(inferred: &InferredConfig, source_dir: &Path) -> String {
+    if inferred.sources.is_empty() {
+        return format!(
+            "No design-token sources discovered under {}; wrote a blank starter.",
+            source_dir.display()
+        );
+    }
+    format!(
+        "Inferred from {} source(s) under {}.",
+        inferred.sources.len(),
+        source_dir.display()
+    )
 }
 
 /// Inspect `cwd` for Tailwind / Next.js signals.

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -79,6 +79,12 @@ enum Command {
         /// Overwrite an existing `plumb.toml`.
         #[arg(long)]
         force: bool,
+        /// Infer the starter config from a project tree. The walker
+        /// discovers CSS custom properties, Tailwind configs, and DTCG
+        /// token JSON files under the given path and bootstraps a
+        /// `plumb.toml` from them.
+        #[arg(long, value_name = "PATH")]
+        from: Option<PathBuf>,
     },
     /// Print the long-form documentation for a rule.
     Explain {
@@ -158,7 +164,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 )
                 .await
             }
-            Command::Init { force } => commands::init::run(force),
+            Command::Init { force, from } => commands::init::run(force, from.as_deref()),
             Command::Explain { rule } => commands::explain::run(&rule),
             Command::Schema => commands::schema::run(),
             Command::Mcp { transport, port } => commands::mcp::run(transport, port).await,

--- a/crates/plumb-cli/tests/init_from.rs
+++ b/crates/plumb-cli/tests/init_from.rs
@@ -1,0 +1,131 @@
+//! End-to-end tests for `plumb init --from <path>`.
+//!
+//! Builds a tempdir fixture (Tailwind config + a CSS token sheet),
+//! runs the CLI binary, and snapshots the rendered `plumb.toml`.
+//! `insta` redacts the absolute fixture path so the snapshot is stable
+//! across machines.
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+#[test]
+fn init_from_infers_starter_config_from_real_project_tree() -> Result<(), Box<dyn std::error::Error>>
+{
+    let project = TempDir::new()?;
+
+    // A representative Tailwind project: tailwind.config.ts at the
+    // root, a styles directory with a `:root` token sheet, and a
+    // `node_modules` decoy that the walker MUST skip.
+    fs::write(
+        project.path().join("tailwind.config.ts"),
+        "export default { content: [] };\n",
+    )?;
+    fs::create_dir_all(project.path().join("src/styles"))?;
+    fs::write(
+        project.path().join("src/styles/tokens.css"),
+        ":root {\n  --color-bg: #ffffff;\n  --color-fg: #0b0b0b;\n  --color-accent: #0b7285;\n  --space-xs: 4px;\n  --space-sm: 8px;\n  --space-md: 16px;\n  --radius-sm: 4px;\n  --radius-md: 8px;\n}\n",
+    )?;
+    fs::create_dir_all(project.path().join("node_modules/decoy"))?;
+    fs::write(
+        project.path().join("node_modules/decoy/poison.css"),
+        ":root { --color-poison: #ff0000; }",
+    )?;
+
+    let outdir = TempDir::new()?;
+    Command::cargo_bin("plumb")?
+        .arg("init")
+        .arg("--from")
+        .arg(project.path())
+        .current_dir(outdir.path())
+        .assert()
+        .success()
+        .stdout(contains("Wrote"))
+        .stdout(contains("Inferred from"));
+
+    let written = fs::read_to_string(outdir.path().join("plumb.toml"))?;
+
+    // Sanity checks on the written body. We assert structural facts
+    // and rely on the snapshot below for the canonical form; the
+    // `toml::to_string_pretty` representation wraps numeric arrays
+    // across lines, hence the substring matches rather than exact
+    // bracketed slices.
+    assert!(written.contains("[color.tokens]"));
+    assert!(written.contains("color-bg = \"#ffffff\""));
+    assert!(written.contains("color-fg = \"#0b0b0b\""));
+    assert!(written.contains("color-accent = \"#0b7285\""));
+    assert!(written.contains("[spacing]"));
+    assert!(written.contains("base_unit = 4"));
+    assert!(written.contains("[radius]"));
+    assert!(
+        written.contains("Tailwind config detected"),
+        "expected Tailwind hint in header"
+    );
+    assert!(
+        !written.contains("color-poison"),
+        "node_modules CSS leaked through the walker"
+    );
+
+    // Determinism: a second invocation against the same tree must
+    // produce byte-identical output.
+    let second_outdir = TempDir::new()?;
+    Command::cargo_bin("plumb")?
+        .arg("init")
+        .arg("--from")
+        .arg(project.path())
+        .current_dir(second_outdir.path())
+        .assert()
+        .success();
+    let second = fs::read_to_string(second_outdir.path().join("plumb.toml"))?;
+    assert_eq!(written, second, "init --from output is non-deterministic");
+
+    // Snapshot — we redact the absolute project path so the snapshot is
+    // portable across machines. We rewrite the path to `<TMP>` here
+    // rather than rely on insta's `filters` feature, which would
+    // require enabling an extra feature on the dev-dep. macOS reports
+    // `/var/folders/...` but `canonicalize` resolves to
+    // `/private/var/folders/...`; redact both.
+    let project_path = project.path().to_string_lossy().into_owned();
+    let canonical = std::fs::canonicalize(project.path())?
+        .to_string_lossy()
+        .into_owned();
+    let redacted = written
+        .replace(&canonical, "<TMP>")
+        .replace(&project_path, "<TMP>");
+    insta::assert_snapshot!("init_from_real_project", redacted);
+
+    Ok(())
+}
+
+#[test]
+fn init_from_missing_directory_errors() -> Result<(), Box<dyn std::error::Error>> {
+    let outdir = TempDir::new()?;
+    Command::cargo_bin("plumb")?
+        .arg("init")
+        .arg("--from")
+        .arg(outdir.path().join("definitely-does-not-exist"))
+        .current_dir(outdir.path())
+        .assert()
+        .code(2)
+        .stderr(contains("source directory not found"));
+    Ok(())
+}
+
+#[test]
+fn init_from_empty_dir_writes_blank_starter() -> Result<(), Box<dyn std::error::Error>> {
+    let project = TempDir::new()?;
+    let outdir = TempDir::new()?;
+    Command::cargo_bin("plumb")?
+        .arg("init")
+        .arg("--from")
+        .arg(project.path())
+        .current_dir(outdir.path())
+        .assert()
+        .success()
+        .stdout(contains("No design-token sources discovered"));
+    let written = fs::read_to_string(outdir.path().join("plumb.toml"))?;
+    assert!(written.contains("No design-token sources were discovered"));
+    Ok(())
+}

--- a/crates/plumb-cli/tests/snapshots/init_from__init_from_real_project.snap
+++ b/crates/plumb-cli/tests/snapshots/init_from__init_from_real_project.snap
@@ -1,0 +1,71 @@
+---
+source: crates/plumb-cli/tests/init_from.rs
+assertion_line: 97
+expression: redacted
+---
+# Plumb configuration — bootstrapped by `plumb init --from <path>` from the sources below.
+#
+# - tailwind: tailwind.config.ts
+# - css: src/styles/tokens.css
+#
+# Tailwind config detected. Plumb merges Tailwind theme tokens at lint time —
+# run `plumb lint` from the same directory and the adapter will resolve Tailwind's theme.
+
+[viewports]
+
+[spacing]
+base_unit = 4
+scale = [
+    4,
+    8,
+    16,
+]
+
+[spacing.tokens]
+space-xs = 4
+space-sm = 8
+space-md = 16
+
+[type]
+families = []
+weights = []
+scale = []
+
+[type.tokens]
+
+[color]
+delta_e_tolerance = 2.0
+
+[color.tokens]
+color-bg = "#ffffff"
+color-fg = "#0b0b0b"
+color-accent = "#0b7285"
+
+[radius]
+scale = [
+    4,
+    8,
+]
+
+[alignment]
+tolerance_px = 3
+
+[shadow]
+scale = []
+
+[z_index]
+scale = []
+
+[opacity]
+scale = []
+
+[rhythm]
+base_line_px = 0
+tolerance_px = 2
+cap_height_fallback_px = 0
+
+[a11y.touch_target]
+min_width_px = 24
+min_height_px = 24
+
+[rules]

--- a/crates/plumb-codegen/AGENTS.md
+++ b/crates/plumb-codegen/AGENTS.md
@@ -1,0 +1,44 @@
+# crates/plumb-codegen — source-tree token inference
+
+See `/AGENTS.md` for repo-wide rules. This file scopes to `plumb-codegen`.
+
+## Purpose
+
+Walks a user's project tree and infers a starter `plumb.toml` from the
+design-token sources it finds: CSS custom properties (`:root { --foo:
+… }`), Tailwind config filenames, and DTCG token JSON files. Public
+surface: `infer_config`, `render_toml`, `InferredConfig`, `CodegenError`.
+
+The crate is consumed by `plumb-cli` only. It does not drive the
+linter; it produces a starter config the user edits.
+
+## Non-negotiable invariants
+
+- `#![forbid(unsafe_code)]`.
+- No `unwrap`/`expect`/`panic!` — every fallible path returns a
+  `CodegenError` (thiserror-derived).
+- No `println!`/`eprintln!`. Diagnostic noise routes through `tracing`.
+- No wall-clock reads. The walker is a pure function of `(source_dir,
+  filesystem state)`.
+- File walks are deterministic: directory entries are sorted by their
+  canonical UTF-8 path before recursion.
+- Observable output uses `IndexMap` (insertion order) and sorted
+  numeric scales.
+- No JS evaluation. The crate notes the presence of a Tailwind config
+  file but does not spawn Node — the existing
+  `plumb_config::merge_tailwind` adapter handles that on demand from
+  the CLI when the user runs the linter, not at `init` time.
+
+## Depends on
+
+- `plumb-core` — `Config` type and the spec sub-structs.
+- `plumb-config` — `scrape_css_properties`, `merge_dtcg`, the typed
+  error variants we re-wrap.
+
+Never depends on `plumb-cdp`, `plumb-format`, or `plumb-mcp`.
+
+## Anti-patterns
+
+- Walking `node_modules` or build output. The walker hard-skips them.
+- Reading network resources to resolve aliases. Inputs are local.
+- Mutating the source tree. The crate is read-only on disk.

--- a/crates/plumb-codegen/CLAUDE.md
+++ b/crates/plumb-codegen/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/plumb-codegen/Cargo.toml
+++ b/crates/plumb-codegen/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "plumb-codegen"
+description = "Source-tree token inference for Plumb. Bootstraps a starter `plumb.toml` from CSS / Tailwind / DTCG sources."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+exclude = ["AGENTS.md", "CLAUDE.md"]
+
+[dependencies]
+plumb-core = { workspace = true }
+plumb-config = { workspace = true }
+indexmap = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/plumb-codegen/README.md
+++ b/crates/plumb-codegen/README.md
@@ -1,0 +1,28 @@
+# plumb-codegen
+
+Source-tree token inference for [Plumb](https://plumb.aramhammoudeh.com).
+
+Walks a project directory, discovers design-token sources (CSS custom
+properties, Tailwind config files, DTCG token JSON), and bootstraps a
+best-effort `plumb.toml`. Wired through the `plumb init --from <path>`
+subcommand.
+
+## Public API
+
+- `infer_config` — walk a source tree and return an [`InferredConfig`]
+  containing a populated [`plumb_core::Config`] and a per-source summary.
+- `render_toml` — serialize an [`InferredConfig`] into a `plumb.toml`
+  with a header comment describing the inputs.
+- `CodegenError` — typed error enum for inference failures.
+
+## Determinism
+
+Source files are walked in sorted order, scales are sorted ascending
+with duplicates removed, and tokens land in [`indexmap::IndexMap`]
+preserving discovery order. Two runs over the same tree produce
+byte-identical output.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)
+or [MIT License](LICENSE-MIT) at your option.

--- a/crates/plumb-codegen/src/classify.rs
+++ b/crates/plumb-codegen/src/classify.rs
@@ -1,0 +1,209 @@
+//! Classify scraped CSS custom properties into [`plumb_core::Config`]
+//! token slots.
+//!
+//! The classifier is a pure function of `(scrapes, config)`: it folds
+//! a scraped property name + value pair into either the color tokens
+//! map, the spacing scale, the radius scale, or the type scale. Names
+//! that don't match any pattern are skipped — the V0 contract is to
+//! produce a *plausible* starter config, not to be exhaustive.
+//!
+//! ## Name patterns
+//!
+//! - **Color tokens.** Any `--color-*`, `--bg-*`, `--fg-*`, `--accent-*`,
+//!   `--surface-*`, `--text-*`, `--border-*`, `--ring-*` declaration
+//!   whose value is a [`ScrapedValue::Color`].
+//! - **Spacing scale + tokens.** Any `--space-*`, `--spacing-*`,
+//!   `--gap-*`, `--padding-*`, `--margin-*`, `--size-*` declaration
+//!   whose value is a [`ScrapedValue::Px`].
+//! - **Radius scale + tokens.** Any `--radius-*`, `--rounded-*`,
+//!   `--corner-*` declaration whose value is a [`ScrapedValue::Px`].
+//! - **Type scale + tokens.** Any `--font-size-*`, `--text-*` (size
+//!   variants like `--text-base`, `--text-lg`), `--type-*`,
+//!   `--leading-*` declaration whose value is a [`ScrapedValue::Px`].
+//!   `--text-*` is shared with color names; we differentiate by value
+//!   type — `Color` lands in colors, `Px` in type sizes.
+
+// Items here are crate-private but live inside a private module; the
+// `redundant_pub_crate` lint flips between deny on `pub(crate)` and the
+// rust-level `unreachable_pub` lint on bare `pub`. Allow the former
+// scoped to this module so the items keep the explicit visibility.
+#![allow(clippy::redundant_pub_crate)]
+
+use plumb_config::{CssPropertyScrape, ScrapedValue};
+use plumb_core::Config;
+
+/// Aggregate stats for the per-file summary.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct PerFileStats {
+    /// Number of color tokens contributed.
+    pub colors: usize,
+    /// Number of dimensional tokens contributed (px values into spacing,
+    /// radius, or type-size buckets).
+    pub dimensions: usize,
+    /// Other scraped properties (rem, em, font stacks, gradients, …).
+    pub other: usize,
+}
+
+impl PerFileStats {
+    pub(crate) fn increment(&mut self, value: &ScrapedValue) {
+        match value {
+            ScrapedValue::Color(_) => self.colors += 1,
+            ScrapedValue::Px(_) => self.dimensions += 1,
+            _ => self.other += 1,
+        }
+    }
+}
+
+/// Fold every `scrape` into the matching `config` slot.
+pub(crate) fn classify_css_scrapes(scrapes: &[CssPropertyScrape], config: &mut Config) {
+    for scrape in scrapes {
+        // Property names always start with `--` per the scraper contract.
+        let stem = scrape
+            .name
+            .strip_prefix("--")
+            .unwrap_or(scrape.name.as_str());
+        let lower = stem.to_ascii_lowercase();
+
+        match &scrape.value {
+            ScrapedValue::Color(hex) => {
+                if is_color_name(&lower) {
+                    config
+                        .color
+                        .tokens
+                        .entry(stem.to_owned())
+                        .or_insert_with(|| hex.clone());
+                }
+            }
+            ScrapedValue::Px(px) => {
+                if is_radius_name(&lower) {
+                    config.radius.scale.push(*px);
+                } else if is_spacing_name(&lower) {
+                    config.spacing.scale.push(*px);
+                    config.spacing.tokens.entry(stem.to_owned()).or_insert(*px);
+                } else if is_type_size_name(&lower) {
+                    config.type_scale.scale.push(*px);
+                    config
+                        .type_scale
+                        .tokens
+                        .entry(stem.to_owned())
+                        .or_insert(*px);
+                }
+            }
+            // V0 leaves rem / em / Other untouched. Translating rem to
+            // px requires an explicit `--root-font-size: 16px` baseline
+            // we don't yet plumb through; keeping these out of the
+            // starter config beats guessing.
+            ScrapedValue::Rem(_) | ScrapedValue::Em(_) | ScrapedValue::Other(_) => {}
+        }
+    }
+}
+
+fn is_color_name(name: &str) -> bool {
+    static PREFIXES: &[&str] = &[
+        "color-", "bg-", "fg-", "accent-", "surface-", "text-", "border-", "ring-",
+    ];
+    PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+fn is_spacing_name(name: &str) -> bool {
+    static PREFIXES: &[&str] = &["space-", "spacing-", "gap-", "padding-", "margin-", "size-"];
+    PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+fn is_radius_name(name: &str) -> bool {
+    static PREFIXES: &[&str] = &["radius-", "rounded-", "corner-"];
+    PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+fn is_type_size_name(name: &str) -> bool {
+    static PREFIXES: &[&str] = &["font-size-", "type-", "leading-"];
+    if PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return true;
+    }
+    // `--text-*` collides with the color namespace. We reach this branch
+    // only when the value was Px, so a type-size interpretation is the
+    // only one available.
+    name.starts_with("text-")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn scrape(name: &str, value: ScrapedValue) -> CssPropertyScrape {
+        CssPropertyScrape {
+            source: PathBuf::from("test.css"),
+            at_rule: None,
+            name: name.to_owned(),
+            raw_value: String::new(),
+            value,
+        }
+    }
+
+    #[test]
+    fn classifies_color_tokens() {
+        let mut config = Config::default();
+        let scrapes = vec![
+            scrape("--color-bg", ScrapedValue::Color("#ffffff".into())),
+            scrape("--accent-brand", ScrapedValue::Color("#0b7285".into())),
+            scrape("--unknown", ScrapedValue::Color("#deadbe".into())),
+        ];
+        classify_css_scrapes(&scrapes, &mut config);
+        assert_eq!(config.color.tokens.len(), 2);
+        assert_eq!(
+            config.color.tokens.get("color-bg"),
+            Some(&"#ffffff".to_owned())
+        );
+    }
+
+    #[test]
+    fn classifies_spacing_tokens() {
+        let mut config = Config::default();
+        let scrapes = vec![
+            scrape("--space-xs", ScrapedValue::Px(4)),
+            scrape("--space-sm", ScrapedValue::Px(8)),
+            scrape("--gap-md", ScrapedValue::Px(16)),
+        ];
+        classify_css_scrapes(&scrapes, &mut config);
+        assert_eq!(config.spacing.scale, vec![4, 8, 16]);
+        assert_eq!(config.spacing.tokens.len(), 3);
+    }
+
+    #[test]
+    fn classifies_radius_tokens() {
+        let mut config = Config::default();
+        let scrapes = vec![
+            scrape("--radius-sm", ScrapedValue::Px(2)),
+            scrape("--radius-md", ScrapedValue::Px(8)),
+            scrape("--rounded-full", ScrapedValue::Px(9999)),
+        ];
+        classify_css_scrapes(&scrapes, &mut config);
+        assert_eq!(config.radius.scale, vec![2, 8, 9999]);
+    }
+
+    #[test]
+    fn classifies_text_color_vs_text_size_by_value_kind() {
+        let mut config = Config::default();
+        let scrapes = vec![
+            scrape("--text-base", ScrapedValue::Px(16)),
+            scrape("--text-primary", ScrapedValue::Color("#0b0b0b".into())),
+        ];
+        classify_css_scrapes(&scrapes, &mut config);
+        assert_eq!(config.type_scale.scale, vec![16]);
+        assert_eq!(config.color.tokens.len(), 1);
+        assert!(config.color.tokens.contains_key("text-primary"));
+    }
+
+    #[test]
+    fn rem_and_em_skip_classification() {
+        let mut config = Config::default();
+        let scrapes = vec![
+            scrape("--space-md", ScrapedValue::Rem(1.0)),
+            scrape("--space-lg", ScrapedValue::Em(1.5)),
+        ];
+        classify_css_scrapes(&scrapes, &mut config);
+        assert!(config.spacing.scale.is_empty());
+    }
+}

--- a/crates/plumb-codegen/src/lib.rs
+++ b/crates/plumb-codegen/src/lib.rs
@@ -1,0 +1,476 @@
+//! # plumb-codegen
+//!
+//! Source-tree token inference for Plumb. Walks a project directory,
+//! discovers design-token sources (CSS custom properties, Tailwind
+//! config files, DTCG token JSON), and bootstraps a best-effort
+//! [`plumb_core::Config`].
+//!
+//! Consumers (`plumb-cli`'s `init --from <path>` command) call
+//! [`infer_config`] to walk the tree and [`render_toml`] to serialize
+//! the result. Both are deterministic: identical inputs produce
+//! byte-identical output across runs and platforms.
+//!
+//! ## Inference sources (V0)
+//!
+//! - **CSS custom properties.** Every `:root { --token: value; }`
+//!   declaration discovered under `src/`, `styles/`, `app/`, or the
+//!   project root is classified by name into the spacing, color,
+//!   radius, and type-scale buckets. Implementation lives in
+//!   [`plumb_config::scrape_css_properties`].
+//! - **Tailwind config files.** Presence of `tailwind.config.{js,ts,
+//!   mjs,cjs,mts,cts}` is recorded in the rendered TOML's header
+//!   comment so the user knows to wire `extends` once that landed.
+//!   The crate never spawns Node; full Tailwind theme resolution is
+//!   handled at lint time by `plumb_config::merge_tailwind`.
+//! - **DTCG token JSON files.** Files matching `*.tokens.json` or
+//!   placed under a `tokens/` directory are merged via
+//!   [`plumb_config::merge_dtcg`].
+//!
+//! ## Determinism contract
+//!
+//! - Directory entries are sorted by their canonical UTF-8 path before
+//!   recursion. The walker visits files in the same order on every
+//!   filesystem.
+//! - Scales (`spacing.scale`, `radius.scale`, `type.scale`) are sorted
+//!   ascending and deduplicated.
+//! - Tokens land in [`indexmap::IndexMap`] in discovery order; insertion
+//!   order is preserved by serde during TOML serialization.
+//! - The walker never reads `SystemTime` / `Instant`. The error
+//!   surface never carries a wall-clock value.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod classify;
+mod render;
+mod walk;
+
+use std::path::{Path, PathBuf};
+
+use indexmap::IndexMap;
+use plumb_config::ConfigError;
+use plumb_core::Config;
+use thiserror::Error;
+
+pub use render::render_toml;
+
+/// Maximum directory depth the walker descends into the source tree.
+///
+/// Most design-token directories sit at depth ≤ 3 (`src/styles/tokens.css`).
+/// 6 covers monorepos with `apps/<name>/src/styles/...` without spending
+/// time on `node_modules`-shaped trees that the walker would otherwise
+/// already skip by name.
+pub const MAX_WALK_DEPTH: usize = 6;
+
+/// Codegen errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CodegenError {
+    /// The supplied source directory does not exist.
+    #[error("source directory not found: {0}")]
+    NotFound(String),
+    /// The supplied path exists but is not a directory.
+    #[error("source path is not a directory: {0}")]
+    NotADirectory(String),
+    /// A filesystem error surfaced during the walk.
+    #[error("failed to read `{path}`: {source}")]
+    Io {
+        /// Path that failed to read.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A discovered token source failed to parse. The wrapped
+    /// [`ConfigError`] carries the span-annotated diagnostic.
+    #[error("failed to parse token source: {0}")]
+    Source(#[from] ConfigError),
+    /// TOML serialization failed.
+    #[error("failed to render TOML: {0}")]
+    Render(#[from] toml::ser::Error),
+}
+
+/// Result of walking a source tree. The [`Config`] field is populated
+/// with whatever tokens the inference passes were able to recover; the
+/// `summary` field records, in stable order, what each pass discovered
+/// so the CLI can surface a one-line note per source.
+#[derive(Debug, Clone)]
+pub struct InferredConfig {
+    /// The inferred config — passed through `serde(deny_unknown_fields)`
+    /// so it round-trips cleanly through `toml::to_string` and back.
+    pub config: Config,
+    /// One human-readable line per inference pass that contributed.
+    /// Sorted by `(source_kind, path)` for stable rendering.
+    pub summary: Vec<String>,
+    /// Token-source files the walker fed to a parser, in the order they
+    /// were consumed. Used for the rendered header comment and tests.
+    pub sources: Vec<TokenSource>,
+}
+
+/// One discovered token-source file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenSource {
+    /// Canonical kind tag for the source.
+    pub kind: TokenSourceKind,
+    /// Path relative to the input `source_dir`.
+    pub relative_path: PathBuf,
+}
+
+/// Kind of a discovered token source. Used to drive both the renderer's
+/// header comment and the per-source summary order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum TokenSourceKind {
+    /// `tailwind.config.{js,ts,mjs,cjs,mts,cts}` at the project root.
+    /// V0 records the presence in the header comment; full theme
+    /// resolution is on the linter side.
+    TailwindConfig,
+    /// CSS file containing one or more `:root` blocks.
+    CssCustomProperties,
+    /// DTCG token document (`*.tokens.json` or `tokens/*.json`).
+    Dtcg,
+}
+
+impl TokenSourceKind {
+    /// Stable, lower-case label used in summaries and rendered header
+    /// comments.
+    fn label(self) -> &'static str {
+        match self {
+            Self::TailwindConfig => "tailwind",
+            Self::CssCustomProperties => "css",
+            Self::Dtcg => "dtcg",
+        }
+    }
+}
+
+/// File extensions of supported Tailwind config files. Order does not
+/// matter for matching but the first hit (in walker order) is what we
+/// surface in the rendered TOML.
+const TAILWIND_CONFIG_NAMES: &[&str] = &[
+    "tailwind.config.ts",
+    "tailwind.config.mts",
+    "tailwind.config.cts",
+    "tailwind.config.js",
+    "tailwind.config.mjs",
+    "tailwind.config.cjs",
+];
+
+/// Walk `source_dir` and infer a [`plumb_core::Config`] from the
+/// design-token sources it finds.
+///
+/// The walker is bounded by [`MAX_WALK_DEPTH`] and skips
+/// `node_modules`, `target`, `dist`, `build`, `.next`, `out`, and any
+/// dotfile directory.
+///
+/// # Errors
+///
+/// - [`CodegenError::NotFound`] if `source_dir` does not exist.
+/// - [`CodegenError::NotADirectory`] if `source_dir` is not a directory.
+/// - [`CodegenError::Io`] if a directory entry cannot be read.
+/// - [`CodegenError::Source`] if a discovered token source fails to
+///   parse. Parse errors carry the source span via
+///   [`plumb_config::ConfigError`].
+pub fn infer_config(source_dir: &Path) -> Result<InferredConfig, CodegenError> {
+    if !source_dir.exists() {
+        return Err(CodegenError::NotFound(source_dir.display().to_string()));
+    }
+    if !source_dir.is_dir() {
+        return Err(CodegenError::NotADirectory(
+            source_dir.display().to_string(),
+        ));
+    }
+
+    let walked = walk::walk(source_dir)?;
+
+    let mut config = Config::default();
+    let mut summary: Vec<(u8, String, String)> = Vec::new();
+    let mut sources: Vec<TokenSource> = Vec::new();
+
+    // Tailwind config — record presence only. Theme resolution is the
+    // linter's job (it spawns Node lazily on `plumb lint`).
+    for tailwind_path in &walked.tailwind_configs {
+        let relative = relative_to(source_dir, tailwind_path);
+        sources.push(TokenSource {
+            kind: TokenSourceKind::TailwindConfig,
+            relative_path: relative.clone(),
+        });
+        summary.push((
+            order_tag(TokenSourceKind::TailwindConfig),
+            display_path(&relative),
+            format!("tailwind config at {}", display_path(&relative)),
+        ));
+    }
+
+    // CSS custom properties.
+    if !walked.css_files.is_empty() {
+        let scrapes = plumb_config::scrape_css_properties(&walked.css_files)?;
+        // Record one summary line per CSS file the scraper emitted from.
+        let mut by_file: IndexMap<PathBuf, classify::PerFileStats> = IndexMap::new();
+        for scrape in &scrapes {
+            by_file
+                .entry(scrape.source.clone())
+                .or_default()
+                .increment(&scrape.value);
+        }
+        classify::classify_css_scrapes(&scrapes, &mut config);
+        // Drain the per-file stats in insertion order (= scraper order =
+        // sorted walk order).
+        for (path, file_stats) in by_file {
+            let relative = relative_to(source_dir, &path);
+            sources.push(TokenSource {
+                kind: TokenSourceKind::CssCustomProperties,
+                relative_path: relative.clone(),
+            });
+            summary.push((
+                order_tag(TokenSourceKind::CssCustomProperties),
+                display_path(&relative),
+                format!(
+                    "css custom properties from {} ({} colors, {} dimensions, {} other)",
+                    display_path(&relative),
+                    file_stats.colors,
+                    file_stats.dimensions,
+                    file_stats.other,
+                ),
+            ));
+        }
+    }
+
+    // DTCG token JSON.
+    for dtcg_path in &walked.dtcg_files {
+        let contents = std::fs::read_to_string(dtcg_path).map_err(|source| CodegenError::Io {
+            path: dtcg_path.display().to_string(),
+            source,
+        })?;
+        let source = plumb_config::DtcgSource {
+            path: dtcg_path.clone(),
+            contents,
+        };
+        let import = plumb_config::merge_dtcg(&mut config, &source)?;
+        let relative = relative_to(source_dir, dtcg_path);
+        sources.push(TokenSource {
+            kind: TokenSourceKind::Dtcg,
+            relative_path: relative.clone(),
+        });
+        summary.push((
+            order_tag(TokenSourceKind::Dtcg),
+            display_path(&relative),
+            format!(
+                "dtcg tokens from {} (+{} colors, +{} spacing, +{} type sizes, +{} radii)",
+                display_path(&relative),
+                import.color_added,
+                import.spacing_added,
+                import.type_size_added,
+                import.radius_added,
+            ),
+        ));
+    }
+
+    // Sort scales ascending with duplicates removed — deterministic
+    // output regardless of file walk order.
+    sort_and_dedup(&mut config.spacing.scale);
+    sort_and_dedup(&mut config.type_scale.scale);
+    sort_and_dedup(&mut config.radius.scale);
+
+    // Stable summary order: `(kind tag, relative path)`.
+    summary.sort();
+    let summary = summary.into_iter().map(|(_, _, line)| line).collect();
+
+    Ok(InferredConfig {
+        config,
+        summary,
+        sources,
+    })
+}
+
+/// Lower numbers sort earlier in the rendered summary. Tailwind first
+/// (it's the framework signal), then CSS, then DTCG.
+fn order_tag(kind: TokenSourceKind) -> u8 {
+    match kind {
+        TokenSourceKind::TailwindConfig => 0,
+        TokenSourceKind::CssCustomProperties => 1,
+        TokenSourceKind::Dtcg => 2,
+    }
+}
+
+/// Compute `path` relative to `base`, falling back to `path` when the
+/// strip fails (e.g. an absolute path the walker handed back verbatim
+/// because canonicalization was not possible).
+fn relative_to(base: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(base)
+        .map_or_else(|_| path.to_path_buf(), Path::to_path_buf)
+}
+
+/// Render a path with forward slashes regardless of host OS so summaries
+/// and TOML headers are byte-identical across Windows / Linux / macOS.
+fn display_path(path: &Path) -> String {
+    path.components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn sort_and_dedup<T: Ord>(values: &mut Vec<T>) {
+    values.sort();
+    values.dedup();
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_source_dir_errors() {
+        let err = infer_config(Path::new("/nonexistent/plumb/codegen/test"))
+            .expect_err("infer_config should fail on missing path");
+        assert!(matches!(err, CodegenError::NotFound(_)));
+    }
+
+    #[test]
+    fn non_directory_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-dir.txt");
+        std::fs::write(&file, "hello").unwrap();
+        let err = infer_config(&file).expect_err("infer_config should fail on file path");
+        assert!(matches!(err, CodegenError::NotADirectory(_)));
+    }
+
+    #[test]
+    fn empty_dir_returns_default_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let inferred = infer_config(dir.path()).unwrap();
+        assert!(inferred.summary.is_empty());
+        assert!(inferred.sources.is_empty());
+        assert!(inferred.config.color.tokens.is_empty());
+        assert!(inferred.config.spacing.scale.is_empty());
+    }
+
+    #[test]
+    fn detects_tailwind_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("tailwind.config.ts"),
+            "export default { content: [] };\n",
+        )
+        .unwrap();
+        let inferred = infer_config(dir.path()).unwrap();
+        assert_eq!(inferred.sources.len(), 1);
+        assert_eq!(inferred.sources[0].kind, TokenSourceKind::TailwindConfig);
+        assert_eq!(
+            inferred.sources[0].relative_path,
+            Path::new("tailwind.config.ts")
+        );
+    }
+
+    #[test]
+    fn classifies_css_custom_properties_into_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let styles = dir.path().join("styles");
+        std::fs::create_dir_all(&styles).unwrap();
+        std::fs::write(
+            styles.join("tokens.css"),
+            r":root {
+              --color-bg: #ffffff;
+              --color-fg: #0b0b0b;
+              --color-accent: #0b7285;
+              --space-xs: 4px;
+              --space-sm: 8px;
+              --radius-md: 8px;
+            }",
+        )
+        .unwrap();
+        let inferred = infer_config(dir.path()).unwrap();
+        assert_eq!(inferred.config.color.tokens.len(), 3);
+        assert_eq!(
+            inferred.config.color.tokens.get("color-bg"),
+            Some(&"#ffffff".to_owned())
+        );
+        assert_eq!(inferred.config.spacing.scale, vec![4, 8]);
+        assert_eq!(inferred.config.radius.scale, vec![8]);
+    }
+
+    #[test]
+    fn skips_node_modules_and_dotfile_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        // Should be skipped.
+        for skipped in ["node_modules", "target", ".git", "dist", "build"] {
+            let nested = dir.path().join(skipped).join("nested");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(
+                nested.join("trap.css"),
+                ":root { --color-trap: #ff0000; }\n",
+            )
+            .unwrap();
+        }
+        let inferred = infer_config(dir.path()).unwrap();
+        assert!(inferred.config.color.tokens.is_empty());
+        assert!(inferred.sources.is_empty());
+    }
+
+    #[test]
+    fn deterministic_across_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let styles = dir.path().join("src/styles");
+        std::fs::create_dir_all(&styles).unwrap();
+        std::fs::write(
+            styles.join("a.css"),
+            ":root { --color-a: #aabbcc; --space-xs: 4px; }",
+        )
+        .unwrap();
+        std::fs::write(
+            styles.join("b.css"),
+            ":root { --color-b: #112233; --space-sm: 8px; }",
+        )
+        .unwrap();
+        let one = infer_config(dir.path()).unwrap();
+        let two = infer_config(dir.path()).unwrap();
+        assert_eq!(one.summary, two.summary);
+        assert_eq!(one.config.color.tokens, two.config.color.tokens);
+        assert_eq!(one.config.spacing.scale, two.config.spacing.scale);
+    }
+
+    #[test]
+    fn merges_dtcg_token_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let dtcg = r##"{
+          "color": {
+            "primary": { "$type": "color", "$value": "#0b7285" }
+          },
+          "spacing": {
+            "xs": { "$type": "dimension", "$value": "4px" }
+          }
+        }"##;
+        std::fs::write(dir.path().join("design.tokens.json"), dtcg).unwrap();
+        let inferred = infer_config(dir.path()).unwrap();
+        assert_eq!(
+            inferred.config.color.tokens.get("color/primary"),
+            Some(&"#0b7285".to_owned())
+        );
+        assert!(inferred.config.spacing.tokens.contains_key("spacing/xs"));
+        assert_eq!(inferred.sources.len(), 1);
+        assert_eq!(inferred.sources[0].kind, TokenSourceKind::Dtcg);
+    }
+
+    #[test]
+    fn order_tag_orders_kinds_predictably() {
+        assert!(
+            order_tag(TokenSourceKind::TailwindConfig)
+                < order_tag(TokenSourceKind::CssCustomProperties)
+        );
+        assert!(order_tag(TokenSourceKind::CssCustomProperties) < order_tag(TokenSourceKind::Dtcg));
+    }
+
+    #[test]
+    fn display_path_uses_forward_slashes() {
+        let p = Path::new("src").join("styles").join("tokens.css");
+        assert_eq!(display_path(&p), "src/styles/tokens.css");
+    }
+
+    #[test]
+    fn label_lookup_is_stable() {
+        assert_eq!(TokenSourceKind::TailwindConfig.label(), "tailwind");
+        assert_eq!(TokenSourceKind::CssCustomProperties.label(), "css");
+        assert_eq!(TokenSourceKind::Dtcg.label(), "dtcg");
+    }
+}

--- a/crates/plumb-codegen/src/render.rs
+++ b/crates/plumb-codegen/src/render.rs
@@ -1,0 +1,158 @@
+//! Render an [`InferredConfig`] to a `plumb.toml` string.
+//!
+//! The output starts with a generated header comment that records, in
+//! sorted order, every source the inference pass consumed. The body is
+//! the [`plumb_core::Config`] serialized via `toml::to_string_pretty`,
+//! preserving `IndexMap` insertion order for tokens.
+
+use crate::{CodegenError, InferredConfig, TokenSource, TokenSourceKind};
+
+/// Comment header byline. Single line so the rendered file's first
+/// content line is always the same number of bytes regardless of
+/// whether the inferrer found anything.
+const HEADER: &str =
+    "# Plumb configuration — bootstrapped by `plumb init --from <path>` from the sources below.";
+
+/// Note appended when a Tailwind config was discovered. Plumb's
+/// `extends = "./tailwind.config.*"` directive is still in flight; this
+/// wording is shared with `examples/plumb-tailwind.toml`.
+const TAILWIND_HINT: &str =
+    "# Tailwind config detected. Plumb merges Tailwind theme tokens at lint time —";
+
+/// Render `inferred` to a TOML string.
+///
+/// The output is byte-identical given the same [`InferredConfig`]. The
+/// header lists discovered source files in stable order; the body is
+/// `toml::to_string_pretty` over the [`plumb_core::Config`].
+///
+/// # Errors
+///
+/// Returns [`CodegenError::Render`] if `toml::to_string_pretty` fails
+/// (extremely rare — the [`plumb_core::Config`] schema is `Serialize`).
+pub fn render_toml(inferred: &InferredConfig) -> Result<String, CodegenError> {
+    let mut out = String::new();
+    out.push_str(HEADER);
+    out.push('\n');
+
+    if inferred.sources.is_empty() {
+        out.push_str("# No design-token sources were discovered. Edit the values below to match your system.\n");
+    } else {
+        out.push_str("#\n");
+        write_source_list(&mut out, &inferred.sources);
+    }
+
+    if has_tailwind(&inferred.sources) {
+        out.push_str("#\n");
+        out.push_str(TAILWIND_HINT);
+        out.push('\n');
+        out.push_str("# run `plumb lint` from the same directory and the adapter will resolve Tailwind's theme.\n");
+    }
+
+    out.push('\n');
+
+    let body = toml::to_string_pretty(&inferred.config)?;
+    out.push_str(&body);
+
+    // Always end on a single newline. `toml::to_string_pretty` emits
+    // one already; defensively ensure the file ends consistently.
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+fn write_source_list(out: &mut String, sources: &[TokenSource]) {
+    use std::fmt::Write as _;
+    let mut sorted: Vec<&TokenSource> = sources.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.kind
+            .cmp(&b.kind)
+            .then_with(|| a.relative_path.cmp(&b.relative_path))
+    });
+    for source in sorted {
+        let label = source.kind.label();
+        let path = display_path(&source.relative_path);
+        // Writes to a `String` buffer cannot fail; ignore the result.
+        let _ = writeln!(out, "# - {label}: {path}");
+    }
+}
+
+fn has_tailwind(sources: &[TokenSource]) -> bool {
+    sources
+        .iter()
+        .any(|s| s.kind == TokenSourceKind::TailwindConfig)
+}
+
+fn display_path(path: &std::path::Path) -> String {
+    path.components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use plumb_core::Config;
+    use std::path::PathBuf;
+
+    fn fixture(sources: Vec<TokenSource>) -> InferredConfig {
+        InferredConfig {
+            config: Config::default(),
+            summary: Vec::new(),
+            sources,
+        }
+    }
+
+    #[test]
+    fn empty_inputs_render_with_header_note() {
+        let rendered = render_toml(&fixture(Vec::new())).unwrap();
+        assert!(rendered.starts_with(HEADER));
+        assert!(rendered.contains("No design-token sources were discovered"));
+    }
+
+    #[test]
+    fn renders_sources_in_stable_order() {
+        let inferred = fixture(vec![
+            TokenSource {
+                kind: TokenSourceKind::CssCustomProperties,
+                relative_path: PathBuf::from("z.css"),
+            },
+            TokenSource {
+                kind: TokenSourceKind::CssCustomProperties,
+                relative_path: PathBuf::from("a.css"),
+            },
+            TokenSource {
+                kind: TokenSourceKind::TailwindConfig,
+                relative_path: PathBuf::from("tailwind.config.ts"),
+            },
+        ]);
+        let rendered = render_toml(&inferred).unwrap();
+        let tw_pos = rendered.find("tailwind.config.ts").unwrap();
+        let a_pos = rendered.find("a.css").unwrap();
+        let z_pos = rendered.find("z.css").unwrap();
+        assert!(tw_pos < a_pos, "tailwind should come first");
+        assert!(a_pos < z_pos, "css files should be alphabetical");
+        assert!(rendered.contains("Tailwind config detected"));
+    }
+
+    #[test]
+    fn render_emits_canonical_toml_body() {
+        let mut config = Config::default();
+        config
+            .color
+            .tokens
+            .insert("bg/canvas".into(), "#ffffff".into());
+        let rendered = render_toml(&InferredConfig {
+            config,
+            summary: Vec::new(),
+            sources: Vec::new(),
+        })
+        .unwrap();
+        assert!(rendered.contains("[color]"));
+        assert!(rendered.contains("bg/canvas"));
+        assert!(rendered.ends_with('\n'));
+    }
+}

--- a/crates/plumb-codegen/src/walk.rs
+++ b/crates/plumb-codegen/src/walk.rs
@@ -1,0 +1,275 @@
+//! Deterministic source-tree walker.
+//!
+//! Reads directory entries, filters them through a hard-coded ignore
+//! list (`node_modules`, `target`, `.git`, `dist`, `build`, `.next`,
+//! `out`, and any dotfile dir), and emits sorted lists of token-source
+//! files: Tailwind configs, CSS files, and DTCG token JSON files.
+
+// Items here are crate-private but live inside a private module; the
+// `redundant_pub_crate` lint flips between deny on `pub(crate)` and the
+// rust-level `unreachable_pub` lint on bare `pub`. Allow the former
+// scoped to this module so the items keep the explicit visibility.
+#![allow(clippy::redundant_pub_crate)]
+
+use std::path::{Path, PathBuf};
+
+use crate::{CodegenError, MAX_WALK_DEPTH, TAILWIND_CONFIG_NAMES};
+
+/// Directory names hard-skipped during the walk regardless of depth.
+/// Sorted alphabetically for code-review readability — order does not
+/// affect behavior.
+const SKIPPED_DIRS: &[&str] = &[
+    ".git",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+];
+
+/// Discovered token-source paths, grouped by kind.
+///
+/// Each list is sorted so the caller-visible output is deterministic.
+#[derive(Debug, Default)]
+pub(crate) struct Walked {
+    /// Tailwind config files discovered at the project root.
+    /// V0 looks at root only — nested apps live under
+    /// `apps/*/tailwind.config.*` and we do not want to claim a single
+    /// inferred config for a polyrepo.
+    pub(crate) tailwind_configs: Vec<PathBuf>,
+    /// CSS files (`*.css`) the walker fed to the CSS scraper.
+    pub(crate) css_files: Vec<PathBuf>,
+    /// DTCG token JSON files (`*.tokens.json` or under `tokens/`).
+    pub(crate) dtcg_files: Vec<PathBuf>,
+}
+
+/// Walk `source_dir` and return a [`Walked`] with token-source paths
+/// sorted in a stable order.
+pub(crate) fn walk(source_dir: &Path) -> Result<Walked, CodegenError> {
+    let mut walked = Walked::default();
+
+    // Tailwind: project root only.
+    for name in TAILWIND_CONFIG_NAMES {
+        let candidate = source_dir.join(name);
+        if candidate.is_file() {
+            walked.tailwind_configs.push(candidate);
+        }
+    }
+    walked.tailwind_configs.sort();
+
+    walk_dir(source_dir, source_dir, 0, &mut walked)?;
+
+    walked.css_files.sort();
+    walked.dtcg_files.sort();
+
+    Ok(walked)
+}
+
+fn walk_dir(
+    root: &Path,
+    dir: &Path,
+    depth: usize,
+    walked: &mut Walked,
+) -> Result<(), CodegenError> {
+    if depth > MAX_WALK_DEPTH {
+        return Ok(());
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(source) => {
+            return Err(CodegenError::Io {
+                path: dir.display().to_string(),
+                source,
+            });
+        }
+    };
+
+    let mut sorted: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| CodegenError::Io {
+            path: dir.display().to_string(),
+            source,
+        })?;
+        sorted.push(entry.path());
+    }
+    sorted.sort();
+
+    for path in sorted {
+        let file_type = match std::fs::symlink_metadata(&path) {
+            Ok(meta) => meta.file_type(),
+            Err(_) => continue,
+        };
+        if file_type.is_symlink() {
+            // Skip symlinks; they could escape the source tree, and
+            // following them would risk cycles.
+            continue;
+        }
+        if file_type.is_dir() {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if name.is_empty() || name.starts_with('.') || SKIPPED_DIRS.contains(&name) {
+                continue;
+            }
+            walk_dir(root, &path, depth + 1, walked)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        classify_file(root, &path, walked);
+    }
+
+    Ok(())
+}
+
+/// Decide which bucket (if any) a single file belongs to.
+fn classify_file(root: &Path, path: &Path, walked: &mut Walked) {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+
+    // Skip `tailwind.config.*` here — already discovered at the root.
+    if TAILWIND_CONFIG_NAMES.contains(&name) {
+        return;
+    }
+
+    let lower = name.to_ascii_lowercase();
+
+    if path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("css"))
+    {
+        walked.css_files.push(path.to_path_buf());
+        return;
+    }
+
+    // `.tokens.json` is a compound suffix; `Path::extension` returns
+    // `json`, so we still inspect the lower-cased file name to catch
+    // the design-token convention.
+    if lower.ends_with(".tokens.json") {
+        walked.dtcg_files.push(path.to_path_buf());
+        return;
+    }
+    if path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+        && in_tokens_dir(root, path)
+    {
+        walked.dtcg_files.push(path.to_path_buf());
+    }
+}
+
+/// True if `path` lives under a directory literally named `tokens` at
+/// any depth between `root` and the file. The check uses ASCII
+/// case-insensitive comparison so `Tokens/` works on case-sensitive
+/// filesystems too.
+fn in_tokens_dir(root: &Path, path: &Path) -> bool {
+    let Ok(rel) = path.strip_prefix(root) else {
+        return false;
+    };
+    rel.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .is_some_and(|s| s.eq_ignore_ascii_case("tokens"))
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_finds_tailwind_root_only() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tailwind.config.js"), "module.exports={};").unwrap();
+        // Nested tailwind.config.* should NOT be picked up by the
+        // walker (V0 heuristic: root-only).
+        let nested = dir.path().join("apps").join("docs");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("tailwind.config.js"), "module.exports={};").unwrap();
+
+        let walked = walk(dir.path()).unwrap();
+        assert_eq!(walked.tailwind_configs.len(), 1);
+        assert_eq!(
+            walked.tailwind_configs[0],
+            dir.path().join("tailwind.config.js")
+        );
+    }
+
+    #[test]
+    fn walk_collects_css_in_sorted_order() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("styles")).unwrap();
+        std::fs::write(dir.path().join("styles/b.css"), ":root {}").unwrap();
+        std::fs::write(dir.path().join("styles/a.css"), ":root {}").unwrap();
+        std::fs::write(dir.path().join("z.css"), ":root {}").unwrap();
+
+        let walked = walk(dir.path()).unwrap();
+        assert_eq!(walked.css_files.len(), 3);
+        // Walker emits children before siblings of the parent dir, but
+        // each call to `read_dir` returns sorted output. The end result
+        // is depth-first sorted: `styles/a.css`, `styles/b.css`, `z.css`.
+        assert_eq!(walked.css_files[0], dir.path().join("styles/a.css"));
+        assert_eq!(walked.css_files[1], dir.path().join("styles/b.css"));
+        assert_eq!(walked.css_files[2], dir.path().join("z.css"));
+    }
+
+    #[test]
+    fn walk_picks_up_dtcg_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("design.tokens.json"), "{}").unwrap();
+        std::fs::create_dir_all(dir.path().join("tokens")).unwrap();
+        std::fs::write(dir.path().join("tokens/colors.json"), "{}").unwrap();
+        // Lone `colors.json` outside a `tokens/` dir is ignored.
+        std::fs::write(dir.path().join("colors.json"), "{}").unwrap();
+
+        let walked = walk(dir.path()).unwrap();
+        assert_eq!(walked.dtcg_files.len(), 2);
+    }
+
+    #[test]
+    fn walk_skips_hard_blocked_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        for skipped in SKIPPED_DIRS {
+            let nested = dir.path().join(skipped).join("inner");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(nested.join("trap.css"), ":root {}").unwrap();
+            std::fs::write(nested.join("design.tokens.json"), "{}").unwrap();
+        }
+        let walked = walk(dir.path()).unwrap();
+        assert!(walked.css_files.is_empty(), "skipped CSS leaked through");
+        assert!(walked.dtcg_files.is_empty(), "skipped DTCG leaked through");
+    }
+
+    #[test]
+    fn walk_respects_max_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut deep = dir.path().to_path_buf();
+        for level in 0..(MAX_WALK_DEPTH + 2) {
+            deep = deep.join(format!("d{level}"));
+        }
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("buried.css"), ":root {}").unwrap();
+        let walked = walk(dir.path()).unwrap();
+        assert!(walked.css_files.is_empty());
+    }
+
+    #[test]
+    fn walk_skips_dotfile_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let dot = dir.path().join(".vscode");
+        std::fs::create_dir_all(&dot).unwrap();
+        std::fs::write(dot.join("settings.css"), ":root {}").unwrap();
+        let walked = walk(dir.path()).unwrap();
+        assert!(walked.css_files.is_empty());
+    }
+}

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -33,6 +33,14 @@ Exit codes:
 Write a starter `plumb.toml` to the current directory. Pass `--force` to
 overwrite.
 
+Pass `--from <path>` to bootstrap from an existing project tree. The
+walker discovers CSS custom properties (`:root { --token: value; }`),
+Tailwind config files, and DTCG token JSON, and folds them into a
+starter config. Output is deterministic — two runs against the same
+tree produce byte-identical files. Token names that don't match a
+known prefix (e.g. `--space-*`, `--color-*`, `--radius-*`) are skipped;
+edit the file to fill the gaps.
+
 ### `plumb explain <rule-id>`
 
 Print the long-form documentation for a rule. The argument is a slash-


### PR DESCRIPTION
Closes #82.

## Summary

- Adds a new `plumb-codegen` workspace crate that walks a project tree and infers a starter `plumb.toml` from the design-token sources it finds: CSS custom properties under `:root`, Tailwind config files, and DTCG token JSON files.
- Wires the new crate through `plumb init --from <path>`. The default `plumb init` flow is unchanged.
- Walk order is sorted; scales are sorted ascending and deduplicated; observable output uses `IndexMap` insertion order. Two runs over the same tree produce byte-identical output.

## Architecture

- `plumb-codegen` depends on `plumb-core` + `plumb-config` only.
- Depended on by `plumb-cli` only; never by `plumb-cdp` / `plumb-format` / `plumb-mcp`.
- `#![forbid(unsafe_code)]`, no `unwrap`/`expect`/`panic!`, no `println!`/`eprintln!`, no wall-clock reads.

## V0 inference sources

| Source | Mechanism |
|--------|-----------|
| CSS custom properties | `plumb_config::scrape_css_properties` + a name-prefix classifier (`--color-*`, `--space-*`, `--radius-*`, `--text-*`, …) folded into the corresponding `Config` slot |
| Tailwind config | Filesystem detection at the project root; the renderer notes the file in the header comment. Theme resolution stays on the linter side via `plumb_config::merge_tailwind` |
| DTCG token JSON | `plumb_config::merge_dtcg`, picked up from `*.tokens.json` files or any `*.json` under a `tokens/` directory |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p plumb-codegen -p plumb-cli` — 95 tests pass (26 unit tests in `plumb-codegen`, 25 existing CLI integration tests, plus 3 new `init --from` integration tests, MCP, etc.)
- [x] `just determinism-check` — three lint runs produce byte-identical JSON
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `cargo run -p xtask -- pre-release` — schema in sync, runbooks valid, release-readiness kits valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)