### PR TITLE
feat(cli,format): --suggest-ignores flag (#84)

### DIFF
--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -24,6 +24,10 @@ use crate::commands::{OutputFormat, selector as selector_filter};
 /// Aggregated args for [`run`]. Bundling them into a struct keeps the
 /// `Command::Lint` dispatch readable as the flag surface grows
 /// (PRD §15 — `--wait-for`, `--cookie`, `--storage-state`, etc.).
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "LintArgs mirrors clap CLI flags 1:1; a state-machine refactor would obscure the flag-to-arg mapping"
+)]
 #[derive(Debug)]
 pub struct LintArgs {
     pub url: String,

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -42,6 +42,10 @@ pub struct LintArgs {
     pub disable_animations: bool,
     pub hide_scrollbars: bool,
     pub dpr: Option<f64>,
+    /// When true, append a suggested `.plumbignore` block to the
+    /// rendered output. Pretty format adds a footer; JSON format adds a
+    /// `suggested_ignores` array; SARIF is unchanged.
+    pub suggest_ignores: bool,
 }
 
 /// CLI-side errors that never need to leak across the
@@ -88,6 +92,7 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
         disable_animations,
         hide_scrollbars,
         dpr,
+        suggest_ignores,
     } = args;
 
     tracing::debug!(url = %url, format = %format, viewports = ?viewports, selector = ?selector, "lint");
@@ -168,14 +173,7 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
 
     let violations = plumb_core::run_many(snapshots.iter(), &config);
 
-    let out = match format {
-        OutputFormat::Pretty => plumb_format::pretty(&violations),
-        OutputFormat::Json => plumb_format::json(&violations).context("serialize JSON")?,
-        OutputFormat::Sarif => {
-            plumb_format::sarif_with_rules(&violations, &plumb_core::builtin_rule_metadata())
-                .context("serialize SARIF")?
-        }
-    };
+    let out = render(&violations, format, suggest_ignores)?;
 
     if let Some(path) = output_path {
         std::fs::write(&path, out)
@@ -290,6 +288,40 @@ fn load_config(path: Option<&Path>) -> Result<Config> {
         tracing::debug!("no plumb.toml in CWD; using defaults");
         Ok(Config::default())
     }
+}
+
+/// Format `violations` into the requested string output, optionally
+/// appending the `.plumbignore` suggestion block.
+///
+/// SARIF intentionally ignores `suggest_ignores`: GitHub Code Scanning
+/// consumers parse the strict 2.1.0 schema, and adding a non-standard
+/// property would either confuse them or be silently dropped. Pretty
+/// and JSON have full control of their own envelope.
+fn render(
+    violations: &[plumb_core::Violation],
+    format: OutputFormat,
+    suggest_ignores: bool,
+) -> Result<String> {
+    Ok(match format {
+        OutputFormat::Pretty => {
+            if suggest_ignores {
+                plumb_format::pretty_with_suggested_ignores(violations)
+            } else {
+                plumb_format::pretty(violations)
+            }
+        }
+        OutputFormat::Json => {
+            if suggest_ignores {
+                plumb_format::json_with_suggested_ignores(violations).context("serialize JSON")?
+            } else {
+                plumb_format::json(violations).context("serialize JSON")?
+            }
+        }
+        OutputFormat::Sarif => {
+            plumb_format::sarif_with_rules(violations, &plumb_core::builtin_rule_metadata())
+                .context("serialize SARIF")?
+        }
+    })
 }
 
 fn exit_code_for(violations: &[plumb_core::Violation]) -> ExitCode {

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -140,6 +140,15 @@ enum Command {
         /// for stress-testing rules against hidpi rendering.
         #[arg(long, value_name = "FACTOR")]
         dpr: Option<f64>,
+        /// After the normal lint output, append a suggested
+        /// `.plumbignore` block listing one entry per
+        /// `(rule_id, selector)` tuple that would suppress every
+        /// current violation. Helps adopt Plumb gradually on existing
+        /// codebases. Pretty format appends a footer; JSON format adds
+        /// a `suggested_ignores` array to the envelope; SARIF format is
+        /// unchanged.
+        #[arg(long, default_value_t = false)]
+        suggest_ignores: bool,
     },
     /// Write a starter `plumb.toml` to the current directory.
     Init {
@@ -228,6 +237,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 disable_animations,
                 hide_scrollbars,
                 dpr,
+                suggest_ignores,
             } => {
                 commands::lint::run(commands::lint::LintArgs {
                     url,
@@ -246,6 +256,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
                     disable_animations,
                     hide_scrollbars,
                     dpr,
+                    suggest_ignores,
                 })
                 .await
             }

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -676,3 +676,62 @@ fn lint_accepts_disable_animations_and_hide_scrollbars_and_dpr()
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
+
+// `--suggest-ignores` (#84) — after a normal lint run, append a
+// suggested `.plumbignore` block listing one entry per
+// (rule_id, selector) tuple that would suppress every active violation.
+//
+// The canned `plumb-fake://hello` snapshot fires
+// `spacing/grid-conformance` on `body`, so both the pretty and JSON
+// shapes have a single deterministic entry to assert against.
+
+#[test]
+fn lint_without_suggest_ignores_omits_section() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello"])
+        .assert()
+        .code(3)
+        .stdout(contains("Suggested .plumbignore").not());
+    Ok(())
+}
+
+#[test]
+fn lint_pretty_with_suggest_ignores_appends_footer() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--suggest-ignores"])
+        .assert()
+        .code(3)
+        .stdout(contains("Suggested .plumbignore"))
+        .stdout(contains("would suppress 1 violation"))
+        .stdout(contains("# Format: <rule_id> <selector_path>"))
+        .stdout(contains("spacing/grid-conformance html > body"));
+    Ok(())
+}
+
+#[test]
+fn lint_json_with_suggest_ignores_adds_array() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "json",
+            "--suggest-ignores",
+        ])
+        .assert()
+        .code(3)
+        .stdout(contains("\"suggested_ignores\""))
+        .stdout(contains("\"rule_id\": \"spacing/grid-conformance\""))
+        .stdout(contains("\"selector\": \"html > body\""));
+    Ok(())
+}
+
+#[test]
+fn lint_json_without_suggest_ignores_omits_array() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--format", "json"])
+        .assert()
+        .code(3)
+        .stdout(contains("\"suggested_ignores\"").not());
+    Ok(())
+}

