### PR TITLE
feat(cdp,cli): driver ergonomics — wait/cookies/storage/animations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "plumb-core",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,10 @@ dunce = "1"
 # Color distance (CIEDE2000, D65).
 palette = { version = "0.7", default-features = false, features = ["std"] }
 
+# WHATWG URL parsing — used in plumb-cdp to compute storage-state
+# origins (default-port elision, IDNA, scheme case-folding).
+url = "2"
+
 # Parallelism (used only where deterministic: sorted inputs with deterministic folds).
 rayon = "1"
 

--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -36,6 +36,11 @@ indexmap = { workspace = true }
 # parsing uses serde with `deny_unknown_fields`.
 serde = { workspace = true }
 serde_json = { workspace = true }
+# WHATWG URL parsing — `Url::origin().ascii_serialization()` handles
+# default-port elision, IDNA host normalization, scheme case-folding,
+# and stripping of userinfo / path / query / fragment so the
+# storage-state origin compare matches Playwright's stored format.
+url = { workspace = true }
 
 [dev-dependencies]
 plumb-core = { workspace = true, features = ["test-fake"] }

--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -31,6 +31,11 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 indexmap = { workspace = true }
+# Cookie / header / storage-state plumbing (PRD §15) — `Headers` in
+# chromiumoxide is a `serde_json::Value` wrapper; storage-state.json
+# parsing uses serde with `deny_unknown_fields`.
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 plumb-core = { workspace = true, features = ["test-fake"] }

--- a/crates/plumb-cdp/benches/cdp_benchmarks.rs
+++ b/crates/plumb-cdp/benches/cdp_benchmarks.rs
@@ -178,6 +178,7 @@ mod cdp {
             width: 1280,
             height: 800,
             device_pixel_ratio: 1.0,
+            ..Target::default()
         }
     }
 

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -60,6 +60,9 @@ use chromiumoxide::cdp::browser_protocol::dom_snapshot::{
     CaptureSnapshotParams, CaptureSnapshotReturns, DocumentSnapshot,
 };
 use chromiumoxide::cdp::browser_protocol::emulation::SetDeviceMetricsOverrideParams;
+use chromiumoxide::cdp::browser_protocol::network::{
+    CookieParam, Headers, SetCookiesParams, SetExtraHttpHeadersParams,
+};
 use chromiumoxide::cdp::browser_protocol::page::AddScriptToEvaluateOnNewDocumentParams;
 use chromiumoxide::cdp::browser_protocol::target::{
     CreateBrowserContextParams, CreateTargetParams,
@@ -67,6 +70,7 @@ use chromiumoxide::cdp::browser_protocol::target::{
 use chromiumoxide::detection::DetectionOptions;
 use chromiumoxide::{Browser, BrowserConfig, Handler};
 use futures_util::StreamExt;
+use serde::Deserialize;
 use tokio::task::JoinHandle;
 
 /// Lowest Chromium major version Plumb has validated against. Booting
@@ -126,7 +130,14 @@ pub const COMPUTED_STYLE_WHITELIST: &[&str; 36] = &[
     "height",
 ];
 
-/// A snapshot target: URL + viewport.
+/// A snapshot target: URL + viewport + per-target capture knobs.
+///
+/// The capture knobs (`wait_for_selector`, `wait_ms`,
+/// `disable_animations`, `hide_scrollbars`, `pin_dpr`) are documented
+/// in PRD §15. They control browser-side behavior between navigation
+/// and `DOMSnapshot.captureSnapshot` and never flow into snapshot
+/// content — they only affect *when* the snapshot is captured and what
+/// CSS state the page is in at that moment.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Target {
     /// URL to navigate to. The `plumb-fake://` scheme is reserved for
@@ -140,6 +151,58 @@ pub struct Target {
     pub height: u32,
     /// Device pixel ratio.
     pub device_pixel_ratio: f32,
+    /// Optional CSS selector to wait for before capturing the snapshot.
+    /// When set, the driver polls the page until at least one matching
+    /// element exists. Compatible with [`Self::wait_ms`] — both fire,
+    /// in order: selector first, then the additional sleep.
+    pub wait_for_selector: Option<String>,
+    /// Optional additional milliseconds to sleep before capturing the
+    /// snapshot, after navigation (and after [`Self::wait_for_selector`]).
+    pub wait_ms: Option<u64>,
+    /// Inject CSS that disables animations and transitions before the
+    /// page renders. Defaults to `true` — the historical Plumb behavior
+    /// (PRD §16) — and the CLI exposes a flag that flips this value.
+    pub disable_animations: bool,
+    /// Inject CSS that hides page-level scrollbars. Defaults to `true`
+    /// to match the Chromium launch arg `--hide-scrollbars`. The CSS
+    /// belt-and-suspenders covers cases where the launch arg alone is
+    /// not honored (e.g. older Chromium majors on certain platforms).
+    pub hide_scrollbars: bool,
+    /// Optional explicit device-pixel ratio override applied via
+    /// `Emulation.setDeviceMetricsOverride.deviceScaleFactor` instead of
+    /// using [`Self::device_pixel_ratio`]. When `None`, the existing
+    /// `device_pixel_ratio` is used. The CLI exposes this as `--dpr`.
+    pub pin_dpr: Option<f64>,
+}
+
+impl Target {
+    /// Effective device-scale factor for `Emulation.setDeviceMetricsOverride`.
+    ///
+    /// Prefers [`Self::pin_dpr`] when set, otherwise falls back to
+    /// [`Self::device_pixel_ratio`]. Centralizing the choice keeps the
+    /// "pin overrides default" rule in one place.
+    #[must_use]
+    pub fn effective_dpr(&self) -> f64 {
+        self.pin_dpr
+            .unwrap_or_else(|| f64::from(self.device_pixel_ratio))
+    }
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            viewport: ViewportKey::new("desktop"),
+            width: 1280,
+            height: 800,
+            device_pixel_ratio: 1.0,
+            wait_for_selector: None,
+            wait_ms: None,
+            disable_animations: true,
+            hide_scrollbars: true,
+            pin_dpr: None,
+        }
+    }
 }
 
 /// Errors returned by drivers.
@@ -178,9 +241,332 @@ pub enum CdpError {
         /// What was wrong with the response.
         reason: String,
     },
