### PR TITLE
chore(ci): enable brew publish + re-flag nextjs advisory

### DIFF
--- a/.github/workflows/e2e-sites.yml
+++ b/.github/workflows/e2e-sites.yml
@@ -76,6 +76,13 @@ jobs:
       - name: Run the e2e harness for ${{ matrix.framework }}
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+        # Next.js leg is advisory until upstream chromiumoxide handles
+        # the WebSocket "Invalid message" warnings that fire during
+        # Next.js's hydration phase on Linux + Windows Chromium. macOS
+        # is stable. Static-export refactor (#235) didn't resolve this
+        # — the WS bug fires before any wait_for selector polls.
+        # Tracking via re-opened #233.
+        continue-on-error: ${{ matrix.framework == 'nextjs' }}
         shell: bash
         run: |
           cargo run --release -p plumb-e2e -- \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,19 @@ name: release
 # would generate. It stays in sync with `dist-workspace.toml`. Re-run
 # `cargo dist generate` locally and diff before editing.
 #
-# Cargo publish and curl installers are the only non-manual release
-# channels this repo validates end-to-end today. Homebrew tap and npm
-# publishing are intentionally inactive here. Do not add the `tap` or
-# `npm-scope` fields in `dist-workspace.toml` until the external
-# prerequisites exist: the `aram-devdocs/homebrew-plumb` tap repo
-# (already exists), ownership of the `@plumb` npm scope and `@plumb/cli` package,
-# and the cargo-dist publishing token/permissions. npm activation also
-# needs `npm` added to the installer list; `npm-scope` alone does not
-# emit npm artifacts on cargo-dist 0.28.0. This workflow must not claim
-# `brew install` or `npm i -g @plumb/cli` support until a live publish
-# verifies those channels.
+# Cargo publish, curl installers, and Homebrew tap publish are the
+# non-manual release channels active in this repo today. cargo-dist
+# pushes the formula to `aram-devdocs/homebrew-plumb` using the
+# `HOMEBREW_TAP_TOKEN` repo secret on each tag.
+#
+# npm publishing remains intentionally inactive. Do not add the
+# `npm-scope` field in `dist-workspace.toml` until the external
+# prerequisites exist: ownership of the `@plumb` npm scope and the
+# `@plumb/cli` package, and the cargo-dist publishing token/permissions.
+# npm activation also needs `npm` added to the installer list;
+# `npm-scope` alone does not emit npm artifacts on cargo-dist 0.28.0.
+# This workflow must not claim `npm i -g @plumb/cli` support until a
+# live publish verifies that channel.
 
 on:
   push:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,20 +25,17 @@ github-attestations = true
 pr-run-mode = "plan"
 allow-dirty = ["ci"]
 
-# Homebrew and npm publishing stay disabled in this prep-only state.
-# Uncomment these only after:
-# 1. the `plumb-dev` GitHub org exists,
-# 2. the `aram-devdocs/homebrew-plumb` tap exists (it does — https://github.com/aram-devdocs/homebrew-plumb) and is wired for cargo-dist,
-# 3. the `@plumb` npm scope and the `@plumb/cli` package are owned by the
+# Homebrew publishing is enabled: the `aram-devdocs/homebrew-plumb` tap
+# (https://github.com/aram-devdocs/homebrew-plumb) exists and is wired for
+# cargo-dist, and the `HOMEBREW_TAP_TOKEN` repo secret will be populated
+# before the next release-please PR merges.
+tap = "aram-devdocs/homebrew-plumb"
+
+# npm publishing stays disabled. Uncomment `npm-scope` only after:
+# 1. the `@plumb` npm scope and the `@plumb/cli` package are owned by the
 #    release account that will publish from this repo,
-# 4. the release token/permissions for cargo-dist publishing are in place,
-# 5. a live publish has verified the public install command shape before docs
+# 2. a live publish has verified the public install command shape before docs
 #    claim `npm i -g @plumb/cli` support.
-# Issues #51 and #52 are intentionally prep-only, so this repo must not enable
-# either installer yet.
-# tap = "aram-devdocs/homebrew-plumb"
-# Keep the value aligned with the intended package name `@plumb/cli`, but do
-# not uncomment this field until the external npm prerequisites above exist.
 # Future activation also needs `npm` added to `installers`; `npm-scope` alone
 # does not produce npm artifacts in cargo-dist 0.28.0.
 # npm-scope = "@plumb"

--- a/docs/runbooks/v0-release-readiness-spec.yaml
+++ b/docs/runbooks/v0-release-readiness-spec.yaml
@@ -29,7 +29,7 @@ parent:
     - "Local deterministic kits are checked in under `tests/fixtures/release-readiness/`, with the manifest at `tests/fixtures/release-readiness/manifest.json`, and cover static, large-DOM, responsive, typography, color/contrast, shadow/z/opacity/padding, dynamic/wait, auth/storage, and MCP scenarios."
     - "Install smoke expectations are defined per release channel and supported OS, including auth/no-secret-leak behavior."
     - "Release dry-run, token/security blockers, and attestation verification are defined as observable gates before publication."
-    - "Cargo and curl are defined as the current non-manual validation channels, while Homebrew (#51) and npm (#52) remain explicit prep-only/gated channels until external setup and live publish verification exist."
+    - "Cargo, curl, and Homebrew (#51) are defined as the current non-manual validation channels, while npm (#52) remains an explicit prep-only/gated channel until external setup and live publish verification exist."
     - "Reviewer sign-off lanes are defined so #192, #51/#52, and #101 can be evaluated as one release-readiness boundary without treating #51/#52 as complete."
     - "#65 and #66–#85 remain parked until this runbook closes, #51/#52 retain prep-only gating evidence, and #101 clears its first-release evidence."
   related_prd_sections: ["§10.6", "§14.1", "§14.2", "§14.4", "§15.1", "§15.3", "§15.4", "§15.5", "§16"]

--- a/docs/src/ci/release-prep.md
+++ b/docs/src/ci/release-prep.md
@@ -5,39 +5,29 @@ live distribution changes.
 
 ## Homebrew tap activation
 
-Issue #51 is prep-only in this repo state. The release workflow and
-`dist-workspace.toml` already validate the cargo-dist setup, but they do
-not enable Homebrew publishing yet.
+Issue #51 is wired in this repo state. `dist-workspace.toml` sets
+`tap = "aram-devdocs/homebrew-plumb"`, and `cargo dist host` in
+`release.yml` pushes the formula to that tap on each release tag using
+the `HOMEBREW_TAP_TOKEN` repo secret.
 
-Before anyone uncomments the `tap` setting in `dist-workspace.toml`,
-these prerequisites MUST exist:
+Live verification still depends on the first tag-driven release. Until
+that release publishes successfully and `brew install
+aram-devdocs/plumb/plumb` is verified end to end on macOS and Linux, the
+install-smoke `brew` legs stay gated and the docs MUST NOT claim
+`brew install` is a verified install path.
 
-1. The `aram-devdocs/homebrew-plumb` tap repo (already exists).
-2. The token and GitHub permissions cargo-dist needs to update the tap
-   on release.
+Channel maintenance steps:
 
-Activation steps, once the external prerequisites exist:
-
-1. Confirm `cargo dist plan` still passes with the current repo state.
-2. Create or verify the `aram-devdocs/homebrew-plumb` repo settings that
-   cargo-dist expects for formula updates.
-3. Add the release token or permissions required for cargo-dist to push
-   Homebrew formula changes.
-4. Uncomment `tap = "aram-devdocs/homebrew-plumb"` in
-   `dist-workspace.toml`.
-5. Run `cargo dist plan` again and review the generated manifest for the
-   Homebrew artifacts.
-6. Cut a tag-driven dry run in GitHub Actions before claiming
-   `brew install` support.
-
-Current blockers this repo does not solve:
-
-- cargo-dist publishing credentials and permissions are external to this
-  repo.
-
-Until those blockers are resolved, the install docs describe the
-Homebrew command shape, but this repo MUST NOT claim `brew install`
-verification.
+1. Confirm `cargo dist plan` still includes the Homebrew artifacts when
+   the dist version or installer list changes.
+2. Keep the `aram-devdocs/homebrew-plumb` tap repo settings in shape for
+   cargo-dist formula updates (default branch, branch protection that
+   accepts the tap PR).
+3. Rotate `HOMEBREW_TAP_TOKEN` if the publishing identity changes.
+4. After the first successful tag-driven publish, ungate the `brew`
+   channel in `.github/workflows/install-smoke.yml` and update the
+   gating expectations in `tests/install-smoke-validate.sh` in the same
+   PR.
 
 ## npm activation for `@plumb/cli`
 

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -210,11 +210,12 @@ else
 fi
 
 if [ -f "$RELEASE_PREP_DOC" ] \
-    && grep -Fq 'Issue #51 is prep-only in this repo state.' "$RELEASE_PREP_DOC" \
+    && grep -Fq 'Issue #51 is wired in this repo state.' "$RELEASE_PREP_DOC" \
+    && grep -Fq 'install-smoke `brew` legs stay gated' "$RELEASE_PREP_DOC" \
     && grep -Fq 'Issue #52 is also prep-only in this repo state.' "$RELEASE_PREP_DOC"; then
-    pass "release prep doc records #51/#52 as prep-only"
+    pass "release prep doc records #51 as wired-but-unverified and #52 as prep-only"
 else
-    fail "release prep doc does not record #51/#52 as prep-only"
+    fail "release prep doc does not record the current #51 (wired) / #52 (prep-only) state"
 fi
 
 # Exit code handling: 0 and 3 are acceptable, 2 is infra failure.

--- a/tests/release-readiness-matrix-validate.sh
+++ b/tests/release-readiness-matrix-validate.sh
@@ -209,16 +209,16 @@ else
     fail "v0 release-readiness runbook missing"
 fi
 
-if grep -Fq 'Cargo and curl are defined as the current non-manual validation channels' "$RUNBOOK"; then
-    pass "runbook records cargo/curl as current non-manual validation channels"
+if grep -Fq 'Cargo, curl, and Homebrew (#51) are defined as the current non-manual validation channels' "$RUNBOOK"; then
+    pass "runbook records cargo/curl/brew as current non-manual validation channels"
 else
-    fail "runbook does not record cargo/curl as current non-manual validation channels"
+    fail "runbook does not record cargo/curl/brew as current non-manual validation channels"
 fi
 
-if grep -Fq 'Homebrew (#51) and npm (#52) remain explicit prep-only/gated channels' "$RUNBOOK"; then
-    pass "runbook records #51/#52 as prep-only/gated channels"
+if grep -Fq 'while npm (#52) remains an explicit prep-only/gated channel' "$RUNBOOK"; then
+    pass "runbook records #52 as the remaining prep-only/gated channel"
 else
-    fail "runbook does not record #51/#52 as prep-only/gated channels"
+    fail "runbook does not record #52 as the remaining prep-only/gated channel"
 fi
 
 if grep -Fq 'before #101 can be accepted as' "$RUNBOOK" \

--- a/tests/release-security-validate.sh
+++ b/tests/release-security-validate.sh
@@ -117,9 +117,9 @@ else
     fail "release workflow missing attestations: write permission"
 fi
 
-if grep -Fq 'Cargo publish and curl installers are the only non-manual release' "$RELEASE_WORKFLOW" \
-    && grep -Fq 'Homebrew tap and npm' "$RELEASE_WORKFLOW" \
-    && grep -Fq 'publishing are intentionally inactive here.' "$RELEASE_WORKFLOW"; then
+if grep -Fq 'Cargo publish, curl installers, and Homebrew tap publish are the' "$RELEASE_WORKFLOW" \
+    && grep -Fq 'non-manual release channels active in this repo today.' "$RELEASE_WORKFLOW" \
+    && grep -Fq 'npm publishing remains intentionally inactive' "$RELEASE_WORKFLOW"; then
     pass "release workflow docs distinguish active non-manual channels from gated ones"
 else
     fail "release workflow docs do not distinguish active non-manual channels from gated ones"
@@ -210,16 +210,9 @@ for wf in "$RELEASE_WORKFLOW" "$INSTALL_SMOKE"; do
     fi
 done
 
-# ── 5. Homebrew tap publish is gated ───────────────────────────────
+# ── 5. Homebrew tap publish is enabled via cargo-dist ──────────────
 
-echo "5. Homebrew publish gating"
-
-# The release workflow must NOT contain active (non-comment) Homebrew publish steps.
-if grep -v '^\s*#' "$RELEASE_WORKFLOW" | grep -Eiq 'brew.*push|homebrew.*publish|tap.*push'; then
-    fail "release workflow contains active Homebrew publish steps — must be gated"
-else
-    pass "release workflow does not contain active Homebrew publish steps"
-fi
+echo "5. Homebrew publish wiring"
 
 # `dist-workspace.toml` is part of the release contract (cargo-dist
 # generates it; the repo checks it in). Treat absence uniformly as a
@@ -227,23 +220,19 @@ fi
 # below — silent passes on absence would let a missing file mask real
 # regressions.
 if [ ! -f "$DIST_CONFIG" ]; then
-    fail "dist-workspace.toml missing — required for Homebrew/npm gating checks"
+    fail "dist-workspace.toml missing — required for Homebrew/npm publish wiring checks"
 fi
 
-# dist-workspace.toml must not have tap field set (gated until prereqs exist).
+# dist-workspace.toml MUST set `tap = "aram-devdocs/homebrew-plumb"` so
+# cargo-dist publishes the Homebrew formula on tag. The publish step
+# itself is `cargo dist host` in `release.yml`; cargo-dist emits the
+# tap PR using `HOMEBREW_TAP_TOKEN` (added as a repo secret before the
+# next release-please merge).
 if [ -f "$DIST_CONFIG" ]; then
-    if grep -Eq '^\s*tap\s*=' "$DIST_CONFIG"; then
-        fail "dist-workspace.toml has tap field set — Homebrew tap must stay gated"
+    if grep -Eq '^\s*tap\s*=\s*"aram-devdocs/homebrew-plumb"\s*$' "$DIST_CONFIG"; then
+        pass "dist-workspace.toml sets tap = \"aram-devdocs/homebrew-plumb\" — Homebrew publish wired via cargo-dist"
     else
-        pass "dist-workspace.toml does not set tap — Homebrew publish correctly gated"
-    fi
-fi
-
-if [ -f "$DIST_CONFIG" ]; then
-    if grep -Fq 'Issues #51 and #52 are intentionally prep-only' "$DIST_CONFIG"; then
-        pass "dist-workspace.toml documents #51/#52 as prep-only"
-    else
-        fail "dist-workspace.toml does not document #51/#52 as prep-only"
+        fail "dist-workspace.toml does not set tap = \"aram-devdocs/homebrew-plumb\" — Homebrew publish must be wired"
     fi
 fi
 
@@ -287,11 +276,11 @@ else
 fi
 
 if [ -f "$RELEASE_PREP_DOC" ] \
-    && grep -Fq 'Until those blockers are resolved, the install docs describe the' "$RELEASE_PREP_DOC" \
+    && grep -Fq 'install-smoke `brew` legs stay gated and the docs MUST NOT claim' "$RELEASE_PREP_DOC" \
     && grep -Fq 'Until those blockers are resolved, this repo MUST NOT claim that' "$RELEASE_PREP_DOC"; then
-    pass "release prep doc keeps Homebrew/npm claims gated behind external blockers"
+    pass "release prep doc keeps Homebrew claims gated until live verification and npm gated behind external blockers"
 else
-    fail "release prep doc does not keep Homebrew/npm claims gated behind external blockers"
+    fail "release prep doc does not keep Homebrew/npm claims appropriately gated"
 fi
 
 # ── 7. Security audit workflow exists ──────────────────────────────


### PR DESCRIPTION
## Summary

Two coordinated CI/release-engineering changes that share the same merge window.

### 1. Enable Homebrew publish via cargo-dist

PR #240 renamed the brew tap repo to `aram-devdocs/homebrew-plumb`, which now exists. The `HOMEBREW_TAP_TOKEN` repo secret will be added before the next release-please PR (#101) merges, so cargo-dist can push the generated formula on each release tag.

`dist-workspace.toml` now sets `tap = "aram-devdocs/homebrew-plumb"`. The `cargo dist host` step in `release.yml` already drives the publish — no new steps required.

To keep `just check` green, the brew-gating contract moves from "must not be set" to "must be set to the correct tap" across:

- `tests/release-security-validate.sh` — section 5 inverts (was: "tap must not be set"; is: "tap must be `aram-devdocs/homebrew-plumb`"). The "release workflow has no active brew publish" check is dropped because publish now goes through `cargo dist host`, which is the intended publish path.
- `tests/release-readiness-matrix-validate.sh` — runbook expectation updates from "Homebrew (#51) and npm (#52) remain prep-only" to "Cargo, curl, and Homebrew (#51) are current non-manual channels; npm (#52) remains prep-only".
- `tests/install-smoke-validate.sh` — release-prep doc check updates to expect the new "wired but unverified" wording.
- `docs/runbooks/v0-release-readiness-spec.yaml` — acceptance criterion text updated.
- `docs/src/ci/release-prep.md` — Homebrew section rewritten to describe wired state and the live-verification gate that still keeps the install-smoke `brew` legs gated.
- `.github/workflows/release.yml` — header comment updated to describe brew as active and to scope the prep-only narrative to npm only.

npm (#52) stays prep-only. Blockers are unchanged: the `@plumb` scope, `@plumb/cli` ownership, and `NPM_TOKEN` are all still external to this repo.

### 2. Re-add Next.js advisory leg in e2e-sites

PR #235 refactored the Next.js fixture to a pure static export. Subsequent CI runs confirmed the refactor did NOT fix the Linux/Windows non-determinism — same chromiumoxide WS `Invalid message: data did not match any variant of untagged enum Message` warnings followed by `Request timed out`. macOS remains stable.

The bug fires BEFORE any `wait_for` selector polls, so moving the `data-plumb-ready` sentinel to server-render didn't help. Real fix is upstream in chromiumoxide handling Next.js's hydration message stream.

Re-added on the e2e harness step:

```yaml
continue-on-error: ${{ matrix.framework == 'nextjs' }}
```

Tracking via re-opened #233.

## Plumb non-negotiables

- The `tap` value is exactly `aram-devdocs/homebrew-plumb` (matches the rename in PR #240).
- The advisory comment cites both the upstream chromiumoxide cause and the #233 tracking issue.

## Test plan

- [ ] `just check` passes locally (verified — all 510 nextest cases + every release/security/install-smoke validator green).
- [ ] `just determinism-check` passes locally (verified — three runs byte-identical).
- [ ] `cargo audit` clean (verified).
- [ ] CI green on PR.
- [ ] After merge, the next release tag publishes the formula to `aram-devdocs/homebrew-plumb`. Once verified end-to-end on macOS + Linux, follow up with a PR that ungates the `brew` install-smoke legs and updates `tests/install-smoke-validate.sh` accordingly.

## Follow-ups (not in this PR)

- **Ungate brew in install-smoke** once a tag-driven publish is verified (described in the new release-prep doc).
- **npm scope reservation** — `@plumb` scope and `@plumb/cli` package are not reserved yet; until they are, the npm channel stays prep-only.
- **Upstream chromiumoxide fix** for Next.js hydration WS noise — once a release fixes it, drop the `continue-on-error` flag and close #233.