### PR TITLE
fix(ci): include plumb-codegen in crates.io publish chain

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,9 +67,10 @@ jobs:
           #   → format (core)
           #   → cdp (core)
           #   → config (core)
+          #   → codegen (core, config)
           #   → mcp (core, format, cdp, config)
           #   → cli (all)
-          CRATES=(plumb-core plumb-format plumb-cdp plumb-config plumb-mcp plumb-cli)
+          CRATES=(plumb-core plumb-format plumb-cdp plumb-config plumb-codegen plumb-mcp plumb-cli)
           for crate in "${CRATES[@]}"; do
             echo "::group::Publishing $crate"
             echo "▸ dry-run $crate"


### PR DESCRIPTION
## Summary

plumb-cli depends on plumb-codegen, but the publish chain in release-please.yml skipped it. v0.0.6 died with:

\`\`\`
Caused by:
  no matching package named \`plumb-codegen\` found
  location searched: crates.io index
  required by package \`plumb-cli v0.0.6\`
\`\`\`

(release-please.yml run [25490156870](https://github.com/aram-devdocs/plumb/actions/runs/25490156870).)

## Fix

Insert \`plumb-codegen\` between \`plumb-config\` and \`plumb-mcp\` in the \`CRATES\` publish list. plumb-codegen depends on plumb-core + plumb-config only, so this slot satisfies the bottom-up ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)