### PR TITLE
test(format): redact plumb_version in JSON snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "serde",
  "similar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ notify = "8"
 notify-debouncer-full = "0.6"
 
 # Dev-only.
-insta = { version = "1", features = ["json", "yaml"] }
+insta = { version = "1", features = ["json", "yaml", "filters"] }
 assert_cmd = "2"
 predicates = "3"
 proptest = "1"

--- a/crates/plumb-format/tests/format_snapshots.rs
+++ b/crates/plumb-format/tests/format_snapshots.rs
@@ -76,16 +76,27 @@ fn pretty_grouped_snapshot() {
     insta::assert_snapshot!("pretty_grouped", pretty(&grouped_fixture()));
 }
 
+// Redact the `plumb_version` field — it sources from CARGO_PKG_VERSION
+// and would otherwise force a snapshot bump on every release.
+fn json_snapshot_settings() -> insta::Settings {
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(
+        r#""plumb_version": "\d+\.\d+\.\d+(?:-[\w.+-]+)?""#,
+        r#""plumb_version": "[redacted]""#,
+    );
+    settings
+}
+
 #[test]
 fn json_snapshot() {
     let out = json(&fixture()).expect("json serialize");
-    insta::assert_snapshot!("json", out);
+    json_snapshot_settings().bind(|| insta::assert_snapshot!("json", out));
 }
 
 #[test]
 fn json_stats_snapshot() {
     let out = json(&grouped_fixture()).expect("json serialize grouped");
-    insta::assert_snapshot!("json_stats", out);
+    json_snapshot_settings().bind(|| insta::assert_snapshot!("json_stats", out));
 }
 
 #[test]

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 {
   "ignored": 0,
-  "plumb_version": "0.0.2",
+  "plumb_version": "[redacted]",
   "run_id": "sha256:53a662be238be796f9a08b74adb05e4020dd3d9f653e9bf91a7fb5b1c7a274c0",
   "stats": {
     "counts": {

--- a/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
+++ b/crates/plumb-format/tests/snapshots/format_snapshots__json_stats.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 {
   "ignored": 0,
-  "plumb_version": "0.0.2",
+  "plumb_version": "[redacted]",
   "run_id": "sha256:f47589f64fe0e1ced94e916195257a272a6e8509a8ed2831c060a7398d2f86e6",
   "stats": {
     "counts": {


### PR DESCRIPTION
## Summary

Closes #249. Stops the JSON envelope snapshots from churning on every release.

The two snapshots assert \`\"plumb_version\": \"0.0.X\"\` literally. The value comes from \`env!(\"CARGO_PKG_VERSION\")\`, so v0.0.1 → 0.0.2 broke main CI (fixed in #248) and v0.0.2 → 0.0.3 would have broken release-please #250 the same way.

## Fix

- Enable insta's \`filters\` feature.
- Redact \`\"plumb_version\": \"X.Y.Z\"\` to \`\"plumb_version\": \"[redacted]\"\` via a shared \`Settings::add_filter\` helper bound around the two json snapshot calls.
- Update the two snapshot files to the redacted token.

## Test plan

- [x] \`cargo nextest run -p plumb-format\` green (36/36)
- [ ] After merge, release-please #250 rebases without the snapshot drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)