--- a/crates/plumb-format/src/lib.rs
+++ b/crates/plumb-format/src/lib.rs
@@ -197,7 +197,7 @@ pub fn pretty_with_suggested_ignores(violations: &[Violation]) -> String {
     out
 }
 
-/// Same as [`json`] but extends the envelope with a
+/// Same as [`json()`] but extends the envelope with a
 /// `suggested_ignores` array. Each element is `{ "rule_id": …,
 /// "selector": … }`, sorted by `(rule_id, selector)`.
 ///

--- a/crates/plumb-format/src/lib.rs
+++ b/crates/plumb-format/src/lib.rs
@@ -14,6 +14,11 @@
 //! - [`sarif_with_rules`] — SARIF 2.1.0 for GitHub code-scanning and IDEs.
 //! - [`mcp_compact`] — token-efficient output for the MCP server; returns
 //!   a `(text, structured)` pair matching PRD §14.2.
+//!
+//! [`pretty_with_suggested_ignores`] and [`json_with_suggested_ignores`]
+//! extend the `pretty` and `json` shapes with a `.plumbignore` proposal
+//! derived from the current violations. `plumb lint --suggest-ignores`
+//! routes through them.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -160,6 +165,107 @@ pub fn json(violations: &[Violation]) -> Result<String, serde_json::Error> {
     envelope.insert("summary".to_owned(), stats["counts"].clone());
     envelope.insert("violations".to_owned(), serde_json::to_value(&sorted)?);
     serde_json::to_string_pretty(&Value::Object(envelope))
