### PR TITLE
fix(cli): serialize mcp_http tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2060,6 +2060,7 @@ dependencies = [
  "reqwest",
  "scraper",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2698,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2754,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "selectors"
@@ -2866,6 +2882,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ predicates = "3"
 proptest = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
+serial_test = "3"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/plumb-cli/Cargo.toml
+++ b/crates/plumb-cli/Cargo.toml
@@ -53,6 +53,7 @@ predicates = { workspace = true }
 tempfile = { workspace = true }
 reqwest = { workspace = true }
 insta = { workspace = true }
+serial_test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plumb-cli/tests/mcp_http.rs
+++ b/crates/plumb-cli/tests/mcp_http.rs
@@ -111,6 +111,7 @@ fn http_transport_refuses_to_boot_with_empty_token() {
         .stderr(contains("non-empty bearer token"));
 }
 
+#[serial_test::serial(mcp_http)]
 #[tokio::test]
 async fn http_transport_rejects_requests_without_bearer_token()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -123,6 +124,7 @@ async fn http_transport_rejects_requests_without_bearer_token()
     Ok(())
 }
 
+#[serial_test::serial(mcp_http)]
 #[tokio::test]
 async fn http_transport_rejects_invalid_bearer_token() -> Result<(), Box<dyn std::error::Error>> {
     let (_server, port) = spawn_http_server("secret-token").await?;
@@ -134,6 +136,7 @@ async fn http_transport_rejects_invalid_bearer_token() -> Result<(), Box<dyn std
     Ok(())
 }
 
+#[serial_test::serial(mcp_http)]
 #[tokio::test]
 async fn http_transport_accepts_valid_bearer_token() -> Result<(), Box<dyn std::error::Error>> {
     let (_server, port) = spawn_http_server("secret-token").await?;
@@ -145,6 +148,7 @@ async fn http_transport_accepts_valid_bearer_token() -> Result<(), Box<dyn std::
     Ok(())
 }
 
+#[serial_test::serial(mcp_http)]
 #[tokio::test]
 async fn http_transport_trims_bearer_token_from_environment()
 -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- The 4 async HTTP-transport tests in `crates/plumb-cli/tests/mcp_http.rs` each call `reserve_port()`, which binds a TCP listener on port 0, reads back the OS-assigned port, drops the listener, then spawns a child to re-bind it. The drop-then-bind window is a TOCTOU race; under parallel execution the kernel can hand the same port to two reservations and the loser surfaces "Connection reset by peer" (most often on `http_transport_rejects_invalid_bearer_token`).
- Add `serial_test = "3"` to `[workspace.dependencies]` and the `plumb-cli` `[dev-dependencies]`.
- Annotate every `#[tokio::test]` HTTP fn with `#[serial_test::serial(mcp_http)]` so HTTP tests serialize against each other while non-HTTP tests stay parallel.

## Test plan

- [x] `cargo test -p plumb-cli --test mcp_http` — 6 passed locally
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p plumb-cli --tests -- -D warnings`
- [ ] CI green on the affected matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)