### PR TITLE
fix(ci): publish_tag dispatch + [profile.dist] for v0.0.3 release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      publish_tag:
+        description: "Force-publish this existing tag to crates.io (e.g. v0.0.3). Skips the release-please step."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -32,13 +37,17 @@ jobs:
   crates-io:
     name: Publish to crates.io
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    # Run when release-please cut a new tag, OR when an operator passes
+    # `publish_tag` via workflow_dispatch to retry an existing tag.
+    if: |
+      needs.release-please.outputs.release_created == 'true' ||
+      inputs.publish_tag != ''
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ inputs.publish_tag || needs.release-please.outputs.tag_name }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Refresh Cargo.lock for bumped workspace deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cdp"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chromiumoxide",
  "criterion",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-codegen"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "indexmap",
  "insta",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-config"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "dunce",
  "figment",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "indexmap",
  "insta",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-e2e"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-format"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "indexmap",
  "insta",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-mcp"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "axum",
  "indexmap",
@@ -4432,7 +4432,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,14 @@ strip = "symbols"
 debug = false
 incremental = false
 
+# cargo-dist requires a `[profile.dist]` section to build release artifacts.
+# Inherits the release profile so binaries are byte-identical to local
+# `cargo build --release` output, with `lto = "thin"` to keep cross-platform
+# build time in CI under the 25min job budget.
+[profile.dist]
+inherits = "release"
+lto = "thin"
+
 [profile.dev]
 incremental = true
 codegen-units = 256


### PR DESCRIPTION
## Summary

Two more pipeline fixes (after #248, #251, #253) blocking v0.0.3 ship.

### 1. workflow_dispatch publish path

When release-please.yml is triggered via \`workflow_dispatch\`, the action sees no version-bumping commits since the last release and exits with \`release_created=false\`, so the publish job is skipped. Adds a \`publish_tag\` input that forces the publish chain to run against an existing tag.

\`\`\`bash
gh workflow run release-please.yml --ref main -f publish_tag=v0.0.3
\`\`\`

### 2. \`[profile.dist]\` missing

cargo-dist 0.28 requires a \`[profile.dist]\` profile in the workspace Cargo.toml. Plan succeeded but every per-target build failed with:

\`\`\`
error: profile \`dist\` is not defined
× failed to find bin plumb for path+file:///.../crates/plumb-cli#0.0.3
\`\`\`

(release.yml run [25486740125](https://github.com/aram-devdocs/plumb/actions/runs/25486740125).)

**Fix**: add \`[profile.dist]\` inheriting from \`release\` with \`lto = "thin"\` to keep CI under the 25-min build budget.

## Test plan

- [ ] After merge: \`gh workflow run release-please.yml --ref main -f publish_tag=v0.0.3\` (crates publish)
- [ ] After above passes: \`gh workflow run release.yml --ref main -f tag=v0.0.3\` (cargo-dist build/upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)