+}
+
+/// Compute the deterministic list of `(rule_id, selector)` ignore
+/// suggestions for a violations slice.
+///
+/// Each unique pair surfaces exactly once. The list is sorted by
+/// `(rule_id, selector)` so two runs with the same violations produce
+/// byte-identical output. Used by [`pretty_with_suggested_ignores`] and
+/// [`json_with_suggested_ignores`] and re-exported for callers that
+/// need the raw pairs.
+#[must_use]
+pub fn suggested_ignores(violations: &[Violation]) -> Vec<(String, String)> {
+    let mut pairs: BTreeSet<(String, String)> = BTreeSet::new();
+    for v in violations {
+        pairs.insert((v.rule_id.clone(), v.selector.clone()));
+    }
+    pairs.into_iter().collect()
+}
+
+/// Render a pretty block followed by a suggested `.plumbignore` footer.
+///
+/// The footer contains one line per `(rule_id, selector)` tuple that
+/// would suppress a current violation, sorted by `(rule_id, selector)`.
+/// Two header lines describe the format. When `violations` is empty the
+/// footer reads `(no violations)` and lists no entries.
+#[must_use]
+pub fn pretty_with_suggested_ignores(violations: &[Violation]) -> String {
+    let mut out = pretty(violations);
+    append_suggested_ignores_block(&mut out, violations);
+    out
+}
+
+/// Same as [`json`] but extends the envelope with a
+/// `suggested_ignores` array. Each element is `{ "rule_id": …,
+/// "selector": … }`, sorted by `(rule_id, selector)`.
+///
+/// # Errors
+///
+/// Returns an error if serialization fails.
+pub fn json_with_suggested_ignores(violations: &[Violation]) -> Result<String, serde_json::Error> {
+    let sorted = canonical_sorted(violations);
+
+    let run_id = run_id_for_sorted(&sorted)?;
+    let stats = stats_json(&sorted, &run_id);
+    let suggestions = suggested_ignores_json(violations);
+
+    let mut envelope = serde_json::Map::new();
+    envelope.insert(
+        "plumb_version".to_owned(),
+        Value::String(PLUMB_VERSION.to_owned()),
+    );
+    envelope.insert("run_id".to_owned(), Value::String(run_id));
+    envelope.insert("stats".to_owned(), stats.clone());
+    envelope.insert("suggested_ignores".to_owned(), suggestions);
+    envelope.insert("summary".to_owned(), stats["counts"].clone());
+    envelope.insert("violations".to_owned(), serde_json::to_value(&sorted)?);
+    serde_json::to_string_pretty(&Value::Object(envelope))
+}
+
+fn suggested_ignores_json(violations: &[Violation]) -> Value {
+    let pairs = suggested_ignores(violations);
+    let entries: Vec<Value> = pairs
+        .into_iter()
+        .map(|(rule_id, selector)| {
+            // Build each entry with alphabetically ordered keys so the
+            // output is stable regardless of `serde_json`'s
+            // `preserve_order` feature toggle.
+            let mut map = serde_json::Map::new();
+            map.insert("rule_id".to_owned(), Value::String(rule_id));
+            map.insert("selector".to_owned(), Value::String(selector));
+            Value::Object(map)
+        })
+        .collect();
+    Value::Array(entries)
+}
+
+fn append_suggested_ignores_block(out: &mut String, violations: &[Violation]) {
+    let pairs = suggested_ignores(violations);
+
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    let _ = writeln!(
+        out,
+        "Suggested .plumbignore (would suppress {count} {noun}):",
+        count = violations.len(),
+        noun = if violations.len() == 1 {
+            "violation"
+        } else {
+            "violations"
+        },
+    );
+    out.push_str("# Format: <rule_id> <selector_path>\n");
+    if pairs.is_empty() {
+        out.push_str("# (no violations)\n");
+    } else {
+        for (rule_id, selector) in pairs {
+            let _ = writeln!(out, "{rule_id} {selector}");
+        }
+    }
 }
 
 /// Hex-alphabet table used by [`hex_digest`].
@@ -486,4 +592,115 @@ fn append_pretty_stats(out: &mut String, violations: &[Violation], run_id: &str)
     let _ = writeln!(out, "  {}", summary_line(violations));
     let _ = writeln!(out, "  viewport_count: {viewport_count}");
     let _ = writeln!(out, "  rule_count: {rule_count}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{json_with_suggested_ignores, pretty_with_suggested_ignores, suggested_ignores};
+    use indexmap::IndexMap;
+    use plumb_core::{Severity, ViewportKey, Violation};
+
+    fn violation(rule_id: &str, selector: &str, viewport: &str, dom_order: u64) -> Violation {
+        Violation {
+            rule_id: rule_id.to_owned(),
+            severity: Severity::Warning,
+            message: "test".to_owned(),
+            selector: selector.to_owned(),
+            viewport: ViewportKey::new(viewport),
+            rect: None,
+            dom_order,
+            fix: None,
+            doc_url: format!(
+                "https://plumb.aramhammoudeh.com/rules/{}",
+                rule_id.replace('/', "-")
+            ),
+            metadata: IndexMap::new(),
+        }
+    }
+
+    #[test]
+    fn suggested_ignores_dedupes_across_viewports() {
+        // The same `(rule_id, selector)` pair fires on two viewports;
+        // the suggested-ignores list collapses it to one entry.
+        let v = vec![
+            violation("spacing/grid-conformance", "body", "desktop", 1),
+            violation("spacing/grid-conformance", "body", "mobile", 1),
+        ];
+        let pairs = suggested_ignores(&v);
+        assert_eq!(
+            pairs,
+            vec![("spacing/grid-conformance".to_owned(), "body".to_owned())]
+        );
+    }
+
+    #[test]
+    fn suggested_ignores_sorts_by_rule_then_selector() {
+        // Input is intentionally unsorted; output MUST be sorted by
+        // `(rule_id, selector)` for byte-identical determinism.
+        let v = vec![
+            violation("spacing/grid-conformance", ".footer", "desktop", 3),
+            violation("color/palette-conformance", "#cta", "desktop", 1),
+            violation("spacing/grid-conformance", ".header", "desktop", 2),
+        ];
+        let pairs = suggested_ignores(&v);
+        assert_eq!(
+            pairs,
+            vec![
+                ("color/palette-conformance".to_owned(), "#cta".to_owned()),
+                ("spacing/grid-conformance".to_owned(), ".footer".to_owned()),
+                ("spacing/grid-conformance".to_owned(), ".header".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn suggested_ignores_empty_for_no_violations() {
+        assert!(suggested_ignores(&[]).is_empty());
+    }
+
+    #[test]
+    fn pretty_with_suggested_ignores_appends_block() {
+        let v = vec![violation("spacing/grid-conformance", "body", "desktop", 1)];
+        let out = pretty_with_suggested_ignores(&v);
+        assert!(out.contains("Suggested .plumbignore (would suppress 1 violation):"));
+        assert!(out.contains("# Format: <rule_id> <selector_path>"));
+        assert!(out.contains("spacing/grid-conformance body"));
+    }
+
+    #[test]
+    fn pretty_with_suggested_ignores_handles_empty() {
+        let out = pretty_with_suggested_ignores(&[]);
+        assert!(out.contains("Suggested .plumbignore (would suppress 0 violations):"));
+        assert!(out.contains("(no violations)"));
+    }
+
+    #[test]
+    fn json_with_suggested_ignores_emits_sorted_array() {
+        let v = vec![
+            violation("spacing/grid-conformance", ".footer", "desktop", 3),
+            violation("color/palette-conformance", "#cta", "desktop", 1),
+        ];
+        let raw = json_with_suggested_ignores(&v).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("envelope is valid JSON");
+        let arr = parsed
+            .get("suggested_ignores")
+            .and_then(|v| v.as_array())
+            .expect("suggested_ignores array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["rule_id"], "color/palette-conformance");
+        assert_eq!(arr[0]["selector"], "#cta");
+        assert_eq!(arr[1]["rule_id"], "spacing/grid-conformance");
+        assert_eq!(arr[1]["selector"], ".footer");
+    }
+
+    #[test]
+    fn json_with_suggested_ignores_is_byte_deterministic() {
+        let v = vec![
+            violation("spacing/grid-conformance", ".header", "mobile", 1),
+            violation("color/palette-conformance", "#cta", "desktop", 1),
+        ];
+        let a = json_with_suggested_ignores(&v).expect("serialize a");
+        let b = json_with_suggested_ignores(&v).expect("serialize b");
+        assert_eq!(a, b);
+    }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 # Using Plumb
 
 - [CLI](./cli.md)
+  - [`--suggest-ignores`](./cli/suggest-ignores.md)
 - [MCP server](./mcp.md)
   - [Claude Code](./mcp/claude.md)
   - [Cursor](./mcp/cursor.md)

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -29,6 +29,7 @@ major version falls in Plumb's supported range (see
 | `--disable-animations [bool]` | CSS animation/transition killer. Default `true`. |
 | `--hide-scrollbars [bool]` | CSS scrollbar killer. Default `true`. |
 | `--dpr <factor>` | Pin device-pixel ratio for `Emulation.setDeviceMetricsOverride`. |
+| `--suggest-ignores` | Append a suggested `.plumbignore` block. See [`--suggest-ignores`](./cli/suggest-ignores.md). |
 
 Exit codes:
 

--- a/docs/src/cli/suggest-ignores.md
+++ b/docs/src/cli/suggest-ignores.md
@@ -1,0 +1,88 @@
+# `--suggest-ignores`
+
+`plumb lint --suggest-ignores` appends a suggested `.plumbignore` block
+after the normal lint output. The block lists one entry per
+`(rule_id, selector_path)` tuple that would suppress every current
+violation, sorted by `(rule_id, selector_path)` for byte-identical
+output across runs.
+
+The flag is opt-in. Default behavior is unchanged.
+
+## Why
+
+Plumb is most useful on a brownfield codebase, but a 200-violation
+first run is too noisy to action. `--suggest-ignores` produces a
+ready-made starter ignore file: paste it into `.plumbignore`, fix the
+violations as a follow-up, and remove entries one by one.
+
+## Pretty format
+
+```text
+$ plumb lint plumb-fake://hello --suggest-ignores
+desktop
+  spacing/grid-conformance
+    html > body
+      warning: `html > body` has off-grid padding-top 13px; expected a multiple of 4px.
+      ...
+
+stats
+  ...
+
+Suggested .plumbignore (would suppress 1 violation):
+# Format: <rule_id> <selector_path>
+spacing/grid-conformance html > body
+```
+
+The footer prints after the existing `stats` block, separated by a
+blank line.
+
+## JSON format
+
+`--format json --suggest-ignores` adds a `suggested_ignores` array to
+the existing envelope:
+
+```json
+{
+  "plumb_version": "0.0.1",
+  "run_id": "sha256:…",
+  "stats": { … },
+  "suggested_ignores": [
+    { "rule_id": "color/palette-conformance", "selector": "#cta" },
+    { "rule_id": "spacing/grid-conformance", "selector": "html > body" }
+  ],
+  "summary": { … },
+  "violations": [ … ]
+}
+```
+
+Entries are sorted by `(rule_id, selector)`. The `run_id` and
+`violations` fields are unchanged — toggling `--suggest-ignores` MUST
+NOT shift the run digest.
+
+## SARIF
+
+The SARIF formatter ignores `--suggest-ignores`. SARIF 2.1.0 has no
+canonical slot for ignore suggestions, and consumers (GitHub Code
+Scanning, IDE plugins) parse the schema strictly. Use the JSON output
+for tooling that wants the suggestions.
+
+## File format
+
+The suggested footer follows a deliberately minimal grammar:
+
+```text
+# Format: <rule_id> <selector_path>
+spacing/grid-conformance .header
+spacing/grid-conformance .footer .copyright
+color/palette-conformance #cta-button
+```
+
+One entry per line, two whitespace-separated fields:
+
+- `<rule_id>` — slash-separated rule identifier (e.g.
+  `spacing/grid-conformance`).
+- `<selector_path>` — the CSS selector path Plumb attached to the
+  violation.
+
+Lines beginning with `#` are comments. Trailing whitespace is
+insignificant.


### PR DESCRIPTION
## Summary

- Adds `plumb lint --suggest-ignores`, a default-off flag that appends a suggested `.plumbignore` block to the rendered output.
- Pretty format appends a footer listing one line per `(rule_id, selector)` tuple. JSON format adds a `suggested_ignores` array to the envelope. SARIF intentionally ignores the flag.
- Output is sorted by `(rule_id, selector)` and the JSON `run_id` is unchanged, so determinism holds whether the flag is on or off.

Closes #84.

## Test plan

- [x] `cargo test --workspace --all-features` (4 new CLI integration tests + 7 new plumb-format unit tests, all green)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `just determinism-check` (3 runs of `lint --format json` byte-identical)
- [x] Manual: `lint --format json --suggest-ignores` 3-run byte-diff also identical
- [x] `cargo deny check`
- [x] `mdbook build` + `cargo doc --workspace --no-deps`
- [x] `just validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)