### PR TITLE
fix(cdp): enable test-fake on plumb-cdp prod deps

### DIFF
--- a/crates/plumb-cdp/Cargo.toml
+++ b/crates/plumb-cdp/Cargo.toml
@@ -19,12 +19,14 @@ default = []
 # Opt-in flag for end-to-end tests that need a real Chromium binary in
 # the supported major-version range on the host. Off in `just validate`
 # / CI; flip on for local smoke runs.
-# Pulls in `plumb-core/test-fake` so `FakeDriver::snapshot` (which calls
-# `PlumbSnapshot::canned`) builds without dev-deps.
-e2e-chromium = ["plumb-core/test-fake"]
+e2e-chromium = []
 
 [dependencies]
-plumb-core = { workspace = true }
+# `test-fake` is enabled unconditionally because `FakeDriver::snapshot`
+# (the in-tree `plumb-fake://` CLI scheme) calls `PlumbSnapshot::canned`,
+# which is gated behind that feature in plumb-core. The feature name is
+# legacy — it's a runtime fixture, not a test-only path.
+plumb-core = { workspace = true, features = ["test-fake"] }
 # `fetcher` + `rustls` + `zip8` enables
 # `chromiumoxide::fetcher::BrowserFetcher` (Chrome-for-Testing download)
 # used by the auto-fetch path (issue #78). The rustls transport matches


### PR DESCRIPTION
## Summary

\`FakeDriver::snapshot\` calls \`PlumbSnapshot::canned\`, which is feature-gated. plumb-cdp's prod deps didn't enable the feature, so v0.0.4 \`cargo publish\` failed:

\`\`\`
error[E0599]: no function or associated item named \`canned\` found for struct \`PlumbSnapshot\` in the current scope
\`\`\`

(release-please.yml run [25487980978](https://github.com/aram-devdocs/plumb/actions/runs/25487980978).)

## Fix

Enable \`plumb-core/test-fake\` on plumb-cdp's prod deps (matching plumb-mcp / plumb-cli / plumb-format which already do). Strip the feature wiring from the now-empty \`e2e-chromium\` flag.

## Verified

- \`cargo publish -p plumb-cdp --dry-run --locked\` ✅ now passes locally.

## Follow-up

The \`test-fake\` feature name is misleading — \`canned()\` is a deterministic runtime fixture for the \`plumb-fake://\` CLI scheme, not a test-only construct. Renaming to \`fake-fixture\` is post-V0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)