### PR TITLE
fix(ci): drop aarch64-pc-windows-msvc target post-V0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,6 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-          - target: aarch64-pc-windows-msvc
-            os: windows-11-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,7 +18,6 @@ targets = [
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
-    "aarch64-pc-windows-msvc",
 ]
 github-attestations = true
 pr-run-mode = "plan"


### PR DESCRIPTION
## Summary

cargo-dist 0.28.0 has no native aarch64-pc-windows-msvc binstall artifact. On the windows-11-arm runner, binstall falls back to the x86_64 build, which then refuses to cross-compile to aarch64-pc-windows-msvc:

\`\`\`
× Cross-compilation from x86_64-pc-windows-msvc to aarch64-pc-windows-msvc is not supported
help: no idea how to cross-compile from x86_64-pc-windows-msvc to windows with architecture aarch64
\`\`\`

(release.yml run [25492411830](https://github.com/aram-devdocs/plumb/actions/runs/25492411830) build job 74803570069.)

## Fix

Drop the target. Windows ARM64 is < 1% of installs; ship V0 with 6 targets and re-enable post-launch.

## Follow-up

Tracked in #266 — bump cargo-dist or switch install step to source-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)