### PR TITLE
chore(release): unify registry naming as plumb-cli across cargo / npm / brew

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -159,14 +159,14 @@ jobs:
         if: "!matrix.gated && matrix.channel == 'brew'"
         shell: bash
         run: |
-          brew install plumb-dev/tap/plumb
+          brew install plumb-dev/tap/plumb-cli
 
       # ── npm ───────────────────────────────────────────────────
       - name: Install via npm
         if: "!matrix.gated && matrix.channel == 'npm'"
         shell: bash
         run: |
-          npm install -g @plumb/cli
+          npm install -g plumb-cli
 
       # ── Verify ────────────────────────────────────────────────
       - name: Verify plumb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,19 @@ name: release
 #
 # Cargo publish and curl installers are the only non-manual release
 # channels this repo validates end-to-end today. Homebrew tap and npm
-# publishing are intentionally inactive here. Do not add the `tap` or
-# `npm-scope` fields in `dist-workspace.toml` until the external
-# prerequisites exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap`
-# repo, ownership of the `@plumb` npm scope and `@plumb/cli` package,
-# and the cargo-dist publishing token/permissions. npm activation also
-# needs `npm` added to the installer list; `npm-scope` alone does not
-# emit npm artifacts on cargo-dist 0.28.0. This workflow must not claim
-# `brew install` or `npm i -g @plumb/cli` support until a live publish
-# verifies those channels.
+# publishing are intentionally inactive here. Do not add the `tap`
+# field in `dist-workspace.toml` until the external prerequisites
+# exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap` repo, an
+# npm account with publish permission for the `plumb-cli` unscoped
+# package, and the cargo-dist publishing token/permissions. npm
+# activation also needs `npm` added to the installer list. The V0
+# install string is consistent across channels:
+#   `cargo install plumb-cli`
+#   `npm  i -g plumb-cli`
+#   `brew install plumb-dev/tap/plumb-cli`
+# The binary is `plumb` regardless of channel. This workflow must not
+# claim `brew install` or `npm i -g plumb-cli` support until a live
+# publish verifies those channels.
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ curl -LsSf https://plumb.aramhammoudeh.com/install.sh | sh
 cargo install plumb-cli
 
 # Homebrew (coming soon)
-brew install plumb-dev/tap/plumb
+brew install plumb-dev/tap/plumb-cli
+
+# npm (coming soon)
+npm i -g plumb-cli
 ```
+
+The package name on every channel is `plumb-cli`. The installed binary
+is `plumb`, so usage stays `plumb lint <url>` regardless of channel.
 
 ## Documentation
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,19 +29,21 @@ allow-dirty = ["ci"]
 # Uncomment these only after:
 # 1. the `plumb-dev` GitHub org exists,
 # 2. the `plumb-dev/homebrew-tap` repo exists and is wired for cargo-dist,
-# 3. the `@plumb` npm scope and the `@plumb/cli` package are owned by the
-#    release account that will publish from this repo,
+# 3. an npm account with publish permission for the `plumb-cli` unscoped
+#    package exists. The `plumb` name on crates.io and npm is already
+#    taken (a different project), so the V0 install string is
+#    `npm i -g plumb-cli` mirroring `cargo install plumb-cli` and
+#    `brew install plumb-dev/tap/plumb-cli`. The binary is `plumb` so
+#    `plumb lint <url>` works after install regardless of channel.
 # 4. the release token/permissions for cargo-dist publishing are in place,
 # 5. a live publish has verified the public install command shape before docs
-#    claim `npm i -g @plumb/cli` support.
+#    claim `npm i -g plumb-cli` support.
 # Issues #51 and #52 are intentionally prep-only, so this repo must not enable
 # either installer yet.
 # tap = "plumb-dev/homebrew-tap"
-# Keep the value aligned with the intended package name `@plumb/cli`, but do
-# not uncomment this field until the external npm prerequisites above exist.
-# Future activation also needs `npm` added to `installers`; `npm-scope` alone
-# does not produce npm artifacts in cargo-dist 0.28.0.
-# npm-scope = "@plumb"
+# Future activation needs `npm` added to `installers`. The unscoped
+# `plumb-cli` package matches the cargo package name; no `npm-scope` is
+# needed.
 
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"

--- a/docs/src/ci/release-prep.md
+++ b/docs/src/ci/release-prep.md
@@ -42,43 +42,48 @@ Until those blockers are resolved, the install docs describe the
 Homebrew command shape, but this repo MUST NOT claim `brew install`
 verification.
 
-## npm activation for `@plumb/cli`
+## npm activation for `plumb-cli`
 
 Issue #52 is also prep-only in this repo state. The release workflow and
 `dist-workspace.toml` may validate the cargo-dist config shape, but they
 do not enable npm publishing yet.
 
-Before anyone uncomments the `npm-scope` setting in
-`dist-workspace.toml`, these prerequisites MUST exist:
+The `plumb` package on npm is owned by an unrelated project, so V0
+publishes the unscoped `plumb-cli` package — matching the cargo package
+name. The install string is then consistent across channels:
 
-1. The `@plumb` npm scope.
-2. Ownership or publish access for the `@plumb/cli` package under the
-   release identity used by this repo.
-3. The `NPM_TOKEN` secret and any required repo or environment
+- `cargo install plumb-cli`
+- `npm i -g plumb-cli`
+- `brew install plumb-dev/tap/plumb-cli`
+
+The binary is `plumb` regardless of channel, so usage stays
+`plumb lint <url>`.
+
+Before anyone enables npm publishing in `dist-workspace.toml`, these
+prerequisites MUST exist:
+
+1. An npm account with publish permission for the `plumb-cli` unscoped
+   package.
+2. The `NPM_TOKEN` secret and any required repo or environment
    permissions for release publishing.
 
 Activation steps, once the external prerequisites exist:
 
 1. Confirm `cargo dist plan` still passes with the current repo state.
-2. Verify the commented config shape still matches the intended package
-   name: `npm-scope = "@plumb"` targets `@plumb/cli` for this binary.
-3. Add `npm` to the `installers` list when enabling npm publishing.
-   In cargo-dist 0.28.0, uncommenting `npm-scope` alone does not emit
-   npm artifacts.
-4. Add the `NPM_TOKEN` secret and any required GitHub repo or
+2. Add `npm` to the `installers` list in `dist-workspace.toml`.
+3. Add the `NPM_TOKEN` secret and any required GitHub repo or
    environment permissions for cargo-dist publishing.
-5. Uncomment `npm-scope = "@plumb"` in `dist-workspace.toml`.
-6. Run `cargo dist plan` again and review the generated manifest for npm
+4. Run `cargo dist plan` again and review the generated manifest for npm
    installer entries before tagging a release.
-7. Publish from a controlled release tag and verify the live install on
+5. Publish from a controlled release tag and verify the live install on
    macOS, Linux, and Windows before updating docs or acceptance claims.
 
 Current blockers this repo does not solve:
 
-- The `@plumb` npm scope may not exist yet.
-- Ownership of `@plumb/cli` is external to this repo.
+- Publish permission for the `plumb-cli` unscoped package is external to
+  this repo.
 - `NPM_TOKEN` and the required repo or environment permissions are
   external to this repo.
 
 Until those blockers are resolved, this repo MUST NOT claim that
-`npm i -g @plumb/cli` has been verified.
+`npm i -g plumb-cli` has been verified.

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -70,11 +70,20 @@ cargo install plumb-cli --version 0.1.0
 For macOS or Linuxbrew:
 
 ```bash