+    /// A user-supplied cookie name/value contained illegal characters
+    /// (header injection guard — newlines are refused before reaching
+    /// the browser).
+    #[error("invalid cookie {field} `{input}`: {reason}")]
+    InvalidCookie {
+        /// Which cookie field failed validation (`name` or `value`).
+        field: &'static str,
+        /// The offending input.
+        input: String,
+        /// Reason the input was rejected.
+        reason: &'static str,
+    },
+    /// A user-supplied HTTP header name/value contained illegal
+    /// characters (header injection guard — newlines and `:` in names
+    /// are refused before reaching the browser).
+    #[error("invalid header {field} `{input}`: {reason}")]
+    InvalidHeader {
+        /// Which header field failed validation (`name` or `value`).
+        field: &'static str,
+        /// The offending input.
+        input: String,
+        /// Reason the input was rejected.
+        reason: &'static str,
+    },
+    /// A user-supplied path (auth-script or storage-state) failed the
+    /// safe-path check.
+    #[error("invalid path `{path}`: {reason}")]
+    InvalidPath {
+        /// The offending path.
+        path: PathBuf,
+        /// Reason the path was rejected.
+        reason: String,
+    },
+    /// Failed to parse a Playwright storage-state JSON file.
+    #[error("malformed storage-state file `{path}`: {reason}")]
+    MalformedStorageState {
+        /// The file the driver was reading.
+        path: PathBuf,
+        /// What went wrong.
+        reason: String,
+    },
     /// Any other driver-level failure, carried as a boxed [`std::error::Error`].
     #[error("driver failure: {0}")]
     Driver(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// A cookie to install before navigation.
+///
+/// User-supplied cookies are validated for header-injection-style
+/// payloads (newlines, NULs) before flowing into a CDP `Network.setCookies`
+/// request. A `None` `url` means the cookie is bound to whatever URL the
+/// target ends up navigating to.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Cookie {
+    /// Cookie name.
+    pub name: String,
+    /// Cookie value.
+    pub value: String,
+    /// Optional explicit URL the cookie is associated with. When `None`,
+    /// the cookie is associated with the target URL on injection.
+    pub url: Option<String>,
+    /// Optional cookie domain.
+    pub domain: Option<String>,
+    /// Optional cookie path (defaults to `/`).
+    pub path: Option<String>,
+    /// Optional `Secure` flag.
+    pub secure: Option<bool>,
+    /// Optional `HttpOnly` flag.
+    pub http_only: Option<bool>,
+}
+
+impl Cookie {
+    /// Construct a cookie from a `name=value` token. The pre-navigation
+    /// helper attaches the target URL on injection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdpError::InvalidCookie`] when:
+    /// - The token has no `=` separator.
+    /// - The name is empty.
+    /// - The name or value contains a CR, LF, or NUL byte (header
+    ///   injection).
+    pub fn parse_kv(token: &str) -> Result<Self, CdpError> {
+        let (name, value) = token
+            .split_once('=')
+            .ok_or_else(|| CdpError::InvalidCookie {
+                field: "name",
+                input: token.to_owned(),
+                reason: "expected `name=value`",
+            })?;
+        let name = name.trim().to_owned();
+        let value = value.to_owned();
+        if name.is_empty() {
+            return Err(CdpError::InvalidCookie {
+                field: "name",
+                input: token.to_owned(),
+                reason: "name must not be empty",
+            });
+        }
+        validate_no_ctl(&name, "name", "cookie")?;
+        validate_no_ctl(&value, "value", "cookie")?;
+        Ok(Self {
+            name,
+            value,
+            ..Self::default()
+        })
+    }
+
+    fn into_cdp_param(self, default_url: Option<&str>) -> CookieParam {
+        let mut param = CookieParam::new(self.name, self.value);
+        param.url = self.url.or_else(|| default_url.map(str::to_owned));
+        param.domain = self.domain;
+        param.path = self.path;
+        param.secure = self.secure;
+        param.http_only = self.http_only;
+        param
+    }
+}
+
+fn validate_no_ctl(input: &str, field: &'static str, kind: &'static str) -> Result<(), CdpError> {
+    if input.bytes().any(|b| b == b'\r' || b == b'\n' || b == 0) {
+        return match kind {
+            "cookie" => Err(CdpError::InvalidCookie {
+                field,
+                input: input.to_owned(),
+                reason: "control characters (CR/LF/NUL) are not allowed",
+            }),
+            _ => Err(CdpError::InvalidHeader {
+                field,
+                input: input.to_owned(),
+                reason: "control characters (CR/LF/NUL) are not allowed",
+            }),
+        };
+    }
+    Ok(())
+}
+
+/// Parse and validate an HTTP header `name: value` token.
+///
+/// # Errors
+///
+/// Returns [`CdpError::InvalidHeader`] when:
+/// - The token has no `:` separator.
+/// - The name is empty or contains whitespace / `:` / control bytes.
+/// - The value contains CR, LF, or NUL bytes (header injection).
+pub fn parse_header_kv(token: &str) -> Result<(String, String), CdpError> {
+    let (name, value) = token
+        .split_once(':')
+        .ok_or_else(|| CdpError::InvalidHeader {
+            field: "name",
+            input: token.to_owned(),
+            reason: "expected `name: value`",
+        })?;
+    let name = name.trim().to_owned();
+    let value = value.trim_start().to_owned();
+    if name.is_empty() {
+        return Err(CdpError::InvalidHeader {
+            field: "name",
+            input: token.to_owned(),
+            reason: "name must not be empty",
+        });
+    }
+    if name
+        .bytes()
+        .any(|b| b == b':' || b == b' ' || b == b'\t' || b == b'\r' || b == b'\n' || b == 0)
+    {
+        return Err(CdpError::InvalidHeader {
+            field: "name",
+            input: name,
+            reason: "name must not contain whitespace, `:`, or control bytes",
+        });
+    }
+    validate_no_ctl(&value, "value", "header")?;
+    Ok((name, value))
+}
+
+/// Playwright `storage-state.json` representation.
+///
+/// Matches the format Playwright writes via
+/// [`browserContext.storageState()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state)
+/// — a `cookies` array plus an `origins` array of `{ origin,
+/// localStorage }`. Deserialized with `deny_unknown_fields` so a
+/// future Playwright addition fails loudly rather than being silently
+/// ignored.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageState {
+    /// Cookies preserved across the session.
+    #[serde(default)]
+    pub cookies: Vec<StorageStateCookie>,
+    /// Per-origin localStorage entries.
+    #[serde(default)]
+    pub origins: Vec<StorageStateOrigin>,
+}
+
+/// One cookie entry in a Playwright `storage-state.json`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageStateCookie {
+    /// Cookie name.
+    pub name: String,
+    /// Cookie value.
+    pub value: String,
+    /// Cookie domain.
+    pub domain: String,
+    /// Cookie path.
+    pub path: String,
+    /// Cookie expiration as a Unix timestamp; Playwright uses `-1` for
+    /// session cookies.
+    #[serde(default)]
+    pub expires: f64,
+    /// `HttpOnly` flag.
+    #[serde(default, rename = "httpOnly")]
+    pub http_only: bool,
+    /// `Secure` flag.
+    #[serde(default)]
+    pub secure: bool,
+    /// `SameSite` attribute (typically `"Strict" | "Lax" | "None"`).
+    #[serde(default, rename = "sameSite")]
+    pub same_site: Option<String>,
+}
+
+/// One `origins[]` entry in a Playwright `storage-state.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageStateOrigin {
+    /// The origin URL (e.g. `https://example.com`).
+    pub origin: String,
+    /// `localStorage` entries for the origin.
+    #[serde(default, rename = "localStorage")]
+    pub local_storage: Vec<StorageStateLocalStorageEntry>,
+}
+
+/// One `localStorage[]` entry in a Playwright `storage-state.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageStateLocalStorageEntry {
+    /// localStorage key.
+    pub name: String,
+    /// localStorage value.
+    pub value: String,
+}
+
+impl StorageState {
+    /// Parse a Playwright `storage-state.json` from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdpError::MalformedStorageState`] with `path = ""` when
+    /// the JSON cannot be parsed. Callers that have a real path on hand
+    /// should use [`Self::load_from_path`] instead so the error carries
+    /// the source filename.
+    pub fn parse_str(json: &str) -> Result<Self, CdpError> {
+        serde_json::from_str(json).map_err(|err| CdpError::MalformedStorageState {
+            path: PathBuf::new(),
+            reason: err.to_string(),
+        })
+    }
+
+    /// Read and parse a storage-state file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdpError::InvalidPath`] when the path fails the safe-path
+    /// check, or [`CdpError::MalformedStorageState`] when the file cannot
+    /// be read or parsed.
+    pub fn load_from_path(path: &Path) -> Result<Self, CdpError> {
+        let canonical = canonicalize_safe_path(path)?;
+        let bytes =
+            std::fs::read_to_string(&canonical).map_err(|err| CdpError::MalformedStorageState {
+                path: canonical.clone(),
+                reason: err.to_string(),
+            })?;
+        let mut state: Self =
+            serde_json::from_str(&bytes).map_err(|err| CdpError::MalformedStorageState {
+                path: canonical.clone(),
+                reason: err.to_string(),
+            })?;
+        // Validate every cookie name/value for header-injection style
+        // payloads — Playwright files are typically machine-written but
+        // Plumb cannot trust their provenance.
+        for cookie in &state.cookies {
+            validate_no_ctl(&cookie.name, "name", "cookie")?;
+            validate_no_ctl(&cookie.value, "value", "cookie")?;
+        }
+        // Sort cookies and origins for deterministic injection order.
+        state.cookies.sort_by(|a, b| {
+            (a.domain.as_str(), a.name.as_str()).cmp(&(b.domain.as_str(), b.name.as_str()))
+        });
+        state.origins.sort_by(|a, b| a.origin.cmp(&b.origin));
+        for origin in &mut state.origins {
+            origin.local_storage.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+        Ok(state)
+    }
+}
+
+/// Canonicalize `path` and reject symlinks pointing outside the current
+/// working directory.
+///
+/// `--auth-script` and `--storage-state` accept arbitrary file paths,
+/// so the caller-side check is the last guard before we read user
+/// content. The check refuses paths that:
+/// - cannot be canonicalized (file does not exist / no permission),
+/// - resolve to a different prefix than the current working directory.
+fn canonicalize_safe_path(path: &Path) -> Result<PathBuf, CdpError> {
+    let canonical = path.canonicalize().map_err(|err| CdpError::InvalidPath {
+        path: path.to_path_buf(),
+        reason: format!("could not canonicalize: {err}"),
+    })?;
+    let cwd = std::env::current_dir().map_err(|err| CdpError::InvalidPath {
+        path: path.to_path_buf(),
+        reason: format!("could not read CWD: {err}"),
+    })?;
+    let cwd_canonical = cwd.canonicalize().unwrap_or(cwd);
+    if !canonical.starts_with(&cwd_canonical) {
+        return Err(CdpError::InvalidPath {
+            path: path.to_path_buf(),
+            reason: format!(
+                "path resolves to `{}`, which is outside the current working directory `{}`",
+                canonical.display(),
+                cwd_canonical.display()
+            ),
+        });
+    }
+    Ok(canonical)
 }
 
 /// Async trait for browser drivers. Implementations are expected to be
@@ -228,6 +614,22 @@ pub struct ChromiumOptions {
     /// Profile contents do not flow into [`PlumbSnapshot`] output, so
     /// varying this path does not violate the determinism invariant.
     pub user_data_dir: Option<PathBuf>,
+    /// Cookies to install before navigation (PRD §15 — `--cookie`).
+    /// Iterated in `(name, value)` order for deterministic CDP traffic.
+    pub cookies: Vec<Cookie>,
+    /// Extra HTTP headers to attach to every request (PRD §15 —
+    /// `--header`). Sorted by name on injection so CDP traffic is
+    /// stable across runs.
+    pub headers: Vec<(String, String)>,
+    /// Path to a JavaScript file evaluated on every new document via
+    /// `Page.addScriptToEvaluateOnNewDocument` before navigation
+    /// (PRD §15 — `--auth-script`).
+    pub auth_script: Option<PathBuf>,
+    /// Path to a Playwright `storage-state.json` file. Cookies in the
+    /// file are installed before navigation; localStorage entries are
+    /// preserved as a parsed [`StorageState`] for downstream evaluation
+    /// after navigation when the origin matches.
+    pub storage_state: Option<PathBuf>,
 }
 
 /// Real Chromium-backed driver.
@@ -305,7 +707,7 @@ impl BrowserDriver for ChromiumDriver {
             validate_browser_version(&session.browser).await?;
             let mut snapshots = Vec::with_capacity(targets.len());
             for target in &targets {
-                let snap = capture_target(&session.browser, target).await?;
+                let snap = capture_target(&session.browser, target, &self.options).await?;
                 snapshots.push(snap);
             }
             Ok(snapshots)
@@ -323,26 +725,41 @@ impl BrowserDriver for ChromiumDriver {
     }
 }
 
-async fn capture_target(browser: &Browser, target: &Target) -> Result<PlumbSnapshot, CdpError> {
+async fn capture_target(
+    browser: &Browser,
+    target: &Target,
+    options: &ChromiumOptions,
+) -> Result<PlumbSnapshot, CdpError> {
     let page = browser
         .new_page("about:blank")
         .await
         .map_err(driver_error)?;
 
-    capture_on_page(&page, target).await
+    capture_on_page(&page, target, options).await
 }
 
-/// Apply viewport / animation hooks, navigate, capture a DOM snapshot.
+/// Apply viewport / animation hooks, install cookies and headers,
+/// navigate, capture a DOM snapshot.
 ///
 /// Shared between `ChromiumDriver::capture_target` and
 /// [`PersistentBrowser::snapshot`] so that the per-target work is
-/// expressed in exactly one place.
-async fn capture_on_page(page: &Page, target: &Target) -> Result<PlumbSnapshot, CdpError> {
+/// expressed in exactly one place. The function is split into discrete
+/// stages — `apply_viewport` (DPR + dimensions), `pre_navigate`
+/// (cookies, headers, auth-script, storage-state, animation killer,
+/// scrollbar killer), `goto` + waits, then capture.
+async fn capture_on_page(
+    page: &Page,
+    target: &Target,
+    options: &ChromiumOptions,
+) -> Result<PlumbSnapshot, CdpError> {
     apply_viewport(page, target).await?;
-    inject_animation_killer(page).await?;
+    pre_navigate(page, target, options).await?;
 
     page.goto(target.url.as_str()).await.map_err(driver_error)?;
     page.wait_for_navigation().await.map_err(driver_error)?;
+
+    apply_post_navigate_waits(page, target).await?;
+    apply_storage_state_local_storage(page, target, options).await?;
 
     let params = CaptureSnapshotParams {
         computed_styles: COMPUTED_STYLE_WHITELIST
@@ -380,6 +797,7 @@ pub struct PersistentBrowser {
 struct PersistentBrowserInner {
     browser: Browser,
     handler_task: Mutex<Option<JoinHandle<()>>>,
+    options: ChromiumOptions,
 }
 
 impl PersistentBrowser {
@@ -414,6 +832,7 @@ impl PersistentBrowser {
             inner: Arc::new(PersistentBrowserInner {
                 browser,
                 handler_task: Mutex::new(Some(handler_task)),
+                options,
             }),
         })
     }
@@ -455,7 +874,7 @@ impl PersistentBrowser {
                 .new_page(create_params)
                 .await
                 .map_err(driver_error)?;
-            capture_on_page(&page, &target).await
+            capture_on_page(&page, &target, &self.inner.options).await
         }
         .await;
 
@@ -569,10 +988,13 @@ fn persistent_browser_config(options: &ChromiumOptions) -> Result<BrowserConfig,
 }
 
 async fn apply_viewport(page: &Page, target: &Target) -> Result<(), CdpError> {
+    // `pin_dpr` (PRD §15 — `--dpr`) wins over `device_pixel_ratio` so
+    // that callers can stress determinism by pinning a hidpi factor
+    // independent of the viewport's logical DPR.
     let params = SetDeviceMetricsOverrideParams {
         width: i64::from(target.width),
         height: i64::from(target.height),
-        device_scale_factor: f64::from(target.device_pixel_ratio),
+        device_scale_factor: target.effective_dpr(),
         mobile: false,
         scale: None,
         screen_width: None,
@@ -585,6 +1007,111 @@ async fn apply_viewport(page: &Page, target: &Target) -> Result<(), CdpError> {
     };
     page.execute(params).await.map_err(driver_error)?;
     Ok(())
+}
+
+/// All work that must happen on a fresh page before navigation.
+///
+/// Runs in this fixed order so behavior matches what users expect:
+/// 1. Animation/scrollbar CSS killers — PRD §16 determinism.
+/// 2. Auth script — runs before any page script, so the page-side
+///    bootstrap can set window globals before the SPA boots.
+/// 3. Cookies and HTTP headers — set on the network layer before the
+///    very first request leaves Chromium.
+/// 4. Storage-state cookies — same network layer; localStorage entries
+///    in the storage-state are deferred to [`apply_storage_state_local_storage`]
+///    after the origin loads, since localStorage is origin-scoped.
+async fn pre_navigate(
+    page: &Page,
+    target: &Target,
+    options: &ChromiumOptions,
+) -> Result<(), CdpError> {
+    if target.disable_animations {
+        inject_animation_killer(page).await?;
+    }
+    if target.hide_scrollbars {
+        inject_scrollbar_killer(page).await?;
+    }
+    if let Some(script_path) = options.auth_script.as_deref() {
+        inject_auth_script(page, script_path).await?;
+    }
+    if !options.headers.is_empty() {
+        install_extra_headers(page, &options.headers).await?;
+    }
+    if !options.cookies.is_empty() {
+        install_cookies(page, &options.cookies, target.url.as_str()).await?;
+    }
+    if let Some(state_path) = options.storage_state.as_deref() {
+        install_storage_state_cookies(page, state_path).await?;
+    }
+    Ok(())
+}
+
+/// Wait stages that must run *after* navigation. PRD §15 — `--wait-for`
+/// and `--wait-ms`.
+///
+/// Selector wait fires first (so users can synchronize on a
+/// known-rendered element); the additional `--wait-ms` then runs as a
+/// belt-and-suspenders sleep for SPAs whose post-render work doesn't
+/// finish in the same tick.
+async fn apply_post_navigate_waits(page: &Page, target: &Target) -> Result<(), CdpError> {
+    if let Some(selector) = target.wait_for_selector.as_deref() {
+        wait_for_selector(page, selector).await?;
+    }
+    if let Some(ms) = target.wait_ms {
+        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+    }
+    Ok(())
+}
+
+/// Install localStorage entries from a Playwright storage-state file.
+///
+/// Runs *after* navigation because `localStorage` is origin-scoped and
+/// the only way to write to it from the driver is to evaluate a script
+/// in the page context. Entries whose `origin` does not match the
+/// navigated URL's origin are skipped (same isolation Playwright applies).
+async fn apply_storage_state_local_storage(
+    page: &Page,
+    target: &Target,
+    options: &ChromiumOptions,
+) -> Result<(), CdpError> {
+    let Some(state_path) = options.storage_state.as_deref() else {
+        return Ok(());
+    };
+    let state = StorageState::load_from_path(state_path)?;
+    let target_origin = origin_of(target.url.as_str()).unwrap_or_default();
+    for origin_entry in &state.origins {
+        if origin_entry.origin != target_origin {
+            continue;
+        }
+        for entry in &origin_entry.local_storage {
+            // Build a JSON.stringify-style argument so the values are
+            // safe regardless of contained quotes.
+            let key = serde_json::to_string(&entry.name).map_err(|err| {
+                CdpError::MalformedStorageState {
+                    path: state_path.to_path_buf(),
+                    reason: format!("could not serialize key: {err}"),
+                }
+            })?;
+            let value = serde_json::to_string(&entry.value).map_err(|err| {
+                CdpError::MalformedStorageState {
+                    path: state_path.to_path_buf(),
+                    reason: format!("could not serialize value: {err}"),
+                }
+            })?;
+            let script = format!("window.localStorage.setItem({key}, {value});");
+            page.evaluate(script.as_str()).await.map_err(driver_error)?;
+        }
+    }
+    Ok(())
+}
+
+fn origin_of(url: &str) -> Option<String> {
+    // Minimal origin extractor — `<scheme>://<host>[:<port>]`. Avoids a
+    // url-parser dep; storage-state matching is a string compare against
+    // Playwright's own origin format.
+    let (scheme, rest) = url.split_once("://")?;
+    let host = rest.split('/').next()?;
+    Some(format!("{scheme}://{host}"))
 }
 
 async fn inject_animation_killer(page: &Page) -> Result<(), CdpError> {
@@ -602,14 +1129,142 @@ async fn inject_animation_killer(page: &Page) -> Result<(), CdpError> {
         }'; \
         (document.head || document.documentElement).appendChild(style); \
     })();";
+    add_script_to_evaluate_on_new_document(page, source).await
+}
+
+async fn inject_scrollbar_killer(page: &Page) -> Result<(), CdpError> {
+    // PRD §16 determinism mitigation: scrollbar overlay differs across
+    // platforms / DPRs. The `--hide-scrollbars` Chromium launch arg is a
+    // first line of defense; this CSS injection covers the cases where
+    // the launch arg alone is not honored (Linux non-overlay scrollbars,
+    // CSS-painted scrollbars in some apps).
+    let source = "(() => { \
+        const style = document.createElement('style'); \
+        style.textContent = 'html { overflow: hidden !important; } \
+            ::-webkit-scrollbar { display: none !important; }'; \
+        (document.head || document.documentElement).appendChild(style); \
+    })();";
+    add_script_to_evaluate_on_new_document(page, source).await
+}
+
+async fn inject_auth_script(page: &Page, path: &Path) -> Result<(), CdpError> {
+    let canonical = canonicalize_safe_path(path)?;
+    if canonical.extension().and_then(|s| s.to_str()) != Some("js") {
+        return Err(CdpError::InvalidPath {
+            path: path.to_path_buf(),
+            reason: "auth script must have a `.js` extension".to_owned(),
+        });
+    }
+    let source = std::fs::read_to_string(&canonical).map_err(|err| CdpError::InvalidPath {
+        path: canonical.clone(),
+        reason: format!("could not read: {err}"),
+    })?;
+    add_script_to_evaluate_on_new_document(page, &source).await
+}
+
+async fn add_script_to_evaluate_on_new_document(page: &Page, source: &str) -> Result<(), CdpError> {
     let params = AddScriptToEvaluateOnNewDocumentParams {
-        source: source.to_string(),
+        source: source.to_owned(),
         world_name: None,
         include_command_line_api: None,
         run_immediately: Some(true),
     };
     page.execute(params).await.map_err(driver_error)?;
     Ok(())
+}
+
+async fn install_extra_headers(page: &Page, headers: &[(String, String)]) -> Result<(), CdpError> {
+    // Sort by name for deterministic CDP traffic. Plumb's invariant is
+    // byte-identical *output*, but stable network-layer requests make
+    // diffing tcpdumps across runs viable too.
+    let mut entries: Vec<(String, String)> = headers.to_vec();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut object = serde_json::Map::with_capacity(entries.len());
+    for (name, value) in entries {
+        validate_no_ctl(&name, "name", "header")?;
+        validate_no_ctl(&value, "value", "header")?;
+        object.insert(name, serde_json::Value::String(value));
+    }
+    let params = SetExtraHttpHeadersParams::new(Headers::new(serde_json::Value::Object(object)));
+    page.execute(params).await.map_err(driver_error)?;
+    Ok(())
+}
+
+async fn install_cookies(
+    page: &Page,
+    cookies: &[Cookie],
+    default_url: &str,
+) -> Result<(), CdpError> {
+    // Sort by `(name, value)` so the network-layer call is stable across
+    // runs even when the caller supplied cookies in a different order.
+    let mut sorted: Vec<Cookie> = cookies.to_vec();
+    sorted.sort_by(|a, b| {
+        (a.name.as_str(), a.value.as_str()).cmp(&(b.name.as_str(), b.value.as_str()))
+    });
+    let url_for_cookies = if default_url.starts_with("http") {
+        Some(default_url)
+    } else {
+        None
+    };
+    let params = SetCookiesParams::new(
+        sorted
+            .into_iter()
+            .map(|c| c.into_cdp_param(url_for_cookies))
+            .collect(),
+    );
+    page.execute(params).await.map_err(driver_error)?;
+    Ok(())
+}
+
+async fn install_storage_state_cookies(page: &Page, path: &Path) -> Result<(), CdpError> {
+    let state = StorageState::load_from_path(path)?;
+    if state.cookies.is_empty() {
+        return Ok(());
+    }
+    let mut params: Vec<CookieParam> = Vec::with_capacity(state.cookies.len());
+    for cookie in state.cookies {
+        let mut p = CookieParam::new(cookie.name, cookie.value);
+        p.domain = Some(cookie.domain);
+        p.path = Some(cookie.path);
+        p.secure = Some(cookie.secure);
+        p.http_only = Some(cookie.http_only);
+        params.push(p);
+    }
+    page.execute(SetCookiesParams::new(params))
+        .await
+        .map_err(driver_error)?;
+    Ok(())
+}
+
+async fn wait_for_selector(page: &Page, selector: &str) -> Result<(), CdpError> {
+    // Poll `find_element` with a 50ms backoff up to 10 seconds total
+    // (PRD §15 default). The selector is the users contract for "the
+    // page is rendered enough for me" — burning the full 10 seconds is
+    // intentional when the selector never matches; we surface that as a
+    // driver error so CI fails loudly rather than capturing a half-baked
+    // snapshot.
+    //
+    // Wall-clock-free implementation: an outer `tokio::time::timeout`
+    // bounds the whole loop. Tokios timer infrastructure does its own
+    // monotonic time tracking internally and is allowed in `plumb-cdp`
+    // because it doesnt leak into the snapshot (PRD §9 isolates the
+    // "no wall-clock" rule to the rule engine and observable output).
+    let attempt = async {
+        loop {
+            match page.find_element(selector.to_owned()).await {
+                Ok(_) => return Ok::<(), CdpError>(()),
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        }
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(10), attempt).await {
+        Ok(result) => result,
+        Err(_) => Err(CdpError::Driver(Box::new(io::Error::other(format!(
+            "wait_for_selector `{selector}` exhausted 10s budget"
+        ))))),
+    }
 }
 
 /// Deterministic fake driver. Recognizes `plumb-fake://hello` and returns
@@ -1546,5 +2201,130 @@ mod tests {
             matches!(err, CdpError::MalformedSnapshot { ref reason } if reason.contains("out of range")),
             "expected MalformedSnapshot for OOB index, got {err:?}"
         );
+    }
+
+    use super::{Cookie, StorageState, parse_header_kv};
+
+    #[test]
+    fn cookie_parse_kv_accepts_simple_pair() {
+        let c = Cookie::parse_kv("session=abc123").unwrap();
+        assert_eq!(c.name, "session");
+        assert_eq!(c.value, "abc123");
+        assert!(c.url.is_none());
+    }
+
+    #[test]
+    fn cookie_parse_kv_rejects_missing_separator() {
+        let err = Cookie::parse_kv("nosep").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { .. }));
+    }
+
+    #[test]
+    fn cookie_parse_kv_rejects_empty_name() {
+        let err = Cookie::parse_kv("=value").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { .. }));
+    }
+
+    #[test]
+    fn cookie_parse_kv_rejects_crlf_in_value() {
+        let err = Cookie::parse_kv("name=hello\r\nSet-Cookie: pwn=1").unwrap_err();
+        match err {
+            CdpError::InvalidCookie { field, reason, .. } => {
+                assert_eq!(field, "value");
+                assert!(reason.contains("control characters"));
+            }
+            other => panic!("expected InvalidCookie, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn header_parse_kv_accepts_pair() {
+        let (n, v) = parse_header_kv("X-Trace-Id: 12345").unwrap();
+        assert_eq!(n, "X-Trace-Id");
+        assert_eq!(v, "12345");
+    }
+
+    #[test]
+    fn header_parse_kv_rejects_missing_colon() {
+        let err = parse_header_kv("nope").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { .. }));
+    }
+
+    #[test]
+    fn header_parse_kv_rejects_lf_in_value() {
+        let err = parse_header_kv("X-Pwn: hi\nInjected: 1").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { .. }));
+    }
+
+    #[test]
+    fn header_parse_kv_rejects_space_in_name() {
+        let err = parse_header_kv("X Header: 1").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { .. }));
+    }
+
+    #[test]
+    fn storage_state_parses_minimal_payload() {
+        let json = r#"{
+            "cookies": [
+                {"name":"a","value":"1","domain":".example.com","path":"/","expires":-1,"httpOnly":false,"secure":false,"sameSite":"Lax"}
+            ],
+            "origins": [
+                {"origin":"https://example.com","localStorage":[{"name":"k","value":"v"}]}
+            ]
+        }"#;
+        let state = StorageState::parse_str(json).unwrap();
+        assert_eq!(state.cookies.len(), 1);
+        assert_eq!(state.cookies[0].name, "a");
+        assert_eq!(state.origins.len(), 1);
+        assert_eq!(state.origins[0].origin, "https://example.com");
+        assert_eq!(state.origins[0].local_storage[0].name, "k");
+    }
+
+    #[test]
+    fn storage_state_parses_empty_payload() {
+        let state = StorageState::parse_str(r#"{"cookies":[],"origins":[]}"#).unwrap();
+        assert!(state.cookies.is_empty());
+        assert!(state.origins.is_empty());
+    }
+
+    #[test]
+    fn storage_state_rejects_unknown_fields() {
+        let json = r#"{"cookies":[],"origins":[],"unexpected":42}"#;
+        let err = StorageState::parse_str(json).unwrap_err();
+        assert!(matches!(err, CdpError::MalformedStorageState { .. }));
+    }
+
+    #[test]
+    fn target_default_sets_capture_knobs() {
+        let t = super::Target::default();
+        assert!(t.disable_animations);
+        assert!(t.hide_scrollbars);
+        assert!(t.wait_for_selector.is_none());
+        assert!(t.wait_ms.is_none());
+        assert!(t.pin_dpr.is_none());
+    }
+
+    #[test]
+    fn target_effective_dpr_prefers_pin_over_default() {
+        let mut t = super::Target {
+            device_pixel_ratio: 1.0,
+            ..super::Target::default()
+        };
+        assert!((t.effective_dpr() - 1.0).abs() < f64::EPSILON);
+        t.pin_dpr = Some(3.0);
+        assert!((t.effective_dpr() - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn origin_of_handles_https_url() {
+        assert_eq!(
+            super::origin_of("https://example.com/path?q=1").as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(
+            super::origin_of("http://example.com:8080/").as_deref(),
+            Some("http://example.com:8080")
+        );
+        assert_eq!(super::origin_of("notaurl").as_deref(), None);
     }
 }

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -628,6 +628,30 @@ impl StorageState {
     }
 }
 
+/// Public CLI-facing wrapper around [`canonicalize_safe_path`].
+///
+/// `plumb-cli` validates `--auth-script` / `--storage-state` paths up
+/// front (before driver dispatch) so the FakeDriver path also rejects
+/// outside-CWD inputs — without this, the safe-path check would only
+/// fire on the real Chromium code path and tests against
+/// `plumb-fake://hello` would silently accept a malicious-looking
+/// `--auth-script /etc/passwd`.
+///
+/// # Errors
+///
+/// Returns [`CdpError::InvalidPath`] when `path` cannot be
+/// canonicalized or canonicalizes to a location outside the current
+/// working directory.
+///
+/// # Security boundary
+///
+/// Same caveats as [`canonicalize_safe_path`]: this is a best-effort
+/// usability guard, **not** a sandbox. See that function's docs for
+/// the full TOCTOU discussion.
+pub fn validate_safe_path(path: &Path) -> Result<PathBuf, CdpError> {
+    canonicalize_safe_path(path)
+}
+
 /// Canonicalize `path` and reject symlinks pointing outside the current
 /// working directory.
 ///

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -544,17 +544,46 @@ pub struct StorageStateLocalStorageEntry {
 impl StorageState {
     /// Parse a Playwright `storage-state.json` from a string.
     ///
+    /// Validates every cookie name, value, domain, and path for
+    /// header-injection-style payloads (control bytes) and sorts the
+    /// cookies / origins / localStorage entries for deterministic
+    /// injection order.
+    ///
     /// # Errors
     ///
     /// Returns [`CdpError::MalformedStorageState`] with `path = ""` when
-    /// the JSON cannot be parsed. Callers that have a real path on hand
-    /// should use [`Self::load_from_path`] instead so the error carries
-    /// the source filename.
+    /// the JSON cannot be parsed. Returns [`CdpError::InvalidCookie`]
+    /// when a cookie field contains control bytes. Callers that have a
+    /// real path on hand should use [`Self::load_from_path`] instead so
+    /// the error carries the source filename.
     pub fn parse_str(json: &str) -> Result<Self, CdpError> {
-        serde_json::from_str(json).map_err(|err| CdpError::MalformedStorageState {
-            path: PathBuf::new(),
-            reason: err.to_string(),
-        })
+        let mut state: Self =
+            serde_json::from_str(json).map_err(|err| CdpError::MalformedStorageState {
+                path: PathBuf::new(),
+                reason: err.to_string(),
+            })?;
+        // Validate every cookie name/value/domain/path for
+        // header-injection style payloads — Playwright files are
+        // typically machine-written but Plumb cannot trust their
+        // provenance. `domain` and `path` flow into a CDP
+        // `Network.setCookies` call alongside the name/value, so an
+        // unchecked CR/LF in either field would smuggle just as
+        // effectively as one in the value.
+        for cookie in &state.cookies {
+            validate_no_ctl(&cookie.name, "name", "cookie")?;
+            validate_no_ctl(&cookie.value, "value", "cookie")?;
+            validate_no_ctl(&cookie.domain, "domain", "cookie")?;
+            validate_no_ctl(&cookie.path, "path", "cookie")?;
+        }
+        // Sort cookies and origins for deterministic injection order.
+        state.cookies.sort_by(|a, b| {
+            (a.domain.as_str(), a.name.as_str()).cmp(&(b.domain.as_str(), b.name.as_str()))
+        });
+        state.origins.sort_by(|a, b| a.origin.cmp(&b.origin));
+        for origin in &mut state.origins {
+            origin.local_storage.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+        Ok(state)
     }
 
     /// Read and parse a storage-state file from disk.
@@ -585,27 +614,17 @@ impl StorageState {
                 path: canonical.clone(),
                 reason: err.to_string(),
             })?;
-        let mut state: Self =
-            serde_json::from_str(&bytes).map_err(|err| CdpError::MalformedStorageState {
-                path: canonical.clone(),
-                reason: err.to_string(),
-            })?;
-        // Validate every cookie name/value for header-injection style
-        // payloads — Playwright files are typically machine-written but
-        // Plumb cannot trust their provenance.
-        for cookie in &state.cookies {
-            validate_no_ctl(&cookie.name, "name", "cookie")?;
-            validate_no_ctl(&cookie.value, "value", "cookie")?;
-        }
-        // Sort cookies and origins for deterministic injection order.
-        state.cookies.sort_by(|a, b| {
-            (a.domain.as_str(), a.name.as_str()).cmp(&(b.domain.as_str(), b.name.as_str()))
-        });
-        state.origins.sort_by(|a, b| a.origin.cmp(&b.origin));
-        for origin in &mut state.origins {
-            origin.local_storage.sort_by(|a, b| a.name.cmp(&b.name));
-        }
-        Ok(state)
+        // Re-stamp `MalformedStorageState` errors with the source path
+        // so callers see *which* file failed; cookie-validation errors
+        // pass through unchanged because they carry the offending input
+        // rather than a path.
+        Self::parse_str(&bytes).map_err(|err| match err {
+            CdpError::MalformedStorageState { reason, .. } => CdpError::MalformedStorageState {
+                path: canonical,
+                reason,
+            },
+            other => other,
+        })
     }
 }
 
@@ -2502,6 +2521,53 @@ mod tests {
         let json = r#"{"cookies":[],"origins":[],"unexpected":42}"#;
         let err = StorageState::parse_str(json).unwrap_err();
         assert!(matches!(err, CdpError::MalformedStorageState { .. }));
+    }
+
+    #[test]
+    fn storage_state_parse_str_rejects_crlf_in_cookie_domain() {
+        // `parse_str` is the canonical validation entry point —
+        // `load_from_path` delegates to it. Drive it directly so the
+        // test doesn't need disk I/O or a CWD swap.
+        let json = "{\"cookies\":[{\"name\":\"a\",\"value\":\"1\",\
+            \"domain\":\"evil\\r\\nSet-Cookie: x=y\",\"path\":\"/\",\
+            \"expires\":-1,\"httpOnly\":false,\"secure\":false,\"sameSite\":\"Lax\"}],\
+            \"origins\":[]}";
+        let err = StorageState::parse_str(json).unwrap_err();
+        match err {
+            CdpError::InvalidCookie { field, reason, .. } => {
+                assert_eq!(field, "domain");
+                assert!(reason.contains("control characters"));
+            }
+            other => panic!("expected InvalidCookie domain rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_state_parse_str_rejects_crlf_in_cookie_path() {
+        let json = "{\"cookies\":[{\"name\":\"a\",\"value\":\"1\",\
+            \"domain\":\"example.com\",\"path\":\"/foo\\nbar\",\
+            \"expires\":-1,\"httpOnly\":false,\"secure\":false,\"sameSite\":\"Lax\"}],\
+            \"origins\":[]}";
+        let err = StorageState::parse_str(json).unwrap_err();
+        match err {
+            CdpError::InvalidCookie { field, reason, .. } => {
+                assert_eq!(field, "path");
+                assert!(reason.contains("control characters"));
+            }
+            other => panic!("expected InvalidCookie path rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_state_parse_str_rejects_full_c0_range_in_cookie_value() {
+        // M1 + M3: the parser rejects every C0 byte (and DEL) in
+        // cookie value, not only CR/LF/NUL.
+        let json = "{\"cookies\":[{\"name\":\"a\",\"value\":\"v\\u001bx\",\
+            \"domain\":\"example.com\",\"path\":\"/\",\
+            \"expires\":-1,\"httpOnly\":false,\"secure\":false,\"sameSite\":\"Lax\"}],\
+            \"origins\":[]}";
+        let err = StorageState::parse_str(json).unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { field: "value", .. }));
     }
 
     #[test]

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -320,9 +320,8 @@ impl Cookie {
     ///
     /// Returns [`CdpError::InvalidCookie`] when:
     /// - The token has no `=` separator.
-    /// - The name is empty.
-    /// - The name or value contains a CR, LF, or NUL byte (header
-    ///   injection).
+    /// - The name is empty or contains whitespace / control bytes.
+    /// - The value contains control bytes (header injection).
     pub fn parse_kv(token: &str) -> Result<Self, CdpError> {
         let (name, value) = token
             .split_once('=')
@@ -333,15 +332,8 @@ impl Cookie {
             })?;
         let name = name.trim().to_owned();
         let value = value.to_owned();
-        if name.is_empty() {
-            return Err(CdpError::InvalidCookie {
-                field: "name",
-                input: token.to_owned(),
-                reason: "name must not be empty",
-            });
-        }
-        validate_no_ctl(&name, "name", "cookie")?;
-        validate_no_ctl(&value, "value", "cookie")?;
+        validate_cookie_name(&name)?;
+        validate_cookie_value(&value)?;
         Ok(Self {
             name,
             value,
@@ -360,20 +352,101 @@ impl Cookie {
     }
 }
 
+/// Reject any byte that is a C0 control character (`< 0x20`) or DEL
+/// (`0x7F`). Plumb chooses to reject every C0 byte rather than only the
+/// HTTP-specific CR/LF/NUL trio because a cookie or header value with
+/// any control byte is almost certainly a smuggling attempt and never
+/// a legitimate input. Tab (`\t`, `0x09`) is also rejected; HTTP
+/// whitespace folding has been deprecated in RFC 7230 §3.2.4 and Plumb
+/// has no compatibility need for it on inputs the user types into a
+/// shell flag.
+fn is_disallowed_ctl(byte: u8) -> bool {
+    byte < 0x20 || byte == 0x7F
+}
+
 fn validate_no_ctl(input: &str, field: &'static str, kind: &'static str) -> Result<(), CdpError> {
-    if input.bytes().any(|b| b == b'\r' || b == b'\n' || b == 0) {
+    if input.bytes().any(is_disallowed_ctl) {
         return match kind {
             "cookie" => Err(CdpError::InvalidCookie {
                 field,
                 input: input.to_owned(),
-                reason: "control characters (CR/LF/NUL) are not allowed",
+                reason: "control characters (C0 / DEL) are not allowed",
             }),
             _ => Err(CdpError::InvalidHeader {
                 field,
                 input: input.to_owned(),
-                reason: "control characters (CR/LF/NUL) are not allowed",
+                reason: "control characters (C0 / DEL) are not allowed",
             }),
         };
+    }
+    Ok(())
+}
+
+/// Validate an HTTP header name. Rejects empty names, names containing
+/// `:` (the field-line separator), whitespace, or control bytes.
+///
+/// Shared between [`parse_header_kv`] (CLI input parser) and the
+/// pre-injection sweep in `install_extra_headers` (library boundary).
+fn validate_header_name(name: &str) -> Result<(), CdpError> {
+    if name.is_empty() {
+        return Err(CdpError::InvalidHeader {
+            field: "name",
+            input: name.to_owned(),
+            reason: "name must not be empty",
+        });
+    }
+    if name
+        .bytes()
+        .any(|b| b == b':' || b == b' ' || b == b'\t' || is_disallowed_ctl(b))
+    {
+        return Err(CdpError::InvalidHeader {
+            field: "name",
+            input: name.to_owned(),
+            reason: "name must not contain whitespace, `:`, or control bytes",
+        });
+    }
+    Ok(())
+}
+
+/// Validate a cookie name. Rejects empty names, names containing `=`
+/// (the cookie separator), whitespace, or control bytes.
+///
+/// Shared between [`Cookie::parse_kv`] (CLI input parser) and the
+/// pre-injection sweep in `install_cookies` (library boundary). The
+/// rules mirror RFC 6265 token characters minus the bytes Chromium's
+/// `Network.setCookies` would reject.
+fn validate_cookie_name(name: &str) -> Result<(), CdpError> {
+    if name.is_empty() {
+        return Err(CdpError::InvalidCookie {
+            field: "name",
+            input: name.to_owned(),
+            reason: "name must not be empty",
+        });
+    }
+    if name
+        .bytes()
+        .any(|b| b == b'=' || b == b' ' || b == b'\t' || is_disallowed_ctl(b))
+    {
+        return Err(CdpError::InvalidCookie {
+            field: "name",
+            input: name.to_owned(),
+            reason: "name must not contain whitespace, `=`, or control bytes",
+        });
+    }
+    Ok(())
+}
+
+/// Validate a cookie value. Rejects values containing whitespace
+/// (which Chromium normalizes inconsistently) or control bytes.
+///
+/// Shared between [`Cookie::parse_kv`] and `install_cookies`.
+fn validate_cookie_value(value: &str) -> Result<(), CdpError> {
+    if value.bytes().any(is_disallowed_ctl) {
+        return Err(CdpError::InvalidCookie {
+            field: "value",
+            input: value.to_owned(),
+            reason: "control characters (C0 / DEL) are not allowed",
+        });
     }
     Ok(())
 }
@@ -385,7 +458,7 @@ fn validate_no_ctl(input: &str, field: &'static str, kind: &'static str) -> Resu
 /// Returns [`CdpError::InvalidHeader`] when:
 /// - The token has no `:` separator.
 /// - The name is empty or contains whitespace / `:` / control bytes.
-/// - The value contains CR, LF, or NUL bytes (header injection).
+/// - The value contains control bytes (header injection).
 pub fn parse_header_kv(token: &str) -> Result<(String, String), CdpError> {
     let (name, value) = token
         .split_once(':')
@@ -396,23 +469,7 @@ pub fn parse_header_kv(token: &str) -> Result<(String, String), CdpError> {
         })?;
     let name = name.trim().to_owned();
     let value = value.trim_start().to_owned();
-    if name.is_empty() {
-        return Err(CdpError::InvalidHeader {
-            field: "name",
-            input: token.to_owned(),
-            reason: "name must not be empty",
-        });
-    }
-    if name
-        .bytes()
-        .any(|b| b == b':' || b == b' ' || b == b'\t' || b == b'\r' || b == b'\n' || b == 0)
-    {
-        return Err(CdpError::InvalidHeader {
-            field: "name",
-            input: name,
-            reason: "name must not contain whitespace, `:`, or control bytes",
-        });
-    }
+    validate_header_name(&name)?;
     validate_no_ctl(&value, "value", "header")?;
     Ok((name, value))
 }
@@ -1244,7 +1301,12 @@ async fn install_extra_headers(page: &Page, headers: &[(String, String)]) -> Res
     entries.sort_by(|a, b| a.0.cmp(&b.0));
     let mut object = serde_json::Map::with_capacity(entries.len());
     for (name, value) in entries {
-        validate_no_ctl(&name, "name", "header")?;
+        // Library-boundary re-validation: `headers: Vec<(String, String)>`
+        // is `pub` on `ChromiumOptions`, so a downstream consumer can
+        // construct entries without going through `parse_header_kv`.
+        // Apply the same checks here to keep header-injection guards
+        // intact regardless of how the entries were built.
+        validate_header_name(&name)?;
         validate_no_ctl(&value, "value", "header")?;
         object.insert(name, serde_json::Value::String(value));
     }
@@ -1264,6 +1326,21 @@ async fn install_cookies(
     sorted.sort_by(|a, b| {
         (a.name.as_str(), a.value.as_str()).cmp(&(b.name.as_str(), b.value.as_str()))
     });
+    // Library-boundary re-validation: `Cookie` fields are all `pub`, so
+    // a downstream consumer can build a `Cookie` without going through
+    // `Cookie::parse_kv`. Apply the same name/value checks here so the
+    // injection guards are not bypassable. `domain` and `path`, when
+    // present, also pass through the control-byte check.
+    for cookie in &sorted {
+        validate_cookie_name(&cookie.name)?;
+        validate_cookie_value(&cookie.value)?;
+        if let Some(domain) = cookie.domain.as_deref() {
+            validate_no_ctl(domain, "domain", "cookie")?;
+        }
+        if let Some(path) = cookie.path.as_deref() {
+            validate_no_ctl(path, "path", "cookie")?;
+        }
+    }
     let url_for_cookies = if default_url.starts_with("http") {
         Some(default_url)
     } else {
@@ -2322,6 +2399,67 @@ mod tests {
     fn header_parse_kv_rejects_space_in_name() {
         let err = parse_header_kv("X Header: 1").unwrap_err();
         assert!(matches!(err, CdpError::InvalidHeader { .. }));
+    }
+
+    #[test]
+    fn validate_header_name_rejects_colon() {
+        // Library-boundary check: a downstream consumer might construct
+        // `headers: vec![("Foo:Bar".into(), "1".into())]` directly.
+        // `parse_header_kv` would split that, but
+        // `install_extra_headers` calls the validator straight on the
+        // tuple — so the validator must catch `:` itself.
+        let err = super::validate_header_name("Foo:Bar").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { field: "name", .. }));
+    }
+
+    #[test]
+    fn validate_header_name_rejects_whitespace() {
+        let err = super::validate_header_name("X Header").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { .. }));
+        let err = super::validate_header_name("X\tHeader").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidHeader { .. }));
+    }
+
+    #[test]
+    fn validate_header_name_rejects_control_bytes() {
+        // Every C0 control byte (and DEL) is rejected. Spot-check the
+        // canonical ones plus a non-CRLF C1-adjacent byte (BEL, 0x07).
+        for &c in b"\r\n\0\x07\x1b\x7f" {
+            let name = format!("X-Hi{}Foo", c as char);
+            let err = super::validate_header_name(&name).unwrap_err();
+            assert!(
+                matches!(err, CdpError::InvalidHeader { .. }),
+                "expected InvalidHeader for byte {c:#x}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_cookie_name_rejects_equals_and_whitespace() {
+        // Library-boundary: `Cookie { name: "foo=bar", .. }` would be
+        // accepted by the parser (it splits on the *first* `=`) but
+        // direct construction would let `=` through. The standalone
+        // validator must reject it.
+        let err = super::validate_cookie_name("foo=bar").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { field: "name", .. }));
+        let err = super::validate_cookie_name("foo bar").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { .. }));
+    }
+
+    #[test]
+    fn validate_cookie_value_rejects_full_c0_range() {
+        // Tightened beyond CR/LF/NUL — every C0 byte and DEL is now
+        // rejected. Tab is in the C0 range so it's also rejected.
+        for c in 0u8..0x20 {
+            let value = format!("v{}x", c as char);
+            let err = super::validate_cookie_value(&value).unwrap_err();
+            assert!(
+                matches!(err, CdpError::InvalidCookie { .. }),
+                "expected InvalidCookie for byte {c:#x}, got {err:?}"
+            );
+        }
+        let err = super::validate_cookie_value("v\x7fx").unwrap_err();
+        assert!(matches!(err, CdpError::InvalidCookie { .. }));
     }
 
     #[test]

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -1237,11 +1237,12 @@ async fn apply_storage_state_local_storage(
         for entry in &origin_entry.local_storage {
             // Build a JSON.stringify-style argument so the values are
             // safe regardless of contained quotes.
-            let key =
-                serde_json::to_string(&entry.name).map_err(|err| CdpError::MalformedStorageState {
+            let key = serde_json::to_string(&entry.name).map_err(|err| {
+                CdpError::MalformedStorageState {
                     path: PathBuf::new(),
                     reason: format!("could not serialize key: {err}"),
-                })?;
+                }
+            })?;
             let value = serde_json::to_string(&entry.value).map_err(|err| {
                 CdpError::MalformedStorageState {
                     path: PathBuf::new(),
@@ -2591,7 +2592,10 @@ mod tests {
             \"expires\":-1,\"httpOnly\":false,\"secure\":false,\"sameSite\":\"Lax\"}],\
             \"origins\":[]}";
         let err = StorageState::parse_str(json).unwrap_err();
-        assert!(matches!(err, CdpError::InvalidCookie { field: "value", .. }));
+        assert!(matches!(
+            err,
+            CdpError::InvalidCookie { field: "value", .. }
+        ));
     }
 
     #[test]

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -596,7 +596,7 @@ impl StorageState {
     ///
     /// # Security boundary
     ///
-    /// The safe-path check via [`canonicalize_safe_path`] is
+    /// The safe-path check via `canonicalize_safe_path` is
     /// **best-effort** only — see that function's docs. The
     /// canonicalize-then-open sequence has an inherent TOCTOU window
     /// where a co-located attacker with write access to a parent
@@ -628,7 +628,7 @@ impl StorageState {
     }
 }
 
-/// Public CLI-facing wrapper around [`canonicalize_safe_path`].
+/// Public CLI-facing wrapper around `canonicalize_safe_path`.
 ///
 /// `plumb-cli` validates `--auth-script` / `--storage-state` paths up
 /// front (before driver dispatch) so the FakeDriver path also rejects
@@ -645,7 +645,7 @@ impl StorageState {
 ///
 /// # Security boundary
 ///
-/// Same caveats as [`canonicalize_safe_path`]: this is a best-effort
+/// Same caveats as `canonicalize_safe_path`: this is a best-effort
 /// usability guard, **not** a sandbox. See that function's docs for
 /// the full TOCTOU discussion.
 pub fn validate_safe_path(path: &Path) -> Result<PathBuf, CdpError> {
@@ -1314,7 +1314,7 @@ async fn inject_scrollbar_killer(page: &Page) -> Result<(), CdpError> {
 ///
 /// # Security boundary
 ///
-/// The safe-path check via [`canonicalize_safe_path`] is best-effort
+/// The safe-path check via `canonicalize_safe_path` is best-effort
 /// only — see that function's docs. Treat the resulting file content
 /// as user-trusted: the CLI hands us a path supplied either by the
 /// invoking user or by an `auth-script` already in the project, never

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -507,6 +507,20 @@ impl StorageState {
     /// Returns [`CdpError::InvalidPath`] when the path fails the safe-path
     /// check, or [`CdpError::MalformedStorageState`] when the file cannot
     /// be read or parsed.
+    ///
+    /// # Security boundary
+    ///
+    /// The safe-path check via [`canonicalize_safe_path`] is
+    /// **best-effort** only — see that function's docs. The
+    /// canonicalize-then-open sequence has an inherent TOCTOU window
+    /// where a co-located attacker with write access to a parent
+    /// directory could swap the resolved file for a symlink between
+    /// the check and the read. Plumb's storage-state loader is
+    /// intended for files the invoking user controls (typically a
+    /// Playwright export checked into the project). It MUST NOT be
+    /// treated as a sandbox against hostile local users. The full
+    /// mitigation (`cap_std::Dir::open`) is out of scope for the wave
+    /// that introduced this loader.
     pub fn load_from_path(path: &Path) -> Result<Self, CdpError> {
         let canonical = canonicalize_safe_path(path)?;
         let bytes =
@@ -546,6 +560,23 @@ impl StorageState {
 /// content. The check refuses paths that:
 /// - cannot be canonicalized (file does not exist / no permission),
 /// - resolve to a different prefix than the current working directory.
+///
+/// # Security boundary
+///
+/// This is a **best-effort** guard against accidental path issues
+/// (typos, copy-pasted absolute paths, runs from the wrong CWD). It is
+/// **not** a security boundary against a co-located attacker who can
+/// race the file system — the canonicalize step and the subsequent
+/// `std::fs::read_to_string` are two separate `open(2)` syscalls, and
+/// an attacker with write access to a parent directory of `path` can
+/// swap the canonicalized target for a symlink between the check and
+/// the read (TOCTOU). A full mitigation would use `cap_std::Dir::open`
+/// to keep the canonicalization and the read inside a single
+/// directory handle; that change is out of scope for the wave that
+/// added this helper.
+///
+/// Future maintainers MUST NOT assume this function defends against a
+/// hostile local user. Treat it as a usability check, not a sandbox.
 fn canonicalize_safe_path(path: &Path) -> Result<PathBuf, CdpError> {
     let canonical = path.canonicalize().map_err(|err| CdpError::InvalidPath {
         path: path.to_path_buf(),
@@ -1166,6 +1197,19 @@ async fn inject_scrollbar_killer(page: &Page) -> Result<(), CdpError> {
     add_script_to_evaluate_on_new_document(page, source).await
 }
 
+/// Read `path` (validated as a `.js` file under the CWD) and register
+/// it as `Page.addScriptToEvaluateOnNewDocument` so it runs before any
+/// page script.
+///
+/// # Security boundary
+///
+/// The safe-path check via [`canonicalize_safe_path`] is best-effort
+/// only — see that function's docs. Treat the resulting file content
+/// as user-trusted: the CLI hands us a path supplied either by the
+/// invoking user or by an `auth-script` already in the project, never
+/// by a remote source. The TOCTOU window between canonicalization and
+/// `std::fs::read_to_string` is acknowledged but not yet closed; the
+/// full fix requires `cap_std`.
 async fn inject_auth_script(page: &Page, path: &Path) -> Result<(), CdpError> {
     let canonical = canonicalize_safe_path(path)?;
     if canonical.extension().and_then(|s| s.to_str()) != Some("js") {

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -753,13 +753,18 @@ async fn capture_on_page(
     options: &ChromiumOptions,
 ) -> Result<PlumbSnapshot, CdpError> {
     apply_viewport(page, target).await?;
-    pre_navigate(page, target, options).await?;
+    // `pre_navigate` returns the parsed `StorageState` (when one is
+    // configured) so the post-navigate localStorage step reuses the
+    // same parsed value. Loading the file twice would open a
+    // time-of-check / time-of-use race where the file changes between
+    // cookie installation and localStorage replay.
+    let storage_state = pre_navigate(page, target, options).await?;
 
     page.goto(target.url.as_str()).await.map_err(driver_error)?;
     page.wait_for_navigation().await.map_err(driver_error)?;
 
     apply_post_navigate_waits(page, target).await?;
-    apply_storage_state_local_storage(page, target, options).await?;
+    apply_storage_state_local_storage(page, target, storage_state.as_ref()).await?;
 
     let params = CaptureSnapshotParams {
         computed_styles: COMPUTED_STYLE_WHITELIST
@@ -1020,11 +1025,18 @@ async fn apply_viewport(page: &Page, target: &Target) -> Result<(), CdpError> {
 /// 4. Storage-state cookies — same network layer; localStorage entries
 ///    in the storage-state are deferred to [`apply_storage_state_local_storage`]
 ///    after the origin loads, since localStorage is origin-scoped.
+///
+/// When [`ChromiumOptions::storage_state`] is set, the file is loaded
+/// and parsed exactly once here. The returned [`StorageState`] is
+/// threaded back into [`apply_storage_state_local_storage`] so the
+/// driver never re-reads the file (closing a TOCTOU window where the
+/// content could change between cookie installation and localStorage
+/// replay).
 async fn pre_navigate(
     page: &Page,
     target: &Target,
     options: &ChromiumOptions,
-) -> Result<(), CdpError> {
+) -> Result<Option<StorageState>, CdpError> {
     if target.disable_animations {
         inject_animation_killer(page).await?;
     }
@@ -1040,10 +1052,14 @@ async fn pre_navigate(
     if !options.cookies.is_empty() {
         install_cookies(page, &options.cookies, target.url.as_str()).await?;
     }
-    if let Some(state_path) = options.storage_state.as_deref() {
-        install_storage_state_cookies(page, state_path).await?;
-    }
-    Ok(())
+    let storage_state = if let Some(state_path) = options.storage_state.as_deref() {
+        let state = StorageState::load_from_path(state_path)?;
+        install_storage_state_cookies(page, &state).await?;
+        Some(state)
+    } else {
+        None
+    };
+    Ok(storage_state)
 }
 
 /// Wait stages that must run *after* navigation. PRD §15 — `--wait-for`
@@ -1063,21 +1079,25 @@ async fn apply_post_navigate_waits(page: &Page, target: &Target) -> Result<(), C
     Ok(())
 }
 
-/// Install localStorage entries from a Playwright storage-state file.
+/// Install localStorage entries from an already-parsed Playwright
+/// storage-state.
 ///
 /// Runs *after* navigation because `localStorage` is origin-scoped and
 /// the only way to write to it from the driver is to evaluate a script
 /// in the page context. Entries whose `origin` does not match the
 /// navigated URL's origin are skipped (same isolation Playwright applies).
+///
+/// The caller provides the parsed [`StorageState`] (loaded once in
+/// [`pre_navigate`]) so the file is never read twice — closing the
+/// TOCTOU window between cookie installation and localStorage replay.
 async fn apply_storage_state_local_storage(
     page: &Page,
     target: &Target,
-    options: &ChromiumOptions,
+    state: Option<&StorageState>,
 ) -> Result<(), CdpError> {
-    let Some(state_path) = options.storage_state.as_deref() else {
+    let Some(state) = state else {
         return Ok(());
     };
-    let state = StorageState::load_from_path(state_path)?;
     let target_origin = origin_of(target.url.as_str()).unwrap_or_default();
     for origin_entry in &state.origins {
         if origin_entry.origin != target_origin {
@@ -1086,15 +1106,14 @@ async fn apply_storage_state_local_storage(
         for entry in &origin_entry.local_storage {
             // Build a JSON.stringify-style argument so the values are
             // safe regardless of contained quotes.
-            let key = serde_json::to_string(&entry.name).map_err(|err| {
-                CdpError::MalformedStorageState {
-                    path: state_path.to_path_buf(),
+            let key =
+                serde_json::to_string(&entry.name).map_err(|err| CdpError::MalformedStorageState {
+                    path: PathBuf::new(),
                     reason: format!("could not serialize key: {err}"),
-                }
-            })?;
+                })?;
             let value = serde_json::to_string(&entry.value).map_err(|err| {
                 CdpError::MalformedStorageState {
-                    path: state_path.to_path_buf(),
+                    path: PathBuf::new(),
                     reason: format!("could not serialize value: {err}"),
                 }
             })?;
@@ -1216,16 +1235,15 @@ async fn install_cookies(
     Ok(())
 }
 
-async fn install_storage_state_cookies(page: &Page, path: &Path) -> Result<(), CdpError> {
-    let state = StorageState::load_from_path(path)?;
+async fn install_storage_state_cookies(page: &Page, state: &StorageState) -> Result<(), CdpError> {
     if state.cookies.is_empty() {
         return Ok(());
     }
     let mut params: Vec<CookieParam> = Vec::with_capacity(state.cookies.len());
-    for cookie in state.cookies {
-        let mut p = CookieParam::new(cookie.name, cookie.value);
-        p.domain = Some(cookie.domain);
-        p.path = Some(cookie.path);
+    for cookie in &state.cookies {
+        let mut p = CookieParam::new(cookie.name.clone(), cookie.value.clone());
+        p.domain = Some(cookie.domain.clone());
+        p.path = Some(cookie.path.clone());
         p.secure = Some(cookie.secure);
         p.http_only = Some(cookie.http_only);
         params.push(p);

--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -1212,13 +1212,23 @@ async fn apply_storage_state_local_storage(
     Ok(())
 }
 
-fn origin_of(url: &str) -> Option<String> {
-    // Minimal origin extractor — `<scheme>://<host>[:<port>]`. Avoids a
-    // url-parser dep; storage-state matching is a string compare against
-    // Playwright's own origin format.
-    let (scheme, rest) = url.split_once("://")?;
-    let host = rest.split('/').next()?;
-    Some(format!("{scheme}://{host}"))
+fn origin_of(input: &str) -> Option<String> {
+    // WHATWG-compliant origin: `Url::origin().ascii_serialization()`
+    // handles default-port elision (`:443` for `https`, `:80` for
+    // `http`), scheme case-folding, IDNA host normalization, and
+    // strips userinfo / path / query / fragment. Matches Playwright's
+    // stored `origin` shape so storage-state origin compares are not
+    // tripped up by `https://example.com:443/foo` vs
+    // `https://example.com`.
+    let parsed = url::Url::parse(input).ok()?;
+    let origin = parsed.origin();
+    if origin.is_tuple() {
+        Some(origin.ascii_serialization())
+    } else {
+        // Opaque origins (e.g. `data:`, `file:`) cannot match a
+        // Playwright-recorded site origin — bail out.
+        None
+    }
 }
 
 async fn inject_animation_killer(page: &Page) -> Result<(), CdpError> {
@@ -2526,5 +2536,41 @@ mod tests {
             Some("http://example.com:8080")
         );
         assert_eq!(super::origin_of("notaurl").as_deref(), None);
+    }
+
+    #[test]
+    fn origin_of_strips_default_ports() {
+        // WHATWG origin: default ports are elided.
+        assert_eq!(
+            super::origin_of("https://example.com:443/").as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(
+            super::origin_of("http://example.com:80/").as_deref(),
+            Some("http://example.com")
+        );
+    }
+
+    #[test]
+    fn origin_of_normalizes_scheme_and_host_case() {
+        assert_eq!(
+            super::origin_of("HTTPS://Example.COM/path").as_deref(),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn origin_of_strips_userinfo_query_fragment() {
+        assert_eq!(
+            super::origin_of("https://user:pw@example.com/p?q=1#frag").as_deref(),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn origin_of_returns_none_for_opaque_origins() {
+        // `data:` and `file:` URLs have opaque origins and cannot match
+        // a Playwright-recorded site origin.
+        assert_eq!(super::origin_of("data:text/plain,hello").as_deref(), None);
     }
 }

--- a/crates/plumb-cdp/tests/driver_contract.rs
+++ b/crates/plumb-cdp/tests/driver_contract.rs
@@ -12,6 +12,7 @@ fn target(url: &str) -> Target {
         width: 1280,
         height: 800,
         device_pixel_ratio: 1.0,
+        ..Target::default()
     }
 }
 
@@ -136,6 +137,7 @@ fn isolated_driver() -> std::io::Result<(ChromiumDriver, tempfile::TempDir)> {
     let driver = ChromiumDriver::new(ChromiumOptions {
         executable_path: None,
         user_data_dir: Some(dir.path().to_path_buf()),
+        ..ChromiumOptions::default()
     });
     Ok((driver, dir))
 }

--- a/crates/plumb-cdp/tests/persistent_browser.rs
+++ b/crates/plumb-cdp/tests/persistent_browser.rs
@@ -23,6 +23,7 @@ fn target(url: &str) -> Target {
         width: 1280,
         height: 800,
         device_pixel_ratio: 1.0,
+        ..Target::default()
     }
 }
 
@@ -84,6 +85,7 @@ fn isolated_options() -> std::io::Result<(ChromiumOptions, tempfile::TempDir)> {
         ChromiumOptions {
             executable_path: None,
             user_data_dir: Some(dir.path().to_path_buf()),
+            ..ChromiumOptions::default()
         },
         dir,
     ))

--- a/crates/plumb-cdp/tests/snapshot_all_default.rs
+++ b/crates/plumb-cdp/tests/snapshot_all_default.rs
@@ -15,6 +15,7 @@ fn target(viewport: &str, width: u32, height: u32) -> Target {
         width,
         height,
         device_pixel_ratio: 1.0,
+        ..Target::default()
     }
 }
 

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -14,7 +14,7 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use plumb_cdp::{
     BrowserDriver, ChromiumDriver, ChromiumOptions, Cookie, FakeDriver, Target, is_fake_url,
-    parse_header_kv,
+    parse_header_kv, validate_safe_path,
 };
 use plumb_core::{Config, Severity, ViewportKey};
 use thiserror::Error;
@@ -116,6 +116,18 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
         .map(|raw| parse_header_kv(raw).map_err(anyhow::Error::from))
         .collect::<Result<Vec<_>>>()
         .context("parse --header value")?;
+
+    // PRD §15: validate `--auth-script` / `--storage-state` paths up
+    // front so the safe-path check fires on every URL scheme — without
+    // this, the FakeDriver path would silently accept outside-CWD
+    // paths because it never reaches the cdp loaders that own the
+    // check.
+    if let Some(p) = auth_script.as_deref() {
+        validate_safe_path(p).context("validate --auth-script path")?;
+    }
+    if let Some(p) = storage_state.as_deref() {
+        validate_safe_path(p).context("validate --storage-state path")?;
+    }
 
     let snapshots = if is_fake_url(&url) {
         // FakeDriver ignores ChromiumOptions and per-target capture

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -12,11 +12,37 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use plumb_cdp::{BrowserDriver, ChromiumDriver, ChromiumOptions, FakeDriver, Target, is_fake_url};
+use plumb_cdp::{
+    BrowserDriver, ChromiumDriver, ChromiumOptions, Cookie, FakeDriver, Target, is_fake_url,
+    parse_header_kv,
+};
 use plumb_core::{Config, Severity, ViewportKey};
 use thiserror::Error;
 
 use crate::commands::{OutputFormat, selector as selector_filter};
+
+/// Aggregated args for [`run`]. Bundling them into a struct keeps the
+/// `Command::Lint` dispatch readable as the flag surface grows
+/// (PRD §15 — `--wait-for`, `--cookie`, `--storage-state`, etc.).
+#[derive(Debug)]
+pub struct LintArgs {
+    pub url: String,
+    pub config_path: Option<PathBuf>,
+    pub executable_path: Option<PathBuf>,
+    pub format: OutputFormat,
+    pub output_path: Option<PathBuf>,
+    pub viewports: Vec<String>,
+    pub selector: Option<String>,
+    pub wait_for: Option<String>,
+    pub wait_ms: Option<u64>,
+    pub cookies: Vec<String>,
+    pub headers: Vec<String>,
+    pub auth_script: Option<PathBuf>,
+    pub storage_state: Option<PathBuf>,
+    pub disable_animations: bool,
+    pub hide_scrollbars: bool,
+    pub dpr: Option<f64>,
+}
 
 /// CLI-side errors that never need to leak across the
 /// `commands::lint` boundary. Bubbles up to `main` via `anyhow::Error`,
@@ -44,21 +70,56 @@ enum LintError {
     ViewportFlagWithoutConfig { names: Vec<String> },
 }
 
-pub async fn run(
-    url: String,
-    config_path: Option<PathBuf>,
-    executable_path: Option<PathBuf>,
-    format: OutputFormat,
-    output_path: Option<PathBuf>,
-    viewports: Vec<String>,
-    selector: Option<String>,
-) -> Result<ExitCode> {
+pub async fn run(args: LintArgs) -> Result<ExitCode> {
+    let LintArgs {
+        url,
+        config_path,
+        executable_path,
+        format,
+        output_path,
+        viewports,
+        selector,
+        wait_for,
+        wait_ms,
+        cookies,
+        headers,
+        auth_script,
+        storage_state,
+        disable_animations,
+        hide_scrollbars,
+        dpr,
+    } = args;
+
     tracing::debug!(url = %url, format = %format, viewports = ?viewports, selector = ?selector, "lint");
 
     let config = load_config(config_path.as_deref())?;
-    let targets = resolve_targets(&url, &config, &viewports).map_err(anyhow::Error::from)?;
+    let mut targets = resolve_targets(&url, &config, &viewports).map_err(anyhow::Error::from)?;
+
+    // Apply the per-target capture knobs (PRD §15) to every target the
+    // viewport resolver returned. `wait_for` / `wait_ms` / `pin_dpr` are
+    // identical across viewports, so a per-target apply is fine.
+    for target in &mut targets {
+        target.wait_for_selector.clone_from(&wait_for);
+        target.wait_ms = wait_ms;
+        target.disable_animations = disable_animations;
+        target.hide_scrollbars = hide_scrollbars;
+        target.pin_dpr = dpr;
+    }
+
+    let parsed_cookies: Vec<Cookie> = cookies
+        .iter()
+        .map(|raw| Cookie::parse_kv(raw).map_err(anyhow::Error::from))
+        .collect::<Result<Vec<_>>>()
+        .context("parse --cookie value")?;
+    let parsed_headers: Vec<(String, String)> = headers
+        .iter()
+        .map(|raw| parse_header_kv(raw).map_err(anyhow::Error::from))
+        .collect::<Result<Vec<_>>>()
+        .context("parse --header value")?;
 
     let snapshots = if is_fake_url(&url) {
+        // FakeDriver ignores ChromiumOptions and per-target capture
+        // knobs by design — the canned snapshot is deterministic.
         let driver = FakeDriver;
         driver
             .snapshot_all(targets)
@@ -67,6 +128,10 @@ pub async fn run(
     } else {
         let driver = ChromiumDriver::new(ChromiumOptions {
             executable_path,
+            cookies: parsed_cookies,
+            headers: parsed_headers,
+            auth_script,
+            storage_state,
             ..ChromiumOptions::default()
         });
         driver
@@ -153,6 +218,7 @@ fn resolve_targets(
             width: 1280,
             height: 800,
             device_pixel_ratio: 1.0,
+            ..Target::default()
         }]);
     }
 
@@ -166,6 +232,7 @@ fn resolve_targets(
                 width: spec.width,
                 height: spec.height,
                 device_pixel_ratio: spec.device_pixel_ratio,
+                ..Target::default()
             })
             .collect());
     }
@@ -190,6 +257,7 @@ fn resolve_targets(
                 width: spec.width,
                 height: spec.height,
                 device_pixel_ratio: spec.device_pixel_ratio,
+                ..Target::default()
             })
         })
         .collect())

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -42,6 +42,11 @@ struct Cli {
     command: Command,
 }
 
+// `Lint` carries 16 inline fields (#74-#77 PRD §15 capture knobs).
+// Boxing them would force clap field bindings to thread through `Box<T>`,
+// breaking the macro ergonomics, and the enum is constructed exactly once
+// per process (in `Cli::parse`). Allow the size disparity here.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Lint a URL against your design-system spec.
@@ -73,6 +78,68 @@ enum Command {
         /// before rule dispatch.
         #[arg(long, value_name = "CSS_SELECTOR")]
         selector: Option<String>,
+        /// Wait for a CSS selector to appear in the page before
+        /// capturing the snapshot. Useful for SPAs whose first paint
+        /// arrives after the initial network idle event. Compatible
+        /// with `--wait-ms`; the selector wait runs first, then the
+        /// additional sleep.
+        #[arg(long, value_name = "CSS_SELECTOR")]
+        wait_for: Option<String>,
+        /// Sleep N milliseconds after navigation (and after
+        /// `--wait-for`, if both are passed) before capturing the
+        /// snapshot. Belt-and-suspenders for SPAs whose deferred
+        /// rendering does not finish in the same tick.
+        #[arg(long, value_name = "MS")]
+        wait_ms: Option<u64>,
+        /// Pre-set a cookie before navigation, in `name=value` form.
+        /// Repeatable.
+        #[arg(long = "cookie", value_name = "NAME=VALUE", action = ArgAction::Append)]
+        cookies: Vec<String>,
+        /// Add an extra HTTP header to every outgoing request, in
+        /// `name: value` form. Repeatable.
+        #[arg(long = "header", value_name = "NAME:VALUE", action = ArgAction::Append)]
+        headers: Vec<String>,
+        /// Path to a JavaScript file evaluated on every new document
+        /// before navigation (CDP `Page.addScriptToEvaluateOnNewDocument`).
+        /// Used for setting `window.localStorage` or attaching
+        /// `Authorization` headers via `fetch` interception. Refused
+        /// when the path resolves outside the current working directory.
+        #[arg(long, value_name = "PATH")]
+        auth_script: Option<PathBuf>,
+        /// Path to a Playwright `storage-state.json`. Cookies in the
+        /// file are installed before navigation; localStorage entries
+        /// for the matching origin are written via `evaluate` after
+        /// navigation.
+        #[arg(long, value_name = "PATH")]
+        storage_state: Option<PathBuf>,
+        /// Disable CSS animations and transitions before navigation
+        /// for byte-stable snapshots. The driver already does this by
+        /// default; pass `--disable-animations false` to opt out.
+        #[arg(
+            long = "disable-animations",
+            default_value_t = true,
+            action = ArgAction::Set,
+            num_args = 0..=1,
+            default_missing_value = "true"
+        )]
+        disable_animations: bool,
+        /// Inject CSS that hides scrollbars before navigation. The
+        /// driver already does this by default; pass
+        /// `--hide-scrollbars false` to opt out.
+        #[arg(
+            long = "hide-scrollbars",
+            default_value_t = true,
+            action = ArgAction::Set,
+            num_args = 0..=1,
+            default_missing_value = "true"
+        )]
+        hide_scrollbars: bool,
+        /// Pin the device-pixel ratio used by
+        /// `Emulation.setDeviceMetricsOverride`. When unset, the
+        /// configured viewport's `device_pixel_ratio` is used. Useful
+        /// for stress-testing rules against hidpi rendering.
+        #[arg(long, value_name = "FACTOR")]
+        dpr: Option<f64>,
     },
     /// Write a starter `plumb.toml` to the current directory.
     Init {
@@ -146,16 +213,34 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 output,
                 viewports,
                 selector,
+                wait_for,
+                wait_ms,
+                cookies,
+                headers,
+                auth_script,
+                storage_state,
+                disable_animations,
+                hide_scrollbars,
+                dpr,
             } => {
-                commands::lint::run(
+                commands::lint::run(commands::lint::LintArgs {
                     url,
-                    config,
+                    config_path: config,
                     executable_path,
-                    format.into(),
-                    output,
+                    format: format.into(),
+                    output_path: output,
                     viewports,
                     selector,
-                )
+                    wait_for,
+                    wait_ms,
+                    cookies,
+                    headers,
+                    auth_script,
+                    storage_state,
+                    disable_animations,
+                    hide_scrollbars,
+                    dpr,
+                })
                 .await
             }
             Command::Init { force } => commands::init::run(force),

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -603,6 +603,61 @@ fn lint_accepts_storage_state_path_against_fake_driver() -> Result<(), Box<dyn s
 }
 
 #[test]
+fn lint_rejects_auth_script_outside_cwd() -> Result<(), Box<dyn std::error::Error>> {
+    // Two tempdirs: one contains the benign script, the other is the
+    // CWD we run `plumb` from. The script is absolute and outside the
+    // CWD, so the safe-path check MUST refuse it with exit code 2 even
+    // though the URL is `plumb-fake://hello` (the FakeDriver doesn't
+    // need an auth script — the CLI validates the path up front).
+    let script_dir = TempDir::new()?;
+    let script_path = script_dir.path().join("auth.js");
+    fs::write(&script_path, "// benign auth script\n")?;
+
+    let cwd = TempDir::new()?;
+
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--auth-script",
+            script_path
+                .to_str()
+                .ok_or("auth.js path is not valid UTF-8")?,
+        ])
+        .current_dir(cwd.path())
+        .assert()
+        .code(2)
+        .stderr(contains("outside the current working directory"));
+    Ok(())
+}
+
+#[test]
+fn lint_rejects_storage_state_outside_cwd() -> Result<(), Box<dyn std::error::Error>> {
+    // Same shape as the auth-script test above: the storage-state file
+    // is in a separate tempdir and therefore outside the CLI's CWD.
+    let state_dir = TempDir::new()?;
+    let state_path = state_dir.path().join("storage-state.json");
+    fs::write(&state_path, r#"{"cookies":[],"origins":[]}"#)?;
+
+    let cwd = TempDir::new()?;
+
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--storage-state",
+            state_path
+                .to_str()
+                .ok_or("storage-state.json path is not valid UTF-8")?,
+        ])
+        .current_dir(cwd.path())
+        .assert()
+        .code(2)
+        .stderr(contains("outside the current working directory"));
+    Ok(())
+}
+
+#[test]
 fn lint_accepts_disable_animations_and_hide_scrollbars_and_dpr()
 -> Result<(), Box<dyn std::error::Error>> {
     Command::cargo_bin("plumb")?

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -477,3 +477,147 @@ fn lint_fake_url_json_rect_matches_requested_viewport() -> Result<(), Box<dyn st
         .stdout(contains("\"height\": 800").not());
     Ok(())
 }
+
+// ============================================================
+// Driver-ergonomics wave (#74 #75 #76 #77)
+//
+// FakeDriver short-circuits before any browser-side wiring runs, so
+// these tests focus on:
+//   - Argument parsing accepts every flag without error.
+//   - Validation errors surface as exit code 2 with the expected message.
+//   - Successful cases still produce the canned snapshot's violation.
+// Real Chromium-driven coverage lives behind the `e2e-chromium`
+// feature in `crates/plumb-cdp/tests/`.
+
+#[test]
+fn lint_accepts_wait_for_and_wait_ms_against_fake_driver() -> Result<(), Box<dyn std::error::Error>>
+{
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--wait-for",
+            "body",
+            "--wait-ms",
+            "10",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+#[test]
+fn lint_accepts_repeated_cookies_against_fake_driver() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--cookie",
+            "session=abc123",
+            "--cookie",
+            "lang=en",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+#[test]
+fn lint_rejects_malformed_cookie_with_input_error() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--cookie", "no-equals"])
+        .assert()
+        .code(2)
+        .stderr(contains("invalid cookie"));
+    Ok(())
+}
+
+#[test]
+fn lint_rejects_cookie_with_crlf() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--cookie",
+            "name=value\r\nSet-Cookie: pwn=1",
+        ])
+        .assert()
+        .code(2)
+        .stderr(contains("control characters"));
+    Ok(())
+}
+
+#[test]
+fn lint_accepts_repeated_headers_against_fake_driver() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--header",
+            "X-Trace-Id: 12345",
+            "--header",
+            "Authorization: Bearer xyz",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+#[test]
+fn lint_rejects_header_with_lf_injection() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--header",
+            "X-Pwn: hello\nInjected: 1",
+        ])
+        .assert()
+        .code(2)
+        .stderr(contains("control characters"));
+    Ok(())
+}
+
+#[test]
+fn lint_accepts_storage_state_path_against_fake_driver() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let path = dir.path().join("storage-state.json");
+    fs::write(&path, r#"{"cookies":[],"origins":[]}"#)?;
+    // Run from inside the tempdir so the safe-path canonicalize check
+    // passes (the path resolves under CWD).
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--storage-state",
+            "storage-state.json",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(3)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+#[test]
+fn lint_accepts_disable_animations_and_hide_scrollbars_and_dpr()
+-> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--disable-animations",
+            "true",
+            "--hide-scrollbars",
+            "false",
+            "--dpr",
+            "2.0",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -223,6 +223,7 @@ impl PlumbServer {
                 width: 1280,
                 height: 800,
                 device_pixel_ratio: 1.0,
+                ..Target::default()
             };
             match self
                 .browser

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -18,6 +18,17 @@ major version falls in Plumb's supported range (see
 | `--format <pretty\|json\|sarif>` | Output format. Default: `pretty`. |
 | `--output <path>` | Write rendered output to a file instead of stdout. |
 | `-v`, `--verbose` | Increase log verbosity. `-vv` for trace. |
+| `--viewport <name>` | Restrict the run to the named viewport. Repeatable. |
+| `--selector <css>` | Restrict linting to a CSS subtree. |
+| `--wait-for <css>` | Wait for a selector to appear before capturing. |
+| `--wait-ms <ms>` | Sleep N ms after navigation (and after `--wait-for`). |
+| `--cookie <name=value>` | Pre-set a cookie before navigation. Repeatable. |
+| `--header <name: value>` | Add an extra HTTP header to every request. Repeatable. |
+| `--auth-script <path>` | Evaluate a `.js` file on every new document. Path MUST resolve under CWD. |
+| `--storage-state <path>` | Load a Playwright `storage-state.json`. |
+| `--disable-animations [bool]` | CSS animation/transition killer. Default `true`. |
+| `--hide-scrollbars [bool]` | CSS scrollbar killer. Default `true`. |
+| `--dpr <factor>` | Pin device-pixel ratio for `Emulation.setDeviceMetricsOverride`. |
 
 Exit codes:
 


### PR DESCRIPTION
Closes #74, #75, #76, #77.

## Summary

Bundles four CDP-side V1 driver-ergonomics features that all extend the same `Target` and `ChromiumOptions` types in `plumb-cdp`. Splitting would have forced three rebases on the same struct.

- **#74** `--wait-for <selector>` and `--wait-ms <ms>` — wait for an element to render or sleep an extra interval before the snapshot.
- **#75** `--cookie name=value`, `--header 'name: value'`, `--auth-script <path>` — pre-inject session state and run a `.js` bootstrap before navigation. Cookies and headers are control-character-validated at parse time; auth-script paths are canonicalized and refused when they resolve outside CWD.
- **#76** `--storage-state <path>` — load a Playwright `storage-state.json`. Cookies install before navigation; localStorage writes via `page.evaluate` after navigation when the origin matches. Parser uses `serde(deny_unknown_fields)`.
- **#77** `--disable-animations [bool]`, `--hide-scrollbars [bool]`, `--dpr <factor>` — three per-target capture knobs. The first two default to `true` and inject CSS via `Page.addScriptToEvaluateOnNewDocument`. `--dpr` overrides the viewport's `device_pixel_ratio` through `Emulation.setDeviceMetricsOverride`.

A new `pre_navigate` helper centralizes the "set up the page before goto" stages — animation killer, scrollbar killer, auth script, headers, cookies, storage-state cookies — so `ChromiumDriver` and `PersistentBrowser` share one implementation.

CLI flags wire through the new `LintArgs` struct in `plumb_cli::commands::lint`.

## Determinism guarantees

- Cookie iteration is sorted by `(name, value)` before CDP traffic.
- Header iteration is sorted by name before CDP traffic.
- Storage-state cookies are sorted by `(domain, name)` and origins by `origin`.
- The selector wait uses `tokio::time::timeout` (no `Instant::now`).
- All three runs of `just determinism-check` produce byte-identical JSON.

## Security guarantees

- `--cookie` and `--header` reject CR / LF / NUL bytes (header injection).
- Header names additionally reject whitespace and `:`.
- `--auth-script` and `--storage-state` paths are canonicalized; resolution outside CWD is refused.
- Auth-script paths must end in `.js`.
- Storage-state JSON refuses unknown fields.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (all suites pass; 12 new lib unit tests in `plumb-cdp`, 8 new integration tests in `plumb-cli`)
- [x] `just determinism-check` (3 runs byte-identical)
- [x] `cargo deny check` (advisories ok, bans ok, licenses ok, sources ok)
- [x] `just validate` (full local mirror of CI passes)

## Files changed

- `crates/plumb-cdp/src/lib.rs` — `Target` + `ChromiumOptions` extension, `Cookie`, `parse_header_kv`, `StorageState{,Cookie,Origin,LocalStorageEntry}`, `pre_navigate`, `apply_post_navigate_waits`, `apply_storage_state_local_storage`, `inject_scrollbar_killer`, `inject_auth_script`, `install_extra_headers`, `install_cookies`, `install_storage_state_cookies`, `wait_for_selector`, `canonicalize_safe_path`. New variants on `CdpError`. 12 new unit tests.
- `crates/plumb-cdp/Cargo.toml` — adds `serde` + `serde_json` to runtime deps.
- `crates/plumb-cli/src/main.rs` — 8 new `Lint` flags.
- `crates/plumb-cli/src/commands/lint.rs` — new `LintArgs` struct, capture-knob threading, cookie/header parsing, ChromiumOptions wiring.
- `crates/plumb-cli/tests/cli_integration.rs` — 8 new integration tests.
- `crates/plumb-mcp/src/lib.rs`, `crates/plumb-cdp/tests/*.rs`, `crates/plumb-cdp/benches/cdp_benchmarks.rs` — call-site updates for `..Target::default()` / `..ChromiumOptions::default()` after the field expansion.
- `docs/src/cli.md` — updated flag table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)