### PR TITLE
fix(ci): cargo update + dist rename for v0.0.3 publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,13 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Refresh Cargo.lock for bumped workspace deps
+        # release-please bumps the workspace-dep `version` fields in
+        # Cargo.toml but does not touch Cargo.lock, so `cargo publish
+        # --locked` rejects the package. `cargo update --workspace`
+        # regenerates lockfile entries for the workspace crates only;
+        # external dep versions stay pinned to whatever was in main.
+        run: cargo update --workspace
       - name: Publish crates (bottom-up dependency order)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,11 @@ jobs:
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-dist
         run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
-      - name: cargo dist plan
+      - name: dist plan
         id: plan
         run: |
           set -euo pipefail
-          manifest="$(cargo dist plan --tag "${RELEASE_TAG}" --output-format=json)"
+          manifest="$(dist plan --tag "${RELEASE_TAG}" --output-format=json)"
           echo "$manifest" > dist-manifest.json
           echo "manifest<<EOF" >> "$GITHUB_OUTPUT"
           echo "$manifest" >> "$GITHUB_OUTPUT"
@@ -115,11 +115,11 @@ jobs:
       - name: Install musl toolchain
         if: endsWith(matrix.target, '-musl')
         run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: cargo dist build
+      - name: dist build
         shell: bash
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: cargo dist build --tag "${RELEASE_TAG}" --target ${{ matrix.target }}
+        run: dist build --tag "${RELEASE_TAG}" --target ${{ matrix.target }}
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/distrib/*
@@ -145,10 +145,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: cargo-bins/cargo-binstall@main
       - run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
-      - name: cargo dist build installers
+      - name: dist build installers
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: cargo dist build --tag "${RELEASE_TAG}" --artifacts=global
+        run: dist build --tag "${RELEASE_TAG}" --artifacts=global
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: target/distrib/plumb-installer.*
@@ -172,8 +172,8 @@ jobs:
           merge-multiple: true
       - uses: cargo-bins/cargo-binstall@main
       - run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
-      - name: cargo dist host
+      - name: dist host
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: cargo dist host --tag "${RELEASE_TAG}" --steps=upload --steps=release
+        run: dist host --tag "${RELEASE_TAG}" --steps=upload --steps=release


### PR DESCRIPTION
## Summary

Two release-pipeline fixes blocking v0.0.3 publish.

### 1. \`cargo publish --locked\` rejects bumped Cargo.lock

release-please bumps the workspace internal-dep \`version\` fields in Cargo.toml but does not touch Cargo.lock. After v0.0.2 → v0.0.3, the publish job died with:

\`\`\`
error: cannot update the lock file /home/runner/work/plumb/plumb/Cargo.lock
       because --locked was passed to prevent this
\`\`\`

(release-please.yml run [25486100047](https://github.com/aram-devdocs/plumb/actions/runs/25486100047) publish-job 74781982731.)

**Fix**: insert \`cargo update --workspace\` before the publish loop. Scoped to local path crates only — external dep pins are unaffected.

### 2. \`cargo dist\` → \`dist\` rename

cargo-dist 0.28.0 ships the binary as \`dist\`, not \`cargo-dist\`. \`cargo dist plan\` fails with \"no such command: dist\".

\`\`\`
INFO   - dist => /home/runner/.cargo/bin/dist
error: no such command: \`dist\`
\`\`\`

(release.yml dispatch [25486131253](https://github.com/aram-devdocs/plumb/actions/runs/25486131253) Plan job 74782062466.)

**Fix**: replace every \`cargo dist <subcmd>\` with \`dist <subcmd>\` in release.yml.

## Test plan

- [ ] After merge, manually retry: \`gh workflow run release-please.yml --ref main\` (re-publishes v0.0.3 to crates.io)
- [ ] After above passes, manually retry: \`gh workflow run release.yml --ref main -f tag=v0.0.3\` (cargo-dist build/upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)