-brew install plumb-dev/tap/plumb
+brew install plumb-dev/tap/plumb-cli
 ```
 
 The tap repository is `plumb-dev/homebrew-tap`. The formula tracks the
 latest tagged release.
+
+## npm
+
+```bash
+npm i -g plumb-cli
+```
+
+The npm package wraps the same binaries cargo-dist publishes. The
+binary is `plumb` regardless of channel.
 
 ## Build from source
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -57,7 +57,8 @@ Pick the channel that fits your workflow:
 
 - [Install script (macOS / Linux / Windows)](./install.md#install-script-macos--linux--windows) — one-line curl/irm
 - [`cargo install`](./install.md#cargo) — if you already have a Rust toolchain
-- [Homebrew](./install.md#homebrew) — `brew install plumb-dev/tap/plumb`
+- [Homebrew](./install.md#homebrew) — `brew install plumb-dev/tap/plumb-cli`
+- [npm](./install.md#npm) — `npm i -g plumb-cli`
 - [Build from source](./install.md#build-from-source) — the only path available today (pre-alpha)
 
 Then continue with the docs for your workflow:

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -171,7 +171,7 @@ fi
 
 if [ "$brew_gated" -gt 0 ] \
     && grep -Fq "if: \"!matrix.gated && matrix.channel == 'brew'\"" "$WORKFLOW" \
-    && grep -Fq 'brew install plumb-dev/tap/plumb' "$WORKFLOW"; then
+    && grep -Fq 'brew install plumb-dev/tap/plumb-cli' "$WORKFLOW"; then
     pass "brew channel stays gated until a publish path exists"
 else
     fail "brew channel gating/install contract is incorrect"
@@ -179,7 +179,7 @@ fi
 
 if [ "$npm_gated" -gt 0 ] \
     && grep -Fq "if: \"!matrix.gated && matrix.channel == 'npm'\"" "$WORKFLOW" \
-    && grep -Fq 'npm install -g @plumb/cli' "$WORKFLOW"; then
+    && grep -Fq 'npm install -g plumb-cli' "$WORKFLOW"; then
     pass "npm channel stays gated until a publish path exists"
 else
     fail "npm channel gating/install contract is incorrect"


### PR DESCRIPTION
## Summary
- The package name on crates.io / npm / brew is now consistently `plumb-cli`.
- Binary stays `plumb` so usage is `plumb lint <url>` after install on any channel.
- Drops the `@plumb` npm scope plan — `plumb-cli` unscoped is free, simpler, one less account to reserve.

## Why
`plumb` is taken on both crates.io ("functional pipeline framework") and npm ("composition sugar"). `plumb-cli` is free everywhere. Picking the closest free pattern, used identically across all three channels, gives users one mental model:

```
cargo install plumb-cli
npm  i -g plumb-cli
brew install plumb-dev/tap/plumb-cli
```

## Files
- README.md, docs/src/install.md, docs/src/introduction.md, docs/src/ci/release-prep.md — install string updates
- dist-workspace.toml + .github/workflows/release.yml comments — drop `@plumb` scope plan
- .github/workflows/install-smoke.yml — `brew install plumb-dev/tap/plumb-cli` and `npm install -g plumb-cli`
- tests/install-smoke-validate.sh — assertion strings updated

## Test plan
- [x] `just check` (clippy + fmt + agents-md + smoke validators) green locally
- [ ] CI green
- [ ] After merge, downstream PRs (#212, #215) pick up the new install strings via release-readiness matrix