### PR TITLE
chore(deps): remove unused dependencies (cargo-machete cleanup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,11 +2173,9 @@ dependencies = [
  "insta",
  "plumb-config",
  "plumb-core",
- "serde_json",
  "tempfile",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -2218,17 +2203,14 @@ dependencies = [
 name = "plumb-core"
 version = "0.0.1"
 dependencies = [
- "ahash",
  "indexmap",
  "insta",
- "miette",
  "palette",
  "proptest",
  "rayon",
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -2276,7 +2258,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/crates/plumb-codegen/Cargo.toml
+++ b/crates/plumb-codegen/Cargo.toml
@@ -18,10 +18,8 @@ exclude = ["AGENTS.md", "CLAUDE.md"]
 plumb-core = { workspace = true }
 plumb-config = { workspace = true }
 indexmap = { workspace = true }
-serde_json = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/plumb-core/Cargo.toml
+++ b/crates/plumb-core/Cargo.toml
@@ -25,10 +25,7 @@ test-fake = []
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
-thiserror = { workspace = true }
-miette = { workspace = true }
 indexmap = { workspace = true }
-ahash = { workspace = true }
 palette = { workspace = true }
 rayon = { workspace = true }
 

--- a/crates/plumb-mcp/Cargo.toml
+++ b/crates/plumb-mcp/Cargo.toml
@@ -27,7 +27,6 @@ axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 subtle = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Drop 6 dependencies confirmed unused by cargo-machete across 3 crates.
- Each removal was verified by grepping the crate source tree before edit; no source file references the dropped deps (no macro derives, no tracing macros, no `serde_json::*` types).
- Workspace builds, full `cargo nextest run --workspace --all-features` (492 tests) passes, and `just validate` (all 4 gates) passes.

### Removals

- `plumb-core`: `thiserror`, `miette`, `ahash`
- `plumb-mcp`: `tracing`
- `plumb-codegen`: `serde_json`, `tracing`

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo nextest run --workspace --all-features` — 492 passed, 0 skipped
- [x] `cargo machete --with-metadata` — the 6 targeted entries no longer appear
- [x] `just validate` — all gates green (advisories, bans, licenses, sources)

Generated with [Claude Code](https://claude.com/claude-code)