### PR TITLE
fix(ci): drop x86_64-apple-darwin target post-V0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ From the first release onward, this file is maintained automatically by [`releas
 
 ### Changed
 
+- Dropped `x86_64-apple-darwin` (Intel Mac) from the cargo-dist native install matrix. Intel Mac users continue to install via `cargo install plumb-cli`. Re-enable tracked in #269.
 - Docs landing page now frames Plumb around the rendered-UI gap, adds a
   demo placeholder, and points readers to install, MCP, and CI entry
   points.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,7 +13,6 @@ ci = ["github"]
 installers = ["shell", "powershell", "npm"]
 targets = [
     "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -68,6 +68,8 @@ brew install aram-devdocs/plumb/plumb
 The tap repository is `aram-devdocs/homebrew-plumb`. The formula tracks the
 latest tagged release.
 
+> **Intel Mac users**: V0 ships native binaries for Apple Silicon (aarch64) only. Install via `cargo install plumb-cli` instead. Native Intel binaries return when the upstream cargo-dist runner pool stabilizes (#269).
+
 ## npm
 
 If your project already pins CLI tools through npm:


### PR DESCRIPTION
## Summary

Drops Intel Mac (\`x86_64-apple-darwin\`) from the cargo-dist native install matrix to unblock V0 ship. GitHub's macos-13 runner pool starved tonight — single Intel-Mac build queued >50min blocking v0.0.9 release ([run 25494044353](https://github.com/aram-devdocs/plumb/actions/runs/25494044353)). 6 of 7 builds were green.

Apple Silicon coverage via \`aarch64-apple-darwin\` handles every Mac shipped since 2020. Intel Mac users continue to \`cargo install plumb-cli\` from crates.io (verified working).

## Native install matrix after this PR

| Platform | Target |
|---|---|
| macOS Apple Silicon | aarch64-apple-darwin |
| Linux x86_64 | x86_64-unknown-linux-gnu |
| Linux ARM64 | aarch64-unknown-linux-gnu |
| Linux musl | x86_64-unknown-linux-musl |
| Windows x86_64 | x86_64-pc-windows-msvc |

## Re-enable tracked in #269

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` for release.yml
- [x] \`python3 -c \"import tomllib; tomllib.load(...)\"\` for dist-workspace.toml
- [x] \`mdbook build docs/\` (notes the cargo-install fallback for Intel users)
- [x] CHANGELOG.md \`## [Unreleased]\` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)