### PR TITLE
fix(ci): skip Claude review on dependabot/renovate PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,19 @@ concurrency:
 jobs:
   review:
     name: Claude review
-    if: github.event.pull_request.draft == false
+    # Skip on dependabot / renovate PRs. Bot PRs run with reduced
+    # GITHUB_TOKEN scopes, so the action's GitHub App token request
+    # fails with "Internal error: directory mismatch ... fd 4" before
+    # any review can happen. Anthropic's security docs explicitly
+    # recommend filtering bot actors:
+    # https://github.com/anthropics/claude-code-action/blob/main/docs/security.md
+    # The dependency / CI bumps already get full coverage from
+    # determinism, MSRV, three-OS test matrix, cargo-deny, coverage,
+    # and the readiness matrix.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary

- Bot PRs (dependabot, renovate) currently fail the `claude-code-review` workflow with `Internal error: directory mismatch ... fd 4` because the GITHUB_TOKEN issued for bot-triggered runs has reduced scopes that `anthropics/claude-code-action` needs to mint its GitHub App token.
- This PR re-applies a previously reverted filter that skips the `review` job for `dependabot[bot]` and `renovate[bot]`, with the rationale and a link to Anthropic's security docs documented inline so it survives future cleanup passes.
- Dependency and CI bumps still get full coverage from the existing gates (determinism, MSRV, three-OS test matrix, cargo-deny, coverage, readiness matrix), so skipping Claude review on those PRs has no review-quality cost.

## Error this fixes

```
Internal error: directory mismatch ... fd 4
```

Reference: https://github.com/anthropics/claude-code-action/blob/main/docs/security.md

This PR's own Claude review will still run (the actor is a human), so the PR itself smoke-tests the filter.

## Test plan

- [ ] Workflow YAML parses (GitHub Actions schema check on push)
- [ ] `claude-code-review` runs and posts a verdict on this PR (proves non-bot path still works)
- [ ] Next dependabot PR after merge does not trigger `claude-code-review`