### PR TITLE
chore(ci): allow codegen and e2e scopes in PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -34,11 +34,13 @@ jobs:
             cli
             mcp
             cdp
+            codegen
             config
             format
             docs
             ci
             deps
+            e2e
           requireScope: false
           subjectPattern: ^[^A-Z].+
           subjectPatternError: |


### PR DESCRIPTION
## Summary
- Add `codegen` and `e2e` to the PR-title conventional-commits scope allowlist.

## Why
- `codegen` lands as a new workspace crate in #82 (plumb-codegen) — `feat(codegen): ...` titles need to validate.
- `e2e` covers Phase 3 e2e-sites/ infrastructure that comes next in the V0 readiness pass.

## Test plan
- [x] PR title check passes on this PR (matches `chore(ci): ...`).
- [ ] After merge, #212 (`feat(codegen): ...`) re-runs the title check green.