### PR TITLE
chore(ci): rename brew tap to aram-devdocs/homebrew-plumb (closes #51)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,7 +6,7 @@ name: Install smoke test
 # Matrix: {cargo, brew, npm, curl} x {ubuntu, macos, windows}.
 # Cargo and curl are the current non-manual validation paths in this
 # repo state. Brew and npm stay gated/prep-only — they skip until the
-# external prerequisites (plumb-dev org, homebrew-tap repo, npm scope,
+# external prerequisites (aram-devdocs/homebrew-plumb tap repo already exists; npm scope,
 # publish identity, and secrets/permissions) exist.
 # See dist-workspace.toml and docs/src/ci/release-prep.md for details.
 #
@@ -159,7 +159,7 @@ jobs:
         if: "!matrix.gated && matrix.channel == 'brew'"
         shell: bash
         run: |
-          brew install plumb-dev/tap/plumb
+          brew install aram-devdocs/plumb/plumb
 
       # ── npm ───────────────────────────────────────────────────
       - name: Install via npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ name: release
 # channels this repo validates end-to-end today. Homebrew tap and npm
 # publishing are intentionally inactive here. Do not add the `tap` or
 # `npm-scope` fields in `dist-workspace.toml` until the external
-# prerequisites exist: the `plumb-dev` org, the `plumb-dev/homebrew-tap`
-# repo, ownership of the `@plumb` npm scope and `@plumb/cli` package,
+# prerequisites exist: the `aram-devdocs/homebrew-plumb` tap repo
+# (already exists), ownership of the `@plumb` npm scope and `@plumb/cli` package,
 # and the cargo-dist publishing token/permissions. npm activation also
 # needs `npm` added to the installer list; `npm-scope` alone does not
 # emit npm artifacts on cargo-dist 0.28.0. This workflow must not claim

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ curl -LsSf https://plumb.aramhammoudeh.com/install.sh | sh
 # Cargo
 cargo install plumb-cli
 
-# Homebrew (coming soon)
-brew install plumb-dev/tap/plumb
+# Homebrew
+brew install aram-devdocs/plumb/plumb
 ```
 
 ## Documentation

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,7 +28,7 @@ allow-dirty = ["ci"]
 # Homebrew and npm publishing stay disabled in this prep-only state.
 # Uncomment these only after:
 # 1. the `plumb-dev` GitHub org exists,
-# 2. the `plumb-dev/homebrew-tap` repo exists and is wired for cargo-dist,
+# 2. the `aram-devdocs/homebrew-plumb` tap exists (it does — https://github.com/aram-devdocs/homebrew-plumb) and is wired for cargo-dist,
 # 3. the `@plumb` npm scope and the `@plumb/cli` package are owned by the
 #    release account that will publish from this repo,
 # 4. the release token/permissions for cargo-dist publishing are in place,
@@ -36,7 +36,7 @@ allow-dirty = ["ci"]
 #    claim `npm i -g @plumb/cli` support.
 # Issues #51 and #52 are intentionally prep-only, so this repo must not enable
 # either installer yet.
-# tap = "plumb-dev/homebrew-tap"
+# tap = "aram-devdocs/homebrew-plumb"
 # Keep the value aligned with the intended package name `@plumb/cli`, but do
 # not uncomment this field until the external npm prerequisites above exist.
 # Future activation also needs `npm` added to `installers`; `npm-scope` alone

--- a/docs/src/ci/release-prep.md
+++ b/docs/src/ci/release-prep.md
@@ -12,19 +12,18 @@ not enable Homebrew publishing yet.
 Before anyone uncomments the `tap` setting in `dist-workspace.toml`,
 these prerequisites MUST exist:
 
-1. The `plumb-dev` GitHub organization.
-2. The `plumb-dev/homebrew-tap` repository.
-3. The token and GitHub permissions cargo-dist needs to update the tap
+1. The `aram-devdocs/homebrew-plumb` tap repo (already exists).
+2. The token and GitHub permissions cargo-dist needs to update the tap
    on release.
 
 Activation steps, once the external prerequisites exist:
 
 1. Confirm `cargo dist plan` still passes with the current repo state.
-2. Create or verify the `plumb-dev/homebrew-tap` repo settings that
+2. Create or verify the `aram-devdocs/homebrew-plumb` repo settings that
    cargo-dist expects for formula updates.
 3. Add the release token or permissions required for cargo-dist to push
    Homebrew formula changes.
-4. Uncomment `tap = "plumb-dev/homebrew-tap"` in
+4. Uncomment `tap = "aram-devdocs/homebrew-plumb"` in
    `dist-workspace.toml`.
 5. Run `cargo dist plan` again and review the generated manifest for the
    Homebrew artifacts.
@@ -33,8 +32,6 @@ Activation steps, once the external prerequisites exist:
 
 Current blockers this repo does not solve:
 
-- `plumb-dev` org does not exist here.
-- `plumb-dev/homebrew-tap` is not available here.
 - cargo-dist publishing credentials and permissions are external to this
   repo.
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -70,10 +70,10 @@ cargo install plumb-cli --version 0.1.0
 For macOS or Linuxbrew:
 
 ```bash
-brew install plumb-dev/tap/plumb
+brew install aram-devdocs/plumb/plumb
 ```
 
-The tap repository is `plumb-dev/homebrew-tap`. The formula tracks the
+The tap repository is `aram-devdocs/homebrew-plumb`. The formula tracks the
 latest tagged release.
 
 ## Build from source

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -57,7 +57,7 @@ Pick the channel that fits your workflow:
 
 - [Install script (macOS / Linux / Windows)](./install.md#install-script-macos--linux--windows) — one-line curl/irm
 - [`cargo install`](./install.md#cargo) — if you already have a Rust toolchain
-- [Homebrew](./install.md#homebrew) — `brew install plumb-dev/tap/plumb`
+- [Homebrew](./install.md#homebrew) — `brew install aram-devdocs/plumb/plumb`
 - [Build from source](./install.md#build-from-source) — the only path available today (pre-alpha)
 
 Then continue with the docs for your workflow:

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -188,7 +188,7 @@ fi
 
 if [ "$brew_gated" -gt 0 ] \
     && grep -Fq "if: \"!matrix.gated && matrix.channel == 'brew'\"" "$WORKFLOW" \
-    && grep -Fq 'brew install plumb-dev/tap/plumb' "$WORKFLOW"; then
+    && grep -Fq 'brew install aram-devdocs/plumb/plumb' "$WORKFLOW"; then
     pass "brew channel stays gated until a publish path exists"
 else
     fail "brew channel gating/install contract is incorrect"


### PR DESCRIPTION
Renames brew tap references from `plumb-dev/homebrew-tap` to `aram-devdocs/homebrew-plumb` (just created at https://github.com/aram-devdocs/homebrew-plumb). End-user install becomes `brew install aram-devdocs/plumb/plumb`. After merge + HOMEBREW_TAP_TOKEN secret + uncommenting `tap = ...` in dist-workspace.toml, cargo-dist will auto-publish formulae here on each release. Closes #51 (homebrew admin chore — tap repo now exists).