### PR TITLE
chore: cargo fmt after recent merges

### DIFF
--- a/crates/plumb-cdp/src/lib.rs
+++ b/crates/plumb-cdp/src/lib.rs
@@ -1693,11 +1693,10 @@ pub fn snapshot_from_html(html: &str, base_url: &str) -> Result<PlumbSnapshot, C
             // (10 000) at this point, so the conversion is total. The
             // `try_from` keeps this honest if the cap ever grows beyond
             // `u64::MAX` on a future 128-bit target.
-            let dom_order = u64::try_from(element_count).map_err(|_| {
-                CdpError::HtmlElementLimitExceeded {
+            let dom_order =
+                u64::try_from(element_count).map_err(|_| CdpError::HtmlElementLimitExceeded {
                     limit_elements: SNAPSHOT_FROM_HTML_ELEMENT_CAP,
-                }
-            })?;
+                })?;
             dom_orders.insert(node.id(), dom_order);
             element_count += 1;
         }
@@ -2971,15 +2970,15 @@ mod tests {
 
     #[test]
     fn snapshot_from_html_is_byte_deterministic() {
-        let html =
-            "<!doctype html><html><body><main><p>hi</p><p>there</p></main></body></html>";
-        let a =
-            super::snapshot_from_html(html, "https://example.com/").expect("snapshot a");
-        let b =
-            super::snapshot_from_html(html, "https://example.com/").expect("snapshot b");
+        let html = "<!doctype html><html><body><main><p>hi</p><p>there</p></main></body></html>";
+        let a = super::snapshot_from_html(html, "https://example.com/").expect("snapshot a");
+        let b = super::snapshot_from_html(html, "https://example.com/").expect("snapshot b");
         let ja = serde_json::to_string(&a).expect("serialize a");
         let jb = serde_json::to_string(&b).expect("serialize b");
-        assert_eq!(ja, jb, "two calls with identical input must match byte-for-byte");
+        assert_eq!(
+            ja, jb,
+            "two calls with identical input must match byte-for-byte"
+        );
     }
 
     #[test]

--- a/crates/plumb-mcp/src/lib.rs
+++ b/crates/plumb-mcp/src/lib.rs
@@ -341,9 +341,8 @@ impl PlumbServer {
             ));
         }
 
-        let snapshot = snapshot_from_html(&args.html, &args.base_url).map_err(|err| {
-            ErrorData::invalid_params(format!("snapshot_from_html: {err}"), None)
-        })?;
+        let snapshot = snapshot_from_html(&args.html, &args.base_url)
+            .map_err(|err| ErrorData::invalid_params(format!("snapshot_from_html: {err}"), None))?;
         let config = Config::default();
         let violations = run(&snapshot, &config);
         build_lint_url_result(&violations, LintUrlDetail::Compact)


### PR DESCRIPTION
Drive-by `cargo fmt --all` to clean up rustfmt drift introduced by the recent merges (#218 #220 #222). Preflight on main is otherwise green; `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes locally.