### PR TITLE
fix(ci): pin workspace deps to current crate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,30 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
+  # Manual fallback. release-please creates tags using GITHUB_TOKEN, which
+  # GitHub will NOT use to trigger downstream `push` workflows (loop guard).
+  # Use this dispatch (or set RELEASE_PLEASE_TOKEN to a PAT in
+  # release-please.yml) when an automated tag push needs cargo-dist.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build (e.g. v0.0.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
   attestations: write
 
+env:
+  # Resolves to the dispatch input on workflow_dispatch, or the pushed
+  # tag name on tag push. Used as the cargo-dist `--tag` arg and the
+  # checkout `ref` everywhere below.
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -39,9 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ (github.ref_type == 'tag' && github.ref_name) || '' }}
+      tag: ${{ env.RELEASE_TAG }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-dist
         run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
@@ -49,7 +67,7 @@ jobs:
         id: plan
         run: |
           set -euo pipefail
-          manifest="$(cargo dist plan --tag "${{ github.ref_name }}" --output-format=json)"
+          manifest="$(cargo dist plan --tag "${RELEASE_TAG}" --output-format=json)"
           echo "$manifest" > dist-manifest.json
           echo "manifest<<EOF" >> "$GITHUB_OUTPUT"
           echo "$manifest" >> "$GITHUB_OUTPUT"
@@ -83,6 +101,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -97,7 +117,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: cargo dist build
         shell: bash
-        run: cargo dist build --tag "${{ github.ref_name }}" --target ${{ matrix.target }}
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: cargo dist build --tag "${RELEASE_TAG}" --target ${{ matrix.target }}
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/distrib/*
@@ -113,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/download-artifact@v8
         with:
           path: target/distrib/
@@ -122,7 +146,9 @@ jobs:
       - uses: cargo-bins/cargo-binstall@main
       - run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
       - name: cargo dist build installers
-        run: cargo dist build --tag "${{ github.ref_name }}" --artifacts=global
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: cargo dist build --tag "${RELEASE_TAG}" --artifacts=global
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/distrib/plumb-installer.*
@@ -137,6 +163,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/download-artifact@v8
         with:
           path: target/distrib/
@@ -147,4 +175,5 @@ jobs:
       - name: cargo dist host
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo dist host --tag "${{ github.ref_name }}" --steps=upload --steps=release
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: cargo dist host --tag "${RELEASE_TAG}" --steps=upload --steps=release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cdp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chromiumoxide",
  "criterion",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-codegen"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "indexmap",
  "insta",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-config"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "dunce",
  "figment",
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-core"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "indexmap",
  "insta",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-e2e"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-format"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "indexmap",
  "insta",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-mcp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "axum",
  "indexmap",
@@ -4431,7 +4431,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ categories = ["command-line-utilities", "development-tools", "web-programming"]
 
 [workspace.dependencies]
 # Internal path dependencies resolved by consumers.
-plumb-core = { path = "crates/plumb-core", version = "0.0.1" }
-plumb-format = { path = "crates/plumb-format", version = "0.0.1" }
-plumb-cdp = { path = "crates/plumb-cdp", version = "0.0.1" }
-plumb-config = { path = "crates/plumb-config", version = "0.0.1" }
-plumb-codegen = { path = "crates/plumb-codegen", version = "0.0.1" }
-plumb-mcp = { path = "crates/plumb-mcp", version = "0.0.1" }
+plumb-core = { path = "crates/plumb-core", version = "0.0.2" }
+plumb-format = { path = "crates/plumb-format", version = "0.0.2" }
+plumb-cdp = { path = "crates/plumb-cdp", version = "0.0.2" }
+plumb-config = { path = "crates/plumb-config", version = "0.0.2" }
+plumb-codegen = { path = "crates/plumb-codegen", version = "0.0.2" }
+plumb-mcp = { path = "crates/plumb-mcp", version = "0.0.2" }
 
 # CDP driver.
 chromiumoxide = { version = "0.9", default-features = false }

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 {
   "ignored": 0,
-  "plumb_version": "0.0.1",
+  "plumb_version": "0.0.2",
   "run_id": "sha256:53a662be238be796f9a08b74adb05e4020dd3d9f653e9bf91a7fb5b1c7a274c0",
   "stats": {
     "counts": {

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 {
   "ignored": 0,
-  "plumb_version": "0.0.1",
+  "plumb_version": "0.0.2",
   "run_id": "sha256:f47589f64fe0e1ced94e916195257a272a6e8509a8ed2831c060a7398d2f86e6",
   "stats": {
     "counts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,11 +24,13 @@
       "release-type": "simple",
       "include-component-in-tag": false,
       "extra-files": [
-        {
-          "type": "toml",
-          "path": "Cargo.toml",
-          "jsonpath": "$.workspace.package.version"
-        }
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.package.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-core.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-format.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-cdp.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-config.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-codegen.version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies.plumb-mcp.version" }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Two fixes for the broken v0.0.2 release pipeline.

### 1. Workspace dep version drift (root cause of v0.0.2 publish failure)

The workspace internal-dep `version` fields stayed pinned at `"0.0.1"` while the package versions advanced to `0.0.2`. release-please's `simple` release-type only updated `$.workspace.package.version`, so cargo refused to publish `plumb-format`:

```
error: failed to select a version for the requirement `plumb-core = "^0.0.1"`
candidate versions found which didn't match: 0.0.2
required by package `plumb-format v0.0.2`
```

(Failure on release-please run [25482779827](https://github.com/aram-devdocs/plumb/actions/runs/25482779827).)

**Fix**:
- Bump six `[workspace.dependencies] plumb-* = { ... version = "..." }` entries to `"0.0.2"`.
- Extend `release-please-config.json` `extra-files` with six new JSONPaths so future bumps update workspace dep versions in lockstep with the package version. Drift cannot recur.

### 2. release.yml never fired on tag push (cargo-dist did not run)

release-please tagged `v0.0.2` using `GITHUB_TOKEN`. GitHub does NOT fire downstream `push` workflows from tags created by `GITHUB_TOKEN` (loop guard) — `release.yml` had **zero runs** after the v0.0.2 tag landed.

**Fix**:
- Add `workflow_dispatch` to `release.yml` with a `tag` input, threaded through every checkout `ref:` and every `cargo dist --tag` argument via a workflow-scoped `RELEASE_TAG` env. Lets an operator manually trigger the artifact build at any tag without rotating tokens.
- Permanent fix is a PAT in `release-please.yml`; this dispatch is the safety net regardless.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo publish -p plumb-core --dry-run --locked` succeeds
- [x] `python3 yaml-validate release.yml` clean
- [ ] After merge: release-please opens v0.0.3 PR with all 7 jsonpaths updated to `0.0.3`
- [ ] After release-please PR merge: `Publish to crates.io` job green
- [ ] cargo-dist `release.yml` runs on the v0.0.3 tag (or via dispatch fallback) and uploads artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)