### PR TITLE
chore: phase 2 polish bundle (#199 #201 #203 #206)

### DIFF
--- a/crates/plumb-core/src/rules/color/contrast_aa.rs
+++ b/crates/plumb-core/src/rules/color/contrast_aa.rs
@@ -59,6 +59,15 @@ impl Rule for ContrastAa {
 
     fn check(&self, ctx: &SnapshotCtx<'_>, config: &Config, sink: &mut ViolationSink<'_>) {
         let snapshot = ctx.snapshot();
+        // `parent_index` and `nodes_by_dom_order` walk every node in
+        // the snapshot. Both are rebuilt once per `check` call (i.e.
+        // once per rule invocation per snapshot), which is O(N) — the
+        // same order as the per-node scan that follows. If a future
+        // benchmark shows these dominate rule cost on large pages,
+        // hoist them into `SnapshotCtx` so the rule engine builds them
+        // once per snapshot and shares across rules. Until profiling
+        // says otherwise, keep them local to keep `SnapshotCtx`
+        // unspecialized.
         let parents = parent_index(snapshot);
         let nodes_by_dom_order = nodes_by_dom_order(snapshot);
 
@@ -99,6 +108,13 @@ fn violation_for_node(
     let is_large = classify_large_text(font_size_px, font_weight);
     let required_ratio = required_ratio(config, is_large);
     let background = resolve_background(parents, nodes_by_dom_order, node);
+    // `foreground.a` is parsed from CSS into an `f32` via
+    // `parse_alpha`, which clamps the value to `[0.0, 1.0]`. An
+    // exactly-opaque CSS color (`a = 1` or `1.0`) round-trips to the
+    // f32 literal `1.0`, so `(a - 1.0).abs() < f32::EPSILON` is the
+    // correct opacity test under that origin. A wider tolerance would
+    // skip the alpha composite for slightly-translucent colors and
+    // overstate contrast.
     let effective_foreground = if (foreground.a - 1.0).abs() < f32::EPSILON {
         foreground
     } else {

--- a/crates/plumb-core/src/rules/opacity/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/opacity/scale_conformance.rs
@@ -52,7 +52,13 @@ impl Rule for ScaleConformance {
                 continue;
             }
 
-            let nearest = nearest_opacity(value, scale);
+            // The early `scale.is_empty()` guard above ensures
+            // `nearest_opacity` always returns `Some`. The `?` keeps
+            // the rule total even if a future refactor relaxes the
+            // outer guard.
+            let Some(nearest) = nearest_opacity(value, scale) else {
+                continue;
+            };
 
             let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
             metadata.insert("opacity".to_owned(), serde_json::Value::from(value));
@@ -92,16 +98,48 @@ impl Rule for ScaleConformance {
 }
 
 /// Find the nearest opacity in the scale. Ties: lower value wins.
+///
+/// Returns `None` only when `scale` is empty. Encoding the empty-scale
+/// case in the return type keeps the helper total: callers do not
+/// have to repeat an `is_empty()` precondition to avoid a panic, and
+/// the rule stays sound if a future caller forgets the outer guard.
 #[allow(clippy::float_cmp)]
-fn nearest_opacity(value: f64, scale: &[f32]) -> f32 {
-    let mut best = scale[0];
-    let mut best_delta = (value - f64::from(best)).abs();
-    for &candidate in &scale[1..] {
-        let delta = (value - f64::from(candidate)).abs();
-        if delta < best_delta || (delta == best_delta && candidate < best) {
-            best = candidate;
-            best_delta = delta;
+fn nearest_opacity(value: f64, scale: &[f32]) -> Option<f32> {
+    scale.iter().copied().fold(None, |best, candidate| {
+        let candidate_delta = (value - f64::from(candidate)).abs();
+        match best {
+            None => Some(candidate),
+            Some(current) => {
+                let current_delta = (value - f64::from(current)).abs();
+                // Equality on `f64` deltas is intentional: each delta
+                // is computed the same way for every candidate, so a
+                // true tie is exactly representable in `f64`.
+                if candidate_delta < current_delta
+                    || (candidate_delta == current_delta && candidate < current)
+                {
+                    Some(candidate)
+                } else {
+                    Some(current)
+                }
+            }
         }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nearest_opacity;
+
+    #[test]
+    fn empty_scale_returns_none() {
+        assert_eq!(nearest_opacity(0.5, &[]), None);
     }
-    best
+
+    #[test]
+    fn picks_closest_opacity_in_scale() {
+        let scale: [f32; 3] = [0.0, 0.5, 1.0];
+        assert_eq!(nearest_opacity(0.4, &scale), Some(0.5));
+        assert_eq!(nearest_opacity(0.1, &scale), Some(0.0));
+        assert_eq!(nearest_opacity(0.9, &scale), Some(1.0));
+    }
 }

--- a/crates/plumb-core/src/rules/sibling/padding_consistency.rs
+++ b/crates/plumb-core/src/rules/sibling/padding_consistency.rs
@@ -132,13 +132,49 @@ impl Rule for PaddingConsistency {
 ///
 /// For even counts, the lower of the two middle values wins (same
 /// deterministic tie-break as `sibling/height-consistency`).
+///
+/// Uses [`f64::total_cmp`] for the sort key — `partial_cmp` returns
+/// `None` on `NaN`, which would force a fallback comparator and risk
+/// nondeterministic ordering. `total_cmp` defines a total order over
+/// all `f64` bit patterns (including `NaN`s), which keeps the median
+/// reproducible regardless of the input distribution.
 fn median_f64(values: &[f64]) -> f64 {
     let mut sorted: Vec<f64> = values.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(f64::total_cmp);
     let mid = sorted.len() / 2;
     if sorted.len().is_multiple_of(2) {
         sorted[mid - 1]
     } else {
         sorted[mid]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::median_f64;
+
+    #[test]
+    fn median_odd_count_picks_middle() {
+        assert!((median_f64(&[1.0, 5.0, 3.0]) - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn median_even_count_picks_lower_middle() {
+        // Sorted: [1.0, 3.0, 5.0, 7.0]. Lower of the two middle values
+        // wins, which is 3.0.
+        assert!((median_f64(&[1.0, 7.0, 3.0, 5.0]) - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn median_with_nan_is_total_and_does_not_panic() {
+        // `f64::total_cmp` defines a total order over NaN bit patterns,
+        // so the sort is well-defined and deterministic. Without
+        // `total_cmp`, `partial_cmp` would return `None` and the
+        // fallback comparator would risk a nondeterministic median.
+        // total_cmp orders NaN after positive infinity, so sorted
+        // looks like [1.0, 2.0, 3.0, NaN]; the lower middle is 2.0.
+        let values = [1.0_f64, f64::NAN, 3.0, 2.0];
+        let result = median_f64(&values);
+        assert!((result - 2.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/plumb-core/src/rules/type_/weight_conformance.rs
+++ b/crates/plumb-core/src/rules/type_/weight_conformance.rs
@@ -46,7 +46,13 @@ impl Rule for WeightConformance {
                 continue;
             }
 
-            let nearest = nearest_weight(value, weights);
+            // The early `weights.is_empty()` guard above ensures
+            // `nearest_weight` always returns `Some`. The `?` keeps
+            // the rule total even if a future refactor relaxes the
+            // outer guard.
+            let Some(nearest) = nearest_weight(value, weights) else {
+                continue;
+            };
 
             let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
             metadata.insert("font_weight".to_owned(), serde_json::Value::from(value));
@@ -82,15 +88,51 @@ impl Rule for WeightConformance {
 }
 
 /// Find the nearest weight in the scale. Ties: lower wins.
-fn nearest_weight(value: u16, scale: &[u16]) -> u16 {
-    let mut best = scale[0];
-    let mut best_delta = value.abs_diff(best);
-    for &candidate in &scale[1..] {
-        let delta = value.abs_diff(candidate);
-        if delta < best_delta || (delta == best_delta && candidate < best) {
-            best = candidate;
-            best_delta = delta;
+///
+/// Returns `None` only when `scale` is empty. Encoding the empty-scale
+/// case in the return type keeps the helper total: callers do not
+/// have to repeat an `is_empty()` precondition to avoid a panic, and
+/// the rule stays sound if a future caller forgets the outer guard.
+fn nearest_weight(value: u16, scale: &[u16]) -> Option<u16> {
+    scale.iter().copied().fold(None, |best, candidate| {
+        let candidate_delta = value.abs_diff(candidate);
+        match best {
+            None => Some(candidate),
+            Some(current) => {
+                let current_delta = value.abs_diff(current);
+                if candidate_delta < current_delta
+                    || (candidate_delta == current_delta && candidate < current)
+                {
+                    Some(candidate)
+                } else {
+                    Some(current)
+                }
+            }
         }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nearest_weight;
+
+    #[test]
+    fn empty_scale_returns_none() {
+        assert_eq!(nearest_weight(500, &[]), None);
     }
-    best
+
+    #[test]
+    fn picks_closest_weight_in_scale() {
+        let scale = [400, 500, 700];
+        assert_eq!(nearest_weight(450, &scale), Some(400));
+        assert_eq!(nearest_weight(600, &scale), Some(500));
+        assert_eq!(nearest_weight(800, &scale), Some(700));
+    }
+
+    #[test]
+    fn breaks_ties_toward_lower_value() {
+        let scale = [400, 600];
+        // Equidistant: 500 - 400 == 600 - 500. Lower wins.
+        assert_eq!(nearest_weight(500, &scale), Some(400));
+    }
 }

--- a/crates/plumb-core/src/rules/z/scale_conformance.rs
+++ b/crates/plumb-core/src/rules/z/scale_conformance.rs
@@ -50,7 +50,13 @@ impl Rule for ScaleConformance {
                 continue;
             }
 
-            let nearest = nearest_z(value, scale);
+            // The early `scale.is_empty()` guard above ensures
+            // `nearest_z` always returns `Some`. The `?` keeps the
+            // rule total even if a future refactor relaxes the outer
+            // guard.
+            let Some(nearest) = nearest_z(value, scale) else {
+                continue;
+            };
 
             let mut metadata: IndexMap<String, serde_json::Value> = IndexMap::new();
             metadata.insert("z_index".to_owned(), serde_json::Value::from(value));
@@ -88,20 +94,57 @@ impl Rule for ScaleConformance {
 /// Find the nearest z-index in the scale.
 ///
 /// Ties: toward lower absolute value, then toward the value closer to zero.
-fn nearest_z(value: i32, scale: &[i32]) -> i32 {
-    let mut best = scale[0];
-    let mut best_delta = value.abs_diff(best);
-    for &candidate in &scale[1..] {
-        let delta = value.abs_diff(candidate);
-        if delta < best_delta
-            || (delta == best_delta && candidate.unsigned_abs() < best.unsigned_abs())
-            || (delta == best_delta
-                && candidate.unsigned_abs() == best.unsigned_abs()
-                && candidate > best)
-        {
-            best = candidate;
-            best_delta = delta;
+///
+/// Returns `None` only when `scale` is empty. Encoding the empty-scale
+/// case in the return type keeps the helper total: callers do not
+/// have to repeat an `is_empty()` precondition to avoid a panic, and
+/// the rule stays sound if a future caller forgets the outer guard.
+fn nearest_z(value: i32, scale: &[i32]) -> Option<i32> {
+    scale.iter().copied().fold(None, |best, candidate| {
+        let candidate_delta = value.abs_diff(candidate);
+        match best {
+            None => Some(candidate),
+            Some(current) => {
+                let current_delta = value.abs_diff(current);
+                if candidate_delta < current_delta
+                    || (candidate_delta == current_delta
+                        && candidate.unsigned_abs() < current.unsigned_abs())
+                    || (candidate_delta == current_delta
+                        && candidate.unsigned_abs() == current.unsigned_abs()
+                        && candidate > current)
+                {
+                    Some(candidate)
+                } else {
+                    Some(current)
+                }
+            }
         }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nearest_z;
+
+    #[test]
+    fn empty_scale_returns_none() {
+        assert_eq!(nearest_z(5, &[]), None);
     }
-    best
+
+    #[test]
+    fn picks_closest_z_in_scale() {
+        let scale = [0, 10, 100];
+        assert_eq!(nearest_z(7, &scale), Some(10));
+        assert_eq!(nearest_z(3, &scale), Some(0));
+        assert_eq!(nearest_z(60, &scale), Some(100));
+    }
+
+    #[test]
+    fn breaks_ties_toward_higher_signed_value_for_equal_abs() {
+        let scale = [-10, 10];
+        // 0 is equidistant from -10 and 10. With equal absolute value,
+        // the tie-break picks the higher signed value (10), matching
+        // the existing rule contract.
+        assert_eq!(nearest_z(0, &scale), Some(10));
+    }
 }

--- a/crates/plumb-core/tests/golden_color_contrast_aa.rs
+++ b/crates/plumb-core/tests/golden_color_contrast_aa.rs
@@ -9,6 +9,28 @@
 //! - bold 19px text that counts as large,
 //! - bold 18.6px text that still counts as normal under the precise 14pt cutoff,
 //! - text inside a dark section whose nearest ancestor background is not white.
+//!
+//! ## Fixture node map
+//!
+//! The selector each text node uses is the CSS `:nth-child(N)` index of
+//! its position under `body`. The selector index is independent of the
+//! node's `dom_order` — `dom_order` reflects insertion order in the
+//! snapshot vector, which the engine sorts violations by. The table
+//! below pairs each `nth-child(N)` selector with the `dom_order` and
+//! WCAG-relevant style values used in `fixture_snapshot()` so an
+//! agent reading the snapshot can map selector → expected behavior
+//! without re-deriving it from the fixture body.
+//!
+//! | nth-child | dom_order | font-size | font-weight | foreground         | parent bg          | classification | expected verdict |
+//! | --------- | --------- | --------- | ----------- | ------------------ | ------------------ | -------------- | ---------------- |
+//! | 1         | 2         | 16px      | (default)   | rgb(0, 0, 0)       | rgb(255, 255, 255) | normal         | pass             |
+//! | 2         | 3         | 16px      | (default)   | rgb(119, 119, 119) | rgb(255, 255, 255) | normal         | fail (< 4.5:1)   |
+//! | 3         | 4         | 24px      | (default)   | rgb(148, 148, 148) | rgb(255, 255, 255) | large          | pass (>= 3.0:1)  |
+//! | 4         | 5         | 18px      | 700 (bold)  | rgb(148, 148, 148) | rgb(255, 255, 255) | normal         | fail (< 4.5:1)   |
+//! | 5         | 6         | 19px      | 700 (bold)  | rgb(148, 148, 148) | rgb(255, 255, 255) | large          | pass (>= 3.0:1)  |
+//! | 6         | 9         | 18.6px    | 700 (bold)  | rgb(148, 148, 148) | rgb(255, 255, 255) | normal         | fail (< 4.5:1)   |
+//! | section p | 8         | 16px      | (default)   | rgb(120, 120, 120) | rgb(34, 34, 34)    | normal         | pass             |
+//! | 7         | 10        | 16px      | (default)   | rgb(110, 110, 110) | rgb(255, 255, 255) | normal         | pass at 4.5:1, fails at 7.0:1 |
 
 use indexmap::IndexMap;
 use plumb_core::report::Rect;

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -12,8 +12,11 @@ RELEASE_PREP_DOC="$REPO_ROOT/docs/src/ci/release-prep.md"
 
 failures=0
 
+# `pass`/`fail` track the total number of FAIL lines so the final
+# summary reflects how many distinct checks failed instead of
+# clamping to a boolean.
 pass() { echo "  PASS: $1"; }
-fail() { echo "  FAIL: $1" >&2; failures=1; }
+fail() { echo "  FAIL: $1" >&2; failures=$((failures + 1)); }
 
 echo "=== Install-smoke gate validation ==="
 echo ""
@@ -99,6 +102,20 @@ fi
 # Current repo contract: cargo/curl run automatically on all supported
 # platforms; brew/npm stay documented as prep-only until external setup
 # exists.
+#
+# Expected matrix counts (one entry per OS leg, see
+# `.github/workflows/install-smoke.yml`):
+#
+#   cargo_count = 3  → ubuntu + macos + windows (non-manual)
+#   curl_count  = 3  → ubuntu + macos + windows (non-manual; windows
+#                       leg uses PowerShell installer)
+#   brew_count  = 2  → ubuntu + macos only (homebrew has no Windows
+#                       support; gated until a tap publish path exists)
+#   npm_count   = 3  → ubuntu + macos + windows (gated; npm runs
+#                       cross-platform once a publish path exists)
+#
+# Adjust both the counts and the corresponding pass/fail messages
+# together when the matrix changes — they document the contract.
 cargo_count=$(grep -c 'channel: cargo' "$WORKFLOW" || true)
 curl_count=$(grep -c 'channel: curl' "$WORKFLOW" || true)
 brew_count=$(grep -c 'channel: brew' "$WORKFLOW" || true)
@@ -117,15 +134,15 @@ else
 fi
 
 if [ "$brew_count" -eq 2 ]; then
-    pass "brew channel stays limited to supported gated OS legs"
+    pass "brew channel covers ubuntu and macos as gated OS legs (no Windows; homebrew has no Windows support)"
 else
-    fail "brew channel count is $brew_count (expected 2 gated OS legs)"
+    fail "brew channel count is $brew_count (expected 2 gated OS legs: ubuntu + macos)"
 fi
 
 if [ "$npm_count" -eq 3 ]; then
-    pass "npm channel stays limited to supported gated OS legs"
+    pass "npm channel covers all three OSes as gated OS legs"
 else
-    fail "npm channel count is $npm_count (expected 3 gated OS legs)"
+    fail "npm channel count is $npm_count (expected 3 gated OS legs: ubuntu + macos + windows)"
 fi
 
 # ── 5. Verification steps ──────────────────────────────────────────
@@ -297,7 +314,7 @@ fi
 
 echo ""
 if [ "$failures" -ne 0 ]; then
-    echo "FAILED: one or more checks failed."
+    echo "FAILED: $failures check(s) failed."
     exit 1
 else
     echo "PASSED: all checks passed."

--- a/tests/release-readiness-local-kits-validate.sh
+++ b/tests/release-readiness-local-kits-validate.sh
@@ -12,8 +12,11 @@ CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
 
 failures=0
 
+# `pass`/`fail` track the total number of FAIL lines so the final
+# summary reflects how many distinct checks failed instead of
+# clamping to a boolean.
 pass() { echo "  PASS: $1"; }
-fail() { echo "  FAIL: $1" >&2; failures=1; }
+fail() { echo "  FAIL: $1" >&2; failures=$((failures + 1)); }
 
 echo "=== Release-readiness local kit validation ==="
 echo ""
@@ -59,7 +62,7 @@ fi
 
 echo ""
 if [ "$failures" -ne 0 ]; then
-    echo "FAILED: one or more checks failed."
+    echo "FAILED: $failures check(s) failed."
     exit 1
 else
     echo "PASSED: all checks passed."

--- a/tests/release-readiness-matrix-validate.sh
+++ b/tests/release-readiness-matrix-validate.sh
@@ -14,8 +14,11 @@ RUNBOOK="$REPO_ROOT/docs/runbooks/v0-release-readiness-spec.yaml"
 
 failures=0
 
+# `pass`/`fail` track the total number of FAIL lines so the final
+# summary reflects how many distinct checks failed instead of
+# clamping to a boolean.
 pass() { echo "  PASS: $1"; }
-fail() { echo "  FAIL: $1" >&2; failures=1; }
+fail() { echo "  FAIL: $1" >&2; failures=$((failures + 1)); }
 
 echo "=== Release-readiness matrix validation ==="
 echo ""
@@ -227,7 +230,7 @@ fi
 
 echo ""
 if [ "$failures" -ne 0 ]; then
-    echo "FAILED: one or more checks failed."
+    echo "FAILED: $failures check(s) failed."
     exit 1
 else
     echo "PASSED: all checks passed."

--- a/tests/release-security-validate.sh
+++ b/tests/release-security-validate.sh
@@ -16,9 +16,30 @@ RELEASE_PREP_DOC="$REPO_ROOT/docs/src/ci/release-prep.md"
 
 failures=0
 
+# `pass`/`fail` track the total number of FAIL lines emitted so the
+# final exit status reflects true severity (e.g. a "1 failure" run
+# vs a "5 failures" run). The summary at the bottom reads `failures`
+# directly, which lets reviewers see drift across the whole batch
+# instead of clamping it to a boolean.
 pass() { echo "  PASS: $1"; }
-fail() { echo "  FAIL: $1" >&2; failures=1; }
+fail() { echo "  FAIL: $1" >&2; failures=$((failures + 1)); }
 
+# Scan a workflow file for `${{ secrets.* }}` interpolation that lives
+# inside a `run:` block body — the unsafe shape that risks leaking
+# secrets in shell logs.
+#
+# Supported: literal block scalars (`run: |`, `run: |-`, `run: |+`).
+# The Python parser walks the file by indentation: once it sees a
+# `run:` line whose value is `|`, `|-`, or `|+` it considers every
+# more-indented line as part of the run body until indentation
+# returns to the parent.
+#
+# Out of scope: folded scalars (`run: >`, `run: >-`, `run: >+`) and
+# inline single-line `run:` shell commands that already use
+# `${{ secrets.* }}` directly. Plumb's release-related workflows have
+# never used the folded shape — if that changes, extend this scanner
+# in the same PR. Inline `run:` lines containing `secrets.*` are
+# still flagged on the same line.
 scan_run_block_secrets() {
     python3 - "$1" <<'PY'
 import sys
@@ -47,6 +68,9 @@ for i, raw in enumerate(lines, 1):
 
     if stripped.startswith("run:"):
         rest = stripped[len("run:"):].strip()
+        # Literal block scalars only. Folded scalars (`>`, `>-`, `>+`)
+        # are intentionally out of scope; see scan_run_block_secrets
+        # docstring.
         if rest in ("|", "|-", "|+"):
             in_run = True
             run_indent = indent
@@ -127,6 +151,14 @@ echo "4. Secret leakage prevention"
 # in run blocks. The safe pattern is: env: { TOKEN: ${{ secrets.X }} }
 # then reference $TOKEN in the script. Direct ${{ secrets.* }} in run
 # blocks risks leaking secrets in logs.
+#
+# `legacy_env_key_pattern` is built up across two assignments on
+# purpose: the literal we are checking for is the very pattern that
+# would match this validator's source if it were written as a single
+# string. Splitting the pattern into two concatenated halves avoids a
+# self-match here while still letting `grep` reconstruct the full
+# regex — without the split, the guard below would always fail
+# because the validator file itself contains the regex.
 legacy_env_key_pattern='[A-Z_]'
 legacy_env_key_pattern+='*:\s*\${{'
 if grep -Fq "$legacy_env_key_pattern" "$0"; then
@@ -139,7 +171,11 @@ fi
 # the same text inside a run: block must be flagged. This documents the
 # anchored env-key behavior Claude requested while using a stricter
 # context-aware scanner.
+#
+# The fixture file is registered with an EXIT trap so the temp file is
+# removed even if a later assertion exits non-zero under `set -e`.
 scanner_fixture="$(mktemp)"
+trap 'rm -f "$scanner_fixture"' EXIT
 cat >"$scanner_fixture" <<'EOF'
 steps:
   - name: safe env block
@@ -153,6 +189,7 @@ steps:
 EOF
 fixture_hits="$(scan_run_block_secrets "$scanner_fixture")"
 rm -f "$scanner_fixture"
+trap - EXIT
 if printf '%s\n' "$fixture_hits" | grep -Fq 'GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} && curl'; then
     pass "scanner ignores env-key entries and flags direct run-block interpolation"
 else
@@ -184,6 +221,15 @@ else
     pass "release workflow does not contain active Homebrew publish steps"
 fi
 
+# `dist-workspace.toml` is part of the release contract (cargo-dist
+# generates it; the repo checks it in). Treat absence uniformly as a
+# failure across the gating, prep-only-docs, and installer-list checks
+# below — silent passes on absence would let a missing file mask real
+# regressions.
+if [ ! -f "$DIST_CONFIG" ]; then
+    fail "dist-workspace.toml missing — required for Homebrew/npm gating checks"
+fi
+
 # dist-workspace.toml must not have tap field set (gated until prereqs exist).
 if [ -f "$DIST_CONFIG" ]; then
     if grep -Eq '^\s*tap\s*=' "$DIST_CONFIG"; then
@@ -191,15 +237,14 @@ if [ -f "$DIST_CONFIG" ]; then
     else
         pass "dist-workspace.toml does not set tap — Homebrew publish correctly gated"
     fi
-else
-    pass "dist-workspace.toml not found — Homebrew publish correctly absent"
 fi
 
-if [ -f "$DIST_CONFIG" ] \
-    && grep -Fq 'Issues #51 and #52 are intentionally prep-only' "$DIST_CONFIG"; then
-    pass "dist-workspace.toml documents #51/#52 as prep-only"
-else
-    fail "dist-workspace.toml does not document #51/#52 as prep-only"
+if [ -f "$DIST_CONFIG" ]; then
+    if grep -Fq 'Issues #51 and #52 are intentionally prep-only' "$DIST_CONFIG"; then
+        pass "dist-workspace.toml documents #51/#52 as prep-only"
+    else
+        fail "dist-workspace.toml does not document #51/#52 as prep-only"
+    fi
 fi
 
 # ── 6. NPM scope publish is gated ─────────────────────────────────
@@ -213,7 +258,11 @@ else
     pass "release workflow does not contain active npm publish steps"
 fi
 
-# dist-workspace.toml must not have npm-scope field set.
+# Absent-file behavior here mirrors section 5: a missing
+# dist-workspace.toml has already been flagged as a fail above, so the
+# inner checks short-circuit without re-emitting noise. When the file
+# is present, both shape (no `npm-scope`) and content
+# (`installers = ["shell", "powershell"]`) get checked.
 if [ -f "$DIST_CONFIG" ]; then
     if grep -Eq '^\s*npm-scope\s*=' "$DIST_CONFIG"; then
         fail "dist-workspace.toml has npm-scope field set — NPM publish must stay gated"
@@ -222,11 +271,12 @@ if [ -f "$DIST_CONFIG" ]; then
     fi
 fi
 
-if [ -f "$DIST_CONFIG" ] \
-    && grep -Fq 'installers = ["shell", "powershell"]' "$DIST_CONFIG"; then
-    pass "dist-workspace.toml keeps npm out of the active installer list"
-else
-    fail "dist-workspace.toml does not keep npm out of the active installer list"
+if [ -f "$DIST_CONFIG" ]; then
+    if grep -Fq 'installers = ["shell", "powershell"]' "$DIST_CONFIG"; then
+        pass "dist-workspace.toml keeps npm out of the active installer list"
+    else
+        fail "dist-workspace.toml does not keep npm out of the active installer list"
+    fi
 fi
 
 # The install-smoke workflow documents NPM_TOKEN is not yet wired.
@@ -317,7 +367,7 @@ fi
 
 echo ""
 if [ "$failures" -ne 0 ]; then
-    echo "FAILED: one or more checks failed."
+    echo "FAILED: $failures check(s) failed."
     exit 1
 else
     echo "PASSED: all checks passed."


### PR DESCRIPTION
## Summary

Bundled four sub-XS Claude APPROVE follow-up advisories from earlier PRs into a single review-tractable change.

- #199 release-validator hygiene: EXIT trap on the run-block scanner mktemp, fail() helpers now increment the failure count instead of clamping to 1, comment documenting the legacy_env_key_pattern self-match guard, comment scoping the run-block scanner to literal block scalars.
- #201 install-smoke / release-security validator clarity: install-smoke matrix counts (cargo=3, curl=3, brew=2, npm=3) documented inline, npm pass message reworded, dist-workspace.toml absent-file behavior normalized in release-security-validate.sh.
- #203 color/contrast-aa review warnings: f32::EPSILON alpha-opaque invariant comment, parent_index / nodes_by_dom_order rebuild-cost note tied to a profiling trigger, fixture node map table in golden_color_contrast_aa.rs.
- #206 small-rules code polish: nearest_weight, nearest_z, nearest_opacity now encode the non-empty scale invariant via Option<T> + iterator fold; sibling/padding_consistency uses f64::total_cmp; new unit tests for the empty-scale edge case in each helper.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features
- [x] just determinism-check
- [x] cargo deny check (audit)
- [x] just validate (full mirror of CI gates)

Closes #199 #201 #203 #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)