### PR TITLE
docs: pin install --version example to 0.0.9 (latest)

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -54,7 +54,7 @@ This builds from source against the version published to crates.io.
 Pin a version with `--version`:
 
 ```bash
-cargo install plumb-cli --version 0.0.2
+cargo install plumb-cli --version 0.0.9
 ```
 
 ## Homebrew


### PR DESCRIPTION
## Summary

\`docs/src/install.md\` line 57 had \`cargo install plumb-cli --version 0.0.2\`. v0.0.2 was a broken release that never published any artifacts (the empty GitHub release left over from the early publish-pipeline iteration tonight). Latest published on crates.io is v0.0.9 — verified live with \`cargo install plumb-cli\` end-to-end this session.

## Test plan

- [x] \`mdbook build docs/\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)