### PR TITLE
feat(mcp): compare_viewports tool (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ From the first release onward, this file is maintained automatically by [`releas
 - Initial workspace scaffold, tooling, and walking skeleton.
 - PRD-style `[spacing]` and `[type]` config sections with schema validation.
 - `plumb mcp` `lint_url` now accepts an optional `detail` argument. The default `compact` mode preserves the existing MCP payload, while `detail: "full"` returns the canonical full JSON envelope and rejects structured payloads above 50 KB.
+- `plumb mcp` `compare_viewports`: capture snapshots at two-or-more viewports of the same URL and return a deterministic per-node delta (missing nodes, size changes above a configurable pixel threshold, document-order reorderings, computed-style differences). Aggregate counts plus a 200-entry capped diff list keep `structuredContent` under the 10 KB budget.
 - `plumb mcp` now exposes a `plumb://config` resource that returns the resolved `plumb.toml` for the server working directory as JSON.
 - Rule `spacing/grid-conformance`: flags `margin-*`, `padding-*`, `gap`, `row-gap`, and `column-gap` values that aren't multiples of `spacing.base_unit`.
 - Rule `spacing/scale-conformance`: flags the same property set when values aren't members of `spacing.scale`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,6 +1941,7 @@ name = "plumb-mcp"
 version = "0.0.1"
 dependencies = [
  "axum",
+ "indexmap",
  "plumb-cdp",
  "plumb-config",
  "plumb-core",

--- a/crates/plumb-cli/tests/mcp_stdio.rs
+++ b/crates/plumb-cli/tests/mcp_stdio.rs
@@ -162,6 +162,7 @@ fn mcp_initialize_and_tools_list() {
     assert!(names.contains(&"explain_rule"));
     assert!(names.contains(&"list_rules"));
     assert!(names.contains(&"get_config"));
+    assert!(names.contains(&"compare_viewports"));
 
     let echo = tools
         .iter()
@@ -528,4 +529,108 @@ fn mcp_list_rules_returns_every_rule() {
         .as_str()
         .expect("first rule must carry an id string");
     assert!(!first_id.is_empty(), "rule id must not be empty");
+}
+
+fn compare_viewports_request(id: u32, url: &str, viewports: &[Value]) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "compare_viewports",
+            "arguments": { "url": url, "viewports": viewports }
+        }
+    })
+}
+
+#[test]
+fn mcp_compare_viewports_happy_path_returns_structured_payload() {
+    let viewports = vec![
+        json!({ "name": "mobile", "width": 375, "height": 800, "dpr": 2.0 }),
+        json!({ "name": "desktop", "width": 1280, "height": 800, "dpr": 1.0 }),
+    ];
+    let request = compare_viewports_request(2, "plumb-fake://hello", &viewports);
+    let responses = send_and_read(vec![init_request(1), initialized_notification(), request]);
+
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("compare_viewports response missing: got {responses:?}"));
+    let result = &resp["result"];
+
+    assert_eq!(result["isError"].as_bool(), Some(false));
+
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    assert!(
+        text.starts_with("compare_viewports plumb-fake://hello across 2 viewports"),
+        "unexpected compare_viewports text: {text}"
+    );
+
+    let structured = result["structuredContent"]
+        .as_object()
+        .expect("structuredContent object");
+    assert_eq!(structured["url"].as_str(), Some("plumb-fake://hello"));
+    assert_eq!(structured["size_threshold_px"].as_u64(), Some(4));
+    let viewports = structured["viewports"].as_array().expect("viewports array");
+    assert_eq!(viewports.len(), 2);
+    assert_eq!(viewports[0].as_str(), Some("mobile"));
+    assert_eq!(viewports[1].as_str(), Some("desktop"));
+
+    assert_eq!(structured["summary"]["total"].as_u64(), Some(0));
+    assert_eq!(
+        structured["diffs"].as_array().map(std::vec::Vec::is_empty),
+        Some(true),
+        "identical canned snapshots produce zero diffs"
+    );
+    assert_eq!(structured["truncated"].as_bool(), Some(false));
+}
+
+#[test]
+fn mcp_compare_viewports_rejects_single_viewport() {
+    let viewports = vec![json!({ "name": "desktop", "width": 1280, "height": 800, "dpr": 1.0 })];
+    let request = compare_viewports_request(2, "plumb-fake://hello", &viewports);
+    let responses = send_and_read(vec![init_request(1), initialized_notification(), request]);
+
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == 2)
+        .unwrap_or_else(|| panic!("compare_viewports error response missing: got {responses:?}"));
+    let error = resp["error"].as_object().expect("error object");
+    assert_eq!(error["code"].as_i64(), Some(-32602));
+    let message = error["message"].as_str().expect("error message");
+    assert!(
+        message.contains("at least 2 viewports"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn mcp_compare_viewports_response_is_byte_identical_across_runs() {
+    let viewports = vec![
+        json!({ "name": "mobile", "width": 375, "height": 800, "dpr": 2.0 }),
+        json!({ "name": "desktop", "width": 1280, "height": 800, "dpr": 1.0 }),
+    ];
+    let r1 = compare_viewports_request(2, "plumb-fake://hello", &viewports);
+    let r2 = compare_viewports_request(3, "plumb-fake://hello", &viewports);
+    let r3 = compare_viewports_request(4, "plumb-fake://hello", &viewports);
+    let responses = send_and_read(vec![
+        init_request(1),
+        initialized_notification(),
+        r1,
+        r2,
+        r3,
+    ]);
+    let payloads: Vec<&Value> = (2..=4)
+        .map(|id| {
+            responses.iter().find(|r| r["id"] == id).map_or_else(
+                || panic!("compare_viewports response {id} missing"),
+                |r| &r["result"]["structuredContent"],
+            )
+        })
+        .collect();
+    let s0 = serde_json::to_string(payloads[0]).expect("serialize 0");
+    let s1 = serde_json::to_string(payloads[1]).expect("serialize 1");
+    let s2 = serde_json::to_string(payloads[2]).expect("serialize 2");
+    assert_eq!(s0, s1, "compare_viewports output must be deterministic");
+    assert_eq!(s1, s2, "compare_viewports output must be deterministic");
 }

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -33,6 +33,7 @@ subtle = { workspace = true }
 [dev-dependencies]
 plumb-core = { workspace = true, features = ["test-fake"] }
 tokio = { workspace = true, features = ["test-util"] }
+indexmap = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plumb-mcp/src/compare_viewports.rs
+++ b/crates/plumb-mcp/src/compare_viewports.rs
@@ -1,0 +1,658 @@
+//! Pure deterministic viewport-comparison for the `compare_viewports` MCP tool.
+//!
+//! Given two or more [`PlumbSnapshot`]s of the same URL captured at
+//! different viewports, this module produces a sorted list of
+//! per-node diffs: nodes missing on one side, size changes that exceed
+//! a configurable pixel threshold, document-order reordering, and
+//! computed-style differences.
+//!
+//! No I/O, no async, no wall-clock. The output is a pure function of
+//! the inputs and is byte-identical across runs.
+
+// Items are intentionally `pub(crate)` so the parent `lib.rs` can
+// invoke them. The module is private; `unreachable_pub` would flag
+// these without the explicit visibility, and clippy's
+// `redundant_pub_crate` would flag the visibility as redundant. We
+// match the pattern used in `explain.rs`.
+#![allow(clippy::redundant_pub_crate)]
+
+use std::collections::BTreeMap;
+
+use plumb_core::PlumbSnapshot;
+use plumb_core::snapshot::SnapshotNode;
+use serde::Serialize;
+use serde_json::Value;
+
+/// Default pixel threshold for size-change diffs.
+///
+/// A node is reported as "size changed" only when either its width or
+/// its height differs by more than this many CSS pixels between two
+/// viewports. Sub-pixel reflows from font metrics or rounding fall
+/// below the threshold by design.
+pub(crate) const DEFAULT_SIZE_THRESHOLD_PX: u32 = 4;
+
+/// Hard cap on the number of diff entries returned in
+/// `structuredContent`. Aggregation happens server-side: the payload
+/// always reports the full counts in `summary`, but the `diffs` list
+/// is capped to keep agents under the 10 KB structured-content budget.
+const DIFF_ENTRY_CAP: usize = 200;
+
+/// Computed-style properties tracked for cross-viewport diffs.
+///
+/// Limited to the set with the highest signal-to-noise for
+/// mobile/desktop regressions. Adding properties here grows the diff
+/// payload, so any addition needs to be justified against the 10 KB
+/// budget.
+const TRACKED_STYLE_PROPERTIES: &[&str] = &[
+    "display",
+    "flex-direction",
+    "grid-template-columns",
+    "font-size",
+    "color",
+    "background-color",
+    "visibility",
+    "position",
+];
+
+/// Kind of diff entry. Encoded as a discriminator string so JSON
+/// consumers can switch on it without parsing field combinations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum DiffKind {
+    /// Node exists in some viewports but not others.
+    Missing,
+    /// Node bounding-box size changed by more than the threshold.
+    SizeChange,
+    /// Node `dom_order` differs across viewports.
+    Reordered,
+    /// One of the tracked computed-style properties differs.
+    StyleChange,
+}
+
+impl DiffKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::SizeChange => "size_change",
+            Self::Reordered => "reordered",
+            Self::StyleChange => "style_change",
+        }
+    }
+}
+
+/// Aggregate counts shown to the caller alongside the diff list.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub(crate) struct DiffSummary {
+    /// Total number of diff entries discovered (before capping).
+    pub(crate) total: usize,
+    /// Nodes present in some viewports but missing in others.
+    pub(crate) missing: usize,
+    /// Nodes whose bounding box differs above the threshold.
+    pub(crate) size_changes: usize,
+    /// Nodes whose `dom_order` differs across viewports.
+    pub(crate) reordered: usize,
+    /// Nodes whose tracked computed styles differ.
+    pub(crate) style_changes: usize,
+}
+
+/// A single diff entry. Field availability depends on `kind`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DiffEntry {
+    kind: DiffKind,
+    selector: String,
+    /// Property name for `StyleChange`, otherwise empty.
+    property: String,
+    /// Viewports the node is present in (for `Missing`); both
+    /// viewports for binary diffs (otherwise sorted).
+    present_in: Vec<String>,
+    absent_in: Vec<String>,
+    viewport_a: String,
+    viewport_b: String,
+    value_a: String,
+    value_b: String,
+    width_a: u32,
+    height_a: u32,
+    width_b: u32,
+    height_b: u32,
+    delta_px: u32,
+    dom_order_a: u64,
+    dom_order_b: u64,
+}
+
+impl DiffEntry {
+    fn into_json(self) -> Value {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            Value::String(self.kind.as_str().to_string()),
+        );
+        map.insert("selector".to_string(), Value::String(self.selector));
+        match self.kind {
+            DiffKind::Missing => {
+                map.insert(
+                    "present_in".to_string(),
+                    Value::Array(self.present_in.into_iter().map(Value::String).collect()),
+                );
+                map.insert(
+                    "absent_in".to_string(),
+                    Value::Array(self.absent_in.into_iter().map(Value::String).collect()),
+                );
+            }
+            DiffKind::SizeChange => {
+                map.insert("viewport_a".to_string(), Value::String(self.viewport_a));
+                map.insert("viewport_b".to_string(), Value::String(self.viewport_b));
+                map.insert("width_a".to_string(), Value::Number(self.width_a.into()));
+                map.insert("height_a".to_string(), Value::Number(self.height_a.into()));
+                map.insert("width_b".to_string(), Value::Number(self.width_b.into()));
+                map.insert("height_b".to_string(), Value::Number(self.height_b.into()));
+                map.insert("delta_px".to_string(), Value::Number(self.delta_px.into()));
+            }
+            DiffKind::Reordered => {
+                map.insert("viewport_a".to_string(), Value::String(self.viewport_a));
+                map.insert("viewport_b".to_string(), Value::String(self.viewport_b));
+                map.insert(
+                    "dom_order_a".to_string(),
+                    Value::Number(self.dom_order_a.into()),
+                );
+                map.insert(
+                    "dom_order_b".to_string(),
+                    Value::Number(self.dom_order_b.into()),
+                );
+            }
+            DiffKind::StyleChange => {
+                map.insert("property".to_string(), Value::String(self.property));
+                map.insert("viewport_a".to_string(), Value::String(self.viewport_a));
+                map.insert("viewport_b".to_string(), Value::String(self.viewport_b));
+                map.insert("value_a".to_string(), Value::String(self.value_a));
+                map.insert("value_b".to_string(), Value::String(self.value_b));
+            }
+        }
+        Value::Object(map)
+    }
+}
+
+/// Result of comparing two-or-more snapshots.
+pub(crate) struct CompareResult {
+    /// Aggregate counts (counts every diff, even those clipped by the cap).
+    pub(crate) summary: DiffSummary,
+    /// Sorted diff entries, capped at [`DIFF_ENTRY_CAP`].
+    pub(crate) diffs: Vec<Value>,
+    /// `true` when `summary.total > diffs.len()` — the caller may want
+    /// to surface "+N more" in their text block.
+    pub(crate) truncated: bool,
+}
+
+/// Compare two-or-more snapshots and produce a deterministic delta.
+///
+/// `snapshots` MUST be aligned with `viewport_names` — the i-th entry
+/// describes the i-th viewport. The caller is expected to have already
+/// validated that there are at least two viewports.
+///
+/// Determinism: outputs depend only on the inputs. Ordering is by
+/// `(kind, selector, property, viewport_a, viewport_b)`.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub(crate) fn compare_snapshots(
+    snapshots: &[PlumbSnapshot],
+    viewport_names: &[String],
+    size_threshold_px: u32,
+) -> CompareResult {
+    debug_assert_eq!(snapshots.len(), viewport_names.len());
+
+    // Build per-viewport per-selector indexes. BTreeMap so iteration
+    // is deterministic regardless of node insertion order.
+    let mut by_selector: BTreeMap<&str, Vec<Option<NodeView<'_>>>> = BTreeMap::new();
+    for (i, snap) in snapshots.iter().enumerate() {
+        for node in &snap.nodes {
+            let entry = by_selector.entry(node.selector.as_str()).or_insert_with(
+                || -> Vec<Option<NodeView<'_>>> {
+                    let mut v = Vec::with_capacity(snapshots.len());
+                    for _ in 0..snapshots.len() {
+                        v.push(None);
+                    }
+                    v
+                },
+            );
+            entry[i] = Some(NodeView::from_node(node));
+        }
+    }
+
+    let mut entries: Vec<DiffEntry> = Vec::new();
+    let mut summary = DiffSummary::default();
+
+    for (selector, views) in &by_selector {
+        // Missing-in-viewport detection: any selector not present in at
+        // least one viewport but present in another.
+        let present: Vec<String> = views
+            .iter()
+            .zip(viewport_names.iter())
+            .filter_map(|(view, name)| view.as_ref().map(|_| name.clone()))
+            .collect();
+        let absent: Vec<String> = views
+            .iter()
+            .zip(viewport_names.iter())
+            .filter_map(|(view, name)| match view {
+                None => Some(name.clone()),
+                Some(_) => None,
+            })
+            .collect();
+
+        if !absent.is_empty() {
+            summary.missing += 1;
+            entries.push(DiffEntry {
+                kind: DiffKind::Missing,
+                selector: (*selector).to_string(),
+                present_in: present.clone(),
+                absent_in: absent.clone(),
+                ..DiffEntry::blank()
+            });
+            // Skip downstream binary comparisons for this selector
+            // when it isn't present in every viewport — the missing
+            // entry already captures the divergence.
+            continue;
+        }
+
+        // Pairwise comparison against viewport 0 (the "baseline").
+        // For 2 viewports this collapses to a single A↔B comparison.
+        // For N viewports it keeps the diff count linear in N rather
+        // than quadratic.
+        let baseline_idx = 0_usize;
+        let Some(baseline) = views[baseline_idx].as_ref() else {
+            continue;
+        };
+
+        for (i, other) in views.iter().enumerate().skip(1) {
+            let Some(other) = other.as_ref() else {
+                continue;
+            };
+
+            // Reorder
+            if baseline.dom_order != other.dom_order {
+                summary.reordered += 1;
+                entries.push(DiffEntry {
+                    kind: DiffKind::Reordered,
+                    selector: (*selector).to_string(),
+                    viewport_a: viewport_names[baseline_idx].clone(),
+                    viewport_b: viewport_names[i].clone(),
+                    dom_order_a: baseline.dom_order,
+                    dom_order_b: other.dom_order,
+                    ..DiffEntry::blank()
+                });
+            }
+
+            // Size change
+            if let (Some(a), Some(b)) = (baseline.size, other.size) {
+                let dw = a.0.abs_diff(b.0);
+                let dh = a.1.abs_diff(b.1);
+                let delta = dw.max(dh);
+                if delta > size_threshold_px {
+                    summary.size_changes += 1;
+                    entries.push(DiffEntry {
+                        kind: DiffKind::SizeChange,
+                        selector: (*selector).to_string(),
+                        viewport_a: viewport_names[baseline_idx].clone(),
+                        viewport_b: viewport_names[i].clone(),
+                        width_a: a.0,
+                        height_a: a.1,
+                        width_b: b.0,
+                        height_b: b.1,
+                        delta_px: delta,
+                        ..DiffEntry::blank()
+                    });
+                }
+            }
+
+            // Style changes — only over the tracked property allowlist.
+            for property in TRACKED_STYLE_PROPERTIES {
+                let value_a = baseline.style(property);
+                let value_b = other.style(property);
+                if value_a != value_b
+                    && let (Some(va), Some(vb)) = (value_a, value_b)
+                {
+                    summary.style_changes += 1;
+                    entries.push(DiffEntry {
+                        kind: DiffKind::StyleChange,
+                        selector: (*selector).to_string(),
+                        property: (*property).to_string(),
+                        viewport_a: viewport_names[baseline_idx].clone(),
+                        viewport_b: viewport_names[i].clone(),
+                        value_a: va.to_string(),
+                        value_b: vb.to_string(),
+                        ..DiffEntry::blank()
+                    });
+                }
+            }
+        }
+    }
+
+    summary.total =
+        summary.missing + summary.size_changes + summary.reordered + summary.style_changes;
+
+    entries.sort();
+
+    let truncated = entries.len() > DIFF_ENTRY_CAP;
+    if truncated {
+        entries.truncate(DIFF_ENTRY_CAP);
+    }
+
+    let diffs: Vec<Value> = entries.into_iter().map(DiffEntry::into_json).collect();
+
+    CompareResult {
+        summary,
+        diffs,
+        truncated,
+    }
+}
+
+#[derive(Debug)]
+struct NodeView<'a> {
+    dom_order: u64,
+    size: Option<(u32, u32)>,
+    node: &'a SnapshotNode,
+}
+
+impl<'a> NodeView<'a> {
+    fn from_node(node: &'a SnapshotNode) -> Self {
+        Self {
+            dom_order: node.dom_order,
+            size: node.rect.map(|r| (r.width, r.height)),
+            node,
+        }
+    }
+
+    fn style(&self, property: &str) -> Option<&str> {
+        self.node.computed_styles.get(property).map(String::as_str)
+    }
+}
+
+impl DiffEntry {
+    fn blank() -> Self {
+        Self {
+            kind: DiffKind::Missing,
+            selector: String::new(),
+            property: String::new(),
+            present_in: Vec::new(),
+            absent_in: Vec::new(),
+            viewport_a: String::new(),
+            viewport_b: String::new(),
+            value_a: String::new(),
+            value_b: String::new(),
+            width_a: 0,
+            height_a: 0,
+            width_b: 0,
+            height_b: 0,
+            delta_px: 0,
+            dom_order_a: 0,
+            dom_order_b: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use indexmap::IndexMap;
+    use plumb_core::snapshot::SnapshotNode;
+    use plumb_core::{PlumbSnapshot, Rect, ViewportKey};
+
+    use super::*;
+
+    fn snap(viewport: &str, width: u32, nodes: Vec<SnapshotNode>) -> PlumbSnapshot {
+        PlumbSnapshot {
+            url: "plumb-fake://hello".into(),
+            viewport: ViewportKey::new(viewport),
+            viewport_width: width,
+            viewport_height: 800,
+            nodes,
+            text_boxes: Vec::new(),
+        }
+    }
+
+    fn node(
+        dom_order: u64,
+        selector: &str,
+        rect: Option<Rect>,
+        styles: &[(&str, &str)],
+    ) -> SnapshotNode {
+        let mut computed = IndexMap::new();
+        for (k, v) in styles {
+            computed.insert((*k).to_string(), (*v).to_string());
+        }
+        SnapshotNode {
+            dom_order,
+            selector: selector.into(),
+            tag: selector
+                .rsplit_once('>')
+                .map_or_else(|| selector.to_string(), |(_, tail)| tail.trim().to_string()),
+            attrs: IndexMap::new(),
+            computed_styles: computed,
+            rect,
+            parent: None,
+            children: Vec::new(),
+        }
+    }
+
+    fn rect(w: u32, h: u32) -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn identical_snapshots_yield_no_diffs() {
+        let a = snap(
+            "mobile",
+            375,
+            vec![
+                node(0, "html", Some(rect(375, 800)), &[]),
+                node(1, "html > body", Some(rect(375, 800)), &[("color", "red")]),
+            ],
+        );
+        let b = snap(
+            "desktop",
+            1280,
+            vec![
+                node(0, "html", Some(rect(375, 800)), &[]),
+                node(1, "html > body", Some(rect(375, 800)), &[("color", "red")]),
+            ],
+        );
+        let result = compare_snapshots(
+            &[a, b],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        assert_eq!(result.summary.total, 0);
+        assert!(result.diffs.is_empty());
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn missing_node_at_one_viewport_emits_missing_diff() {
+        let mobile = snap(
+            "mobile",
+            375,
+            vec![node(0, "html", Some(rect(375, 800)), &[])],
+        );
+        let desktop = snap(
+            "desktop",
+            1280,
+            vec![
+                node(0, "html", Some(rect(1280, 800)), &[]),
+                node(1, "html > nav", Some(rect(1280, 60)), &[]),
+            ],
+        );
+        let result = compare_snapshots(
+            &[mobile, desktop],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        // One missing (nav) + one size change (html) — html went from
+        // 375 wide to 1280 wide.
+        assert_eq!(result.summary.missing, 1);
+        assert!(
+            result
+                .diffs
+                .iter()
+                .any(|d| d["kind"].as_str() == Some("missing"))
+        );
+        let missing = result
+            .diffs
+            .iter()
+            .find(|d| d["kind"] == "missing")
+            .unwrap();
+        assert_eq!(missing["selector"], "html > nav");
+        assert_eq!(missing["present_in"], serde_json::json!(["desktop"]));
+        assert_eq!(missing["absent_in"], serde_json::json!(["mobile"]));
+    }
+
+    #[test]
+    fn size_change_below_threshold_is_ignored() {
+        let mobile = snap(
+            "mobile",
+            375,
+            vec![node(0, "html > body", Some(rect(100, 100)), &[])],
+        );
+        let desktop = snap(
+            "desktop",
+            1280,
+            vec![node(0, "html > body", Some(rect(102, 100)), &[])],
+        );
+        let result = compare_snapshots(
+            &[mobile, desktop],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        assert_eq!(result.summary.size_changes, 0);
+    }
+
+    #[test]
+    fn size_change_above_threshold_is_reported() {
+        let mobile = snap(
+            "mobile",
+            375,
+            vec![node(0, "html > body", Some(rect(100, 100)), &[])],
+        );
+        let desktop = snap(
+            "desktop",
+            1280,
+            vec![node(0, "html > body", Some(rect(200, 100)), &[])],
+        );
+        let result = compare_snapshots(
+            &[mobile, desktop],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        assert_eq!(result.summary.size_changes, 1);
+        let entry = &result.diffs[0];
+        assert_eq!(entry["kind"], "size_change");
+        assert_eq!(entry["delta_px"], 100);
+    }
+
+    #[test]
+    fn dom_reorder_is_reported() {
+        let mobile = snap(
+            "mobile",
+            375,
+            vec![
+                node(0, "html > body > a", Some(rect(50, 30)), &[]),
+                node(1, "html > body > b", Some(rect(50, 30)), &[]),
+            ],
+        );
+        let desktop = snap(
+            "desktop",
+            1280,
+            vec![
+                node(0, "html > body > b", Some(rect(50, 30)), &[]),
+                node(1, "html > body > a", Some(rect(50, 30)), &[]),
+            ],
+        );
+        let result = compare_snapshots(
+            &[mobile, desktop],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        assert_eq!(result.summary.reordered, 2);
+    }
+
+    #[test]
+    fn style_change_on_tracked_property_is_reported() {
+        let mobile = snap(
+            "mobile",
+            375,
+            vec![node(
+                0,
+                "html > body",
+                Some(rect(375, 800)),
+                &[("display", "block")],
+            )],
+        );
+        let desktop = snap(
+            "desktop",
+            1280,
+            vec![node(
+                0,
+                "html > body",
+                Some(rect(375, 800)),
+                &[("display", "flex")],
+            )],
+        );
+        let result = compare_snapshots(
+            &[mobile, desktop],
+            &["mobile".into(), "desktop".into()],
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        assert_eq!(result.summary.style_changes, 1);
+        let entry = &result.diffs[0];
+        assert_eq!(entry["kind"], "style_change");
+        assert_eq!(entry["property"], "display");
+        assert_eq!(entry["value_a"], "block");
+        assert_eq!(entry["value_b"], "flex");
+    }
+
+    #[test]
+    fn output_is_byte_identical_across_runs() {
+        let a = snap(
+            "mobile",
+            375,
+            vec![
+                node(0, "html", Some(rect(375, 800)), &[]),
+                node(1, "html > body", Some(rect(375, 800)), &[("color", "red")]),
+                node(2, "html > body > nav", Some(rect(375, 60)), &[]),
+            ],
+        );
+        let b = snap(
+            "desktop",
+            1280,
+            vec![
+                node(0, "html", Some(rect(1280, 800)), &[]),
+                node(
+                    1,
+                    "html > body",
+                    Some(rect(1280, 800)),
+                    &[("color", "blue")],
+                ),
+            ],
+        );
+
+        let viewport_names = vec!["mobile".to_string(), "desktop".to_string()];
+        let r1 = compare_snapshots(
+            &[a.clone(), b.clone()],
+            &viewport_names,
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        let r2 = compare_snapshots(
+            &[a.clone(), b.clone()],
+            &viewport_names,
+            DEFAULT_SIZE_THRESHOLD_PX,
+        );
+        let r3 = compare_snapshots(&[a, b], &viewport_names, DEFAULT_SIZE_THRESHOLD_PX);
+        let s1 = serde_json::to_string(&r1.diffs).unwrap();
+        let s2 = serde_json::to_string(&r2.diffs).unwrap();
+        let s3 = serde_json::to_string(&r3.diffs).unwrap();
+        assert_eq!(s1, s2);
+        assert_eq!(s2, s3);
+    }
+}

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -16,6 +16,10 @@
 //!   severity, and one-line summary.
 //! - `get_config` — resolves `plumb.toml` for a given working directory
 //!   and returns the [`Config`] as JSON. Memoized per `(path, mtime)`.
+//! - `compare_viewports` — captures snapshots at two-or-more viewports
+//!   and returns a deterministic diff (missing nodes, size changes,
+//!   reorderings, computed-style changes). 10 KB structuredContent
+//!   budget; aggregate counts plus a capped diff list.
 //!
 //! The [`PlumbServer`] type implements [`rmcp::ServerHandler`] directly.
 //! Extend it by adding a tool descriptor to `list_tools` and a matching
@@ -26,6 +30,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+mod compare_viewports;
 mod explain;
 
 #[doc(hidden)]
@@ -151,6 +156,33 @@ pub struct GetConfigArgs {
     /// The tool resolves `<working_dir>/plumb.toml` deterministically;
     /// it never reads the process current directory.
     pub working_dir: String,
+}
+
+/// One viewport definition for the `compare_viewports` tool.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct CompareViewport {
+    /// Stable name (echoed back in the response under `viewports`).
+    pub name: String,
+    /// Viewport width in CSS pixels.
+    pub width: u32,
+    /// Viewport height in CSS pixels.
+    pub height: u32,
+    /// Device pixel ratio (e.g. 1.0 for desktop, 2.0 for retina).
+    pub dpr: f32,
+}
+
+/// Arguments to the `compare_viewports` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CompareViewportsArgs {
+    /// URL to capture. Accepts `http(s)://` and `plumb-fake://` URLs.
+    pub url: String,
+    /// Two-or-more viewports to capture. The first viewport acts as
+    /// the diff baseline; later viewports are compared against it.
+    pub viewports: Vec<CompareViewport>,
+    /// Pixel threshold above which width/height differences are
+    /// reported. Defaults to 4 px when omitted.
+    #[serde(default)]
+    pub size_threshold_px: Option<u32>,
 }
 
 /// The Plumb MCP server.
@@ -397,6 +429,104 @@ impl PlumbServer {
         Ok(result)
     }
 
+    /// Capture snapshots at two-or-more viewports and return a deterministic
+    /// diff: missing nodes, size changes that exceed `size_threshold_px`,
+    /// document-order reorderings, and computed-style differences.
+    ///
+    /// `plumb-fake://` URLs are served from [`PlumbSnapshot::canned`] without
+    /// warming Chromium. Real URLs share the persistent browser warmed by
+    /// [`PlumbServer::lint_url`].
+    ///
+    /// The structured payload is bounded: the diff list is capped at 200
+    /// entries, and aggregate counts are always reported in `summary`. A
+    /// `truncated` flag signals when entries were clipped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorData::invalid_params`] when fewer than two viewports
+    /// are supplied, when viewport names are non-unique, or when any
+    /// viewport has zero width or height. Driver failures surface as a
+    /// successful response with `is_error = true` and a single text
+    /// content block — never as a JSON-RPC error.
+    pub async fn compare_viewports(
+        &self,
+        args: CompareViewportsArgs,
+    ) -> Result<CallToolResult, ErrorData> {
+        validate_compare_viewports_args(&args)?;
+
+        let viewport_names: Vec<String> = args.viewports.iter().map(|v| v.name.clone()).collect();
+        let snapshots = match self.capture_viewport_snapshots(&args).await {
+            Ok(snaps) => snaps,
+            Err(message) => {
+                return Ok(CallToolResult::error(vec![Content::text(message)]));
+            }
+        };
+
+        let threshold = args
+            .size_threshold_px
+            .unwrap_or(compare_viewports::DEFAULT_SIZE_THRESHOLD_PX);
+        let result = compare_viewports::compare_snapshots(&snapshots, &viewport_names, threshold);
+
+        Ok(build_compare_viewports_result(
+            &args.url,
+            &viewport_names,
+            threshold,
+            result,
+        ))
+    }
+
+    async fn capture_viewport_snapshots(
+        &self,
+        args: &CompareViewportsArgs,
+    ) -> Result<Vec<PlumbSnapshot>, String> {
+        if is_fake_url(&args.url) {
+            // Fake-URL fast path: reuse `PlumbSnapshot::canned` per viewport,
+            // overriding the viewport key + dimensions so downstream diffing
+            // sees distinct viewport metadata. Content stays identical so
+            // the agent gets a clean "no diffs" result it can rely on as
+            // a smoke test.
+            let mut out = Vec::with_capacity(args.viewports.len());
+            for v in &args.viewports {
+                let mut snap = PlumbSnapshot::canned();
+                snap.viewport = ViewportKey::new(v.name.clone());
+                snap.viewport_width = v.width;
+                snap.viewport_height = v.height;
+                snap.url.clone_from(&args.url);
+                out.push(snap);
+            }
+            return Ok(out);
+        }
+
+        let targets: Vec<Target> = args
+            .viewports
+            .iter()
+            .map(|v| Target {
+                url: args.url.clone(),
+                viewport: ViewportKey::new(v.name.clone()),
+                width: v.width,
+                height: v.height,
+                device_pixel_ratio: v.dpr,
+                ..Target::default()
+            })
+            .collect();
+
+        let browser = self
+            .browser
+            .get_or_try_init(|| PersistentBrowser::launch(ChromiumOptions::default()))
+            .await
+            .map_err(|err| format!("compare_viewports failed: {err}"))?;
+
+        let mut snapshots = Vec::with_capacity(targets.len());
+        for target in targets {
+            let snap = browser
+                .snapshot(target)
+                .await
+                .map_err(|err| format!("compare_viewports failed: {err}"))?;
+            snapshots.push(snap);
+        }
+        Ok(snapshots)
+    }
+
     fn resolve_config_for_tool(&self, working_dir: &str) -> Result<ResolvedConfig, ErrorData> {
         if working_dir.is_empty() {
             return Err(ErrorData::invalid_params(
@@ -530,6 +660,127 @@ fn enforce_response_cap(
     Ok(())
 }
 
+/// 10 KB cap on the `compare_viewports` `structuredContent` payload —
+/// matches the budget called out in PRD §14.2 for any tool that returns
+/// per-node detail. Aggregation + diff-list capping keeps real-world
+/// payloads well below this limit.
+const COMPARE_VIEWPORTS_RESPONSE_CAP_BYTES: usize = 10 * 1024;
+
+fn validate_compare_viewports_args(args: &CompareViewportsArgs) -> Result<(), ErrorData> {
+    if args.url.is_empty() {
+        return Err(ErrorData::invalid_params(
+            "url must not be empty".to_string(),
+            None,
+        ));
+    }
+    if args.viewports.len() < 2 {
+        return Err(ErrorData::invalid_params(
+            format!(
+                "compare_viewports requires at least 2 viewports, got {}",
+                args.viewports.len()
+            ),
+            None,
+        ));
+    }
+    let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for v in &args.viewports {
+        if v.name.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "viewport name must not be empty".to_string(),
+                None,
+            ));
+        }
+        if v.width == 0 || v.height == 0 {
+            return Err(ErrorData::invalid_params(
+                format!("viewport `{}` must have non-zero width and height", v.name),
+                None,
+            ));
+        }
+        if !seen.insert(v.name.as_str()) {
+            return Err(ErrorData::invalid_params(
+                format!("viewport name `{}` is duplicated", v.name),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+// `result` is consumed: we move `result.diffs` (a Vec) into the JSON
+// payload and only read `result.summary` / `result.truncated` (both
+// `Copy`). Borrowing would force a clone of the diff vector for no
+// gain.
+#[allow(clippy::needless_pass_by_value)]
+fn build_compare_viewports_result(
+    url: &str,
+    viewport_names: &[String],
+    threshold_px: u32,
+    result: compare_viewports::CompareResult,
+) -> CallToolResult {
+    let summary = result.summary;
+    let truncated = result.truncated;
+    let diff_count = result.diffs.len();
+
+    let mut text = format!(
+        "compare_viewports {} across {} viewports: {} diff(s) [missing={}, size={}, reorder={}, style={}]",
+        url,
+        viewport_names.len(),
+        summary.total,
+        summary.missing,
+        summary.size_changes,
+        summary.reordered,
+        summary.style_changes,
+    );
+    if truncated {
+        use std::fmt::Write as _;
+        let _ = write!(text, " (showing first {diff_count})");
+    }
+
+    let structured = json!({
+        "url": url,
+        "viewports": viewport_names,
+        "size_threshold_px": threshold_px,
+        "summary": {
+            "total": summary.total,
+            "missing": summary.missing,
+            "size_changes": summary.size_changes,
+            "reordered": summary.reordered,
+            "style_changes": summary.style_changes,
+        },
+        "diffs": result.diffs,
+        "truncated": truncated,
+    });
+
+    // Best-effort cap enforcement. Truncation already shrinks oversized
+    // payloads in practice; on the rare path where the cap is still
+    // tripped (e.g. unusually long selectors), drop the diff list and
+    // keep the summary so the caller never receives an oversized blob.
+    let serialized = serde_json::to_string(&structured).unwrap_or_default();
+    let final_structured = if serialized.len() > COMPARE_VIEWPORTS_RESPONSE_CAP_BYTES {
+        json!({
+            "url": url,
+            "viewports": viewport_names,
+            "size_threshold_px": threshold_px,
+            "summary": {
+                "total": summary.total,
+                "missing": summary.missing,
+                "size_changes": summary.size_changes,
+                "reordered": summary.reordered,
+                "style_changes": summary.style_changes,
+            },
+            "diffs": [],
+            "truncated": true,
+            "dropped_for_cap": true,
+        })
+    } else {
+        structured
+    };
+
+    let mut result_obj = CallToolResult::success(vec![Content::text(text)]);
+    result_obj.structured_content = Some(final_structured);
+    result_obj
+}
+
 impl ServerHandler for PlumbServer {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
@@ -541,6 +792,7 @@ impl ServerHandler for PlumbServer {
         info.server_info = Implementation::new("plumb", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
             "Deterministic design-system linter. Call `lint_url` with a URL to get violations; \
+             use `compare_viewports` to diff a URL across mobile/desktop; \
              use `explain_rule` for canonical rule documentation; use `list_rules` to enumerate \
              every built-in rule; use `get_config` to fetch the resolved `plumb.toml` for a \
              working directory; read `plumb://config` to fetch the resolved config for the \
@@ -562,6 +814,7 @@ impl ServerHandler for PlumbServer {
             "explain_rule" => self.explain_rule(parse_tool_args(arguments)?).await,
             "list_rules" => self.list_rules(parse_tool_args(arguments)?).await,
             "get_config" => self.get_config(parse_tool_args(arguments)?).await,
+            "compare_viewports" => self.compare_viewports(parse_tool_args(arguments)?).await,
             unknown => Err(ErrorData::invalid_params(
                 format!("unknown tool: {unknown}"),
                 None,
@@ -591,6 +844,10 @@ impl ServerHandler for PlumbServer {
             tool_descriptor::<GetConfigArgs>(
                 "get_config",
                 "Return the resolved plumb.toml for a working directory as JSON. Memoized per (path, mtime).",
+            ),
+            tool_descriptor::<CompareViewportsArgs>(
+                "compare_viewports",
+                "Capture snapshots at 2+ viewports and return a deterministic diff (missing nodes, size changes, reorderings, computed-style changes). 10 KB structuredContent budget.",
             ),
         ];
         std::future::ready(Ok(ListToolsResult::with_all_items(tools)))

--- a/crates/plumb-mcp/tests/mcp_protocol.rs
+++ b/crates/plumb-mcp/tests/mcp_protocol.rs
@@ -11,7 +11,10 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use plumb_core::register_builtin;
-use plumb_mcp::{ExplainRuleArgs, LintUrlArgs, LintUrlDetail, PlumbServer, documented_rule_ids};
+use plumb_mcp::{
+    CompareViewport, CompareViewportsArgs, ExplainRuleArgs, LintUrlArgs, LintUrlDetail,
+    PlumbServer, documented_rule_ids,
+};
 use rmcp::ServerHandler;
 use rmcp::model::ErrorCode;
 
@@ -252,4 +255,199 @@ async fn many_fake_url_lints_share_one_server_without_warming_chromium() {
         .shutdown()
         .await
         .expect("shutdown must be a no-op after only fake-url calls");
+}
+
+fn viewport(name: &str, width: u32, height: u32, dpr: f32) -> CompareViewport {
+    CompareViewport {
+        name: name.to_owned(),
+        width,
+        height,
+        dpr,
+    }
+}
+
+/// Happy path: two viewports against `plumb-fake://hello` succeed
+/// without warming Chromium and produce a structured payload with the
+/// expected shape.
+#[tokio::test]
+async fn compare_viewports_happy_path_returns_structured_payload() {
+    let server = server();
+    let result = server
+        .compare_viewports(CompareViewportsArgs {
+            url: "plumb-fake://hello".to_owned(),
+            viewports: vec![
+                viewport("mobile", 375, 800, 2.0),
+                viewport("desktop", 1280, 800, 1.0),
+            ],
+            size_threshold_px: None,
+        })
+        .await
+        .expect("fake-url compare_viewports must succeed");
+
+    assert!(
+        !result.is_error.unwrap_or(false),
+        "fake-url compare_viewports must not surface a driver error"
+    );
+
+    let structured = result
+        .structured_content
+        .expect("response must include structuredContent");
+
+    assert_eq!(
+        structured.get("url").and_then(serde_json::Value::as_str),
+        Some("plumb-fake://hello"),
+    );
+    assert_eq!(
+        structured
+            .get("size_threshold_px")
+            .and_then(serde_json::Value::as_u64),
+        Some(4),
+    );
+    let viewports = structured
+        .get("viewports")
+        .and_then(serde_json::Value::as_array)
+        .expect("viewports array");
+    assert_eq!(viewports.len(), 2);
+    assert_eq!(viewports[0].as_str(), Some("mobile"));
+    assert_eq!(viewports[1].as_str(), Some("desktop"));
+
+    let summary = structured
+        .get("summary")
+        .and_then(serde_json::Value::as_object)
+        .expect("summary object");
+    assert_eq!(summary["total"].as_u64(), Some(0));
+    assert_eq!(summary["missing"].as_u64(), Some(0));
+    assert_eq!(summary["size_changes"].as_u64(), Some(0));
+    assert_eq!(summary["reordered"].as_u64(), Some(0));
+    assert_eq!(summary["style_changes"].as_u64(), Some(0));
+
+    assert!(
+        structured
+            .get("diffs")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(std::vec::Vec::is_empty),
+        "identical canned snapshots produce zero diffs"
+    );
+    assert_eq!(
+        structured
+            .get("truncated")
+            .and_then(serde_json::Value::as_bool),
+        Some(false)
+    );
+
+    server
+        .shutdown()
+        .await
+        .expect("shutdown must be a no-op when no browser was warmed");
+}
+
+/// Fewer than two viewports MUST return JSON-RPC `-32602`.
+#[tokio::test]
+async fn compare_viewports_requires_two_viewports() {
+    let server = server();
+    let error = server
+        .compare_viewports(CompareViewportsArgs {
+            url: "plumb-fake://hello".to_owned(),
+            viewports: vec![viewport("desktop", 1280, 800, 1.0)],
+            size_threshold_px: None,
+        })
+        .await
+        .expect_err("single-viewport input must be rejected");
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+    assert!(
+        error.to_string().contains("at least 2 viewports"),
+        "unexpected error: {error:?}"
+    );
+}
+
+/// Duplicate viewport names MUST return JSON-RPC `-32602`.
+#[tokio::test]
+async fn compare_viewports_rejects_duplicate_viewport_names() {
+    let server = server();
+    let error = server
+        .compare_viewports(CompareViewportsArgs {
+            url: "plumb-fake://hello".to_owned(),
+            viewports: vec![
+                viewport("desktop", 1280, 800, 1.0),
+                viewport("desktop", 1440, 900, 2.0),
+            ],
+            size_threshold_px: None,
+        })
+        .await
+        .expect_err("duplicate viewport names must be rejected");
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+    assert!(
+        error.to_string().contains("duplicated"),
+        "unexpected error: {error:?}"
+    );
+}
+
+/// Empty URL MUST return JSON-RPC `-32602`.
+#[tokio::test]
+async fn compare_viewports_rejects_empty_url() {
+    let server = server();
+    let error = server
+        .compare_viewports(CompareViewportsArgs {
+            url: String::new(),
+            viewports: vec![
+                viewport("mobile", 375, 800, 2.0),
+                viewport("desktop", 1280, 800, 1.0),
+            ],
+            size_threshold_px: None,
+        })
+        .await
+        .expect_err("empty url must be rejected");
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+}
+
+/// Zero-dimension viewports MUST return JSON-RPC `-32602`.
+#[tokio::test]
+async fn compare_viewports_rejects_zero_dimension_viewports() {
+    let server = server();
+    let error = server
+        .compare_viewports(CompareViewportsArgs {
+            url: "plumb-fake://hello".to_owned(),
+            viewports: vec![
+                viewport("mobile", 0, 800, 2.0),
+                viewport("desktop", 1280, 800, 1.0),
+            ],
+            size_threshold_px: None,
+        })
+        .await
+        .expect_err("zero-width viewport must be rejected");
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+}
+
+/// Three back-to-back invocations with identical inputs MUST produce
+/// byte-identical structured payloads — the determinism contract from
+/// PRD §16.
+#[tokio::test]
+async fn compare_viewports_is_deterministic_across_runs() {
+    let server = server();
+    let args = || CompareViewportsArgs {
+        url: "plumb-fake://hello".to_owned(),
+        viewports: vec![
+            viewport("mobile", 375, 800, 2.0),
+            viewport("desktop", 1280, 800, 1.0),
+            viewport("widescreen", 1920, 1080, 1.0),
+        ],
+        size_threshold_px: Some(8),
+    };
+    let r1 = server
+        .compare_viewports(args())
+        .await
+        .expect("call 1 must succeed");
+    let r2 = server
+        .compare_viewports(args())
+        .await
+        .expect("call 2 must succeed");
+    let r3 = server
+        .compare_viewports(args())
+        .await
+        .expect("call 3 must succeed");
+    let s1 = serde_json::to_string(&r1.structured_content).expect("serialize 1");
+    let s2 = serde_json::to_string(&r2.structured_content).expect("serialize 2");
+    let s3 = serde_json::to_string(&r3.structured_content).expect("serialize 3");
+    assert_eq!(s1, s2, "compare_viewports must be deterministic");
+    assert_eq!(s2, s3, "compare_viewports must be deterministic");
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Claude Code](./mcp/claude.md)
   - [Cursor](./mcp/cursor.md)
   - [Codex](./mcp/codex.md)
+  - [`compare_viewports`](./mcp/compare-viewports.md)
 - [Configuration](./configuration.md)
 - [FAQ and troubleshooting](./faq.md)
 

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -65,6 +65,7 @@ bind address, not the token value.
 | `explain_rule` | Return canonical documentation and metadata for a Plumb rule by id. Args: `{ "rule_id": "<category>/<id>" }`. |
 | `list_rules` | List every built-in Plumb rule with id, default severity, and one-line summary. No args. |
 | `get_config` | Return resolved `plumb.toml` for a working directory as JSON. Memoized per `(path, mtime)`. |
+| `compare_viewports` | Capture snapshots at 2+ viewports and return a deterministic diff: missing nodes, size changes above a pixel threshold, document-order reorderings, and computed-style differences. Args: `{ "url": "...", "viewports": [{ "name", "width", "height", "dpr" }, ...], "size_threshold_px"?: 4 }`. 10 KB `structuredContent` budget; aggregate counts plus a capped diff list. Full reference: [`compare_viewports`](./mcp/compare-viewports.md). |
 
 ## Resources
 

--- a/docs/src/mcp/compare-viewports.md
+++ b/docs/src/mcp/compare-viewports.md
@@ -1,0 +1,125 @@
+# `compare_viewports`
+
+Capture snapshots at two-or-more viewports of the same URL and return a
+deterministic per-node delta. Useful for catching mobile/desktop
+regressions: nodes that disappear at the small breakpoint, blocks that
+reflow above the threshold, components that swap order, and tracked
+computed-style properties that diverge.
+
+## Arguments
+
+```json
+{
+  "url": "https://example.com/",
+  "viewports": [
+    { "name": "mobile",  "width": 375,  "height": 800, "dpr": 2.0 },
+    { "name": "desktop", "width": 1280, "height": 800, "dpr": 1.0 }
+  ],
+  "size_threshold_px": 4
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | yes | URL to capture. Accepts `http(s)://` and `plumb-fake://`. |
+| `viewports` | array | yes | At least 2 viewports. The first is the diff baseline. |
+| `viewports[].name` | string | yes | Stable name. MUST be unique. |
+| `viewports[].width` | u32 | yes | Viewport width in CSS pixels. MUST be > 0. |
+| `viewports[].height` | u32 | yes | Viewport height in CSS pixels. MUST be > 0. |
+| `viewports[].dpr` | f32 | yes | Device pixel ratio. |
+| `size_threshold_px` | u32 | no | Pixel threshold for size-change diffs. Defaults to 4. |
+
+## Response
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "compare_viewports https://example.com/ across 2 viewports: 4 diff(s) [missing=1, size=2, reorder=0, style=1]"
+    }
+  ],
+  "isError": false,
+  "structuredContent": {
+    "url": "https://example.com/",
+    "viewports": ["mobile", "desktop"],
+    "size_threshold_px": 4,
+    "summary": {
+      "total": 4,
+      "missing": 1,
+      "size_changes": 2,
+      "reordered": 0,
+      "style_changes": 1
+    },
+    "diffs": [
+      {
+        "kind": "missing",
+        "selector": "html > body > nav",
+        "present_in": ["desktop"],
+        "absent_in": ["mobile"]
+      },
+      {
+        "kind": "size_change",
+        "selector": "html > body",
+        "viewport_a": "mobile",
+        "viewport_b": "desktop",
+        "width_a": 375, "height_a": 800,
+        "width_b": 1280, "height_b": 800,
+        "delta_px": 905
+      },
+      {
+        "kind": "style_change",
+        "selector": "html > body > main",
+        "property": "display",
+        "viewport_a": "mobile",
+        "viewport_b": "desktop",
+        "value_a": "block",
+        "value_b": "flex"
+      }
+    ],
+    "truncated": false
+  }
+}
+```
+
+## Diff kinds
+
+| `kind` | When emitted |
+|--------|-------------|
+| `missing` | A selector path exists in some viewports but not others. |
+| `size_change` | A node's width or height changed by more than `size_threshold_px` pixels. |
+| `reordered` | A node's `dom_order` differs across viewports. |
+| `style_change` | A tracked computed-style property differs. Tracked properties: `display`, `flex-direction`, `grid-template-columns`, `font-size`, `color`, `background-color`, `visibility`, `position`. |
+
+## Token budget
+
+`structuredContent` is capped at **10 KB**. Aggregation runs server-side:
+the `summary` always reports the full counts, but the `diffs` array is
+capped at 200 entries. When the cap fires, `truncated` is `true`. On the
+rare path where serialized output exceeds 10 KB even after capping, the
+diff list is dropped entirely and `dropped_for_cap: true` is set so the
+caller can re-issue with a higher `size_threshold_px`.
+
+## Determinism
+
+Three calls with the same arguments produce byte-identical
+`structuredContent`. Diffs are sorted by `(kind, selector, property,
+viewport_a, viewport_b)` before serialization.
+
+## Errors
+
+Returned as JSON-RPC `-32602` on the response's `error` field:
+
+- `viewports` shorter than 2.
+- Duplicate `viewport.name` values.
+- Empty `url` string.
+- Any viewport with `width == 0` or `height == 0`.
+
+Driver failures (Chromium not found, version out of range, navigation
+error) return a successful response with `isError: true` and a single
+text content block describing the error.
+
+## See also
+
+- [`lint_url`](./lint_url.md) — single-viewport lint.
+- [PRD §14.2](../../local/prd.md) — MCP response shape.


### PR DESCRIPTION
## Summary

Closes #80.

- New MCP tool `compare_viewports` captures snapshots at two-or-more viewports of the same URL and returns a deterministic per-node delta: missing nodes, size changes above a configurable pixel threshold (default 4 px), document-order reorderings, and tracked computed-style differences.
- Aggregation runs server-side: the `summary` field always reports full counts, but the `diffs` array is capped at 200 entries to keep `structuredContent` under the 10 KB MCP budget. Three calls with the same args produce byte-identical output.
- Pure-function module (`compare_viewports.rs`) lives in `plumb-mcp` so the diff logic stays unit-testable without a browser. Real URLs share the persistent `PersistentBrowser` warmed by `lint_url`; `plumb-fake://` URLs fan out to per-viewport canned snapshots without spawning Chromium.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p plumb-mcp -p plumb-cli --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p plumb-mcp -p plumb-cli` — 109/109 pass, including 6 new in-process protocol cases (`compare_viewports_*`) and 3 new stdio cases (happy path, single-viewport rejection, byte-identical determinism).
- [x] `just determinism-check` — 3 lint runs byte-identical.
- [x] Schema sanity: `tools/list` includes `compare_viewports` with `url` + `viewports` + `size_threshold_px` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)