### PR TITLE
fix(ci): wire homebrew + npm publish jobs into release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,12 @@ name: release
 # would generate. It stays in sync with `dist-workspace.toml`. Re-run
 # `cargo dist generate` locally and diff before editing.
 #
-# Cargo publish, curl installers, Homebrew tap publish, and npm publish are the
-# non-manual release channels active in this repo today. cargo-dist
-# pushes the formula to `aram-devdocs/homebrew-plumb` using the
-# `HOMEBREW_TAP_TOKEN` repo secret on each tag, and publishes the
-# unscoped `plumb-cli` npm package using the `NPM_TOKEN` repo secret.
+# Cargo publish, curl installers, Homebrew tap publish, and npm publish are the non-manual release channels active in this repo today.
+# The Homebrew formula push (to `aram-devdocs/homebrew-plumb` via the
+# `HOMEBREW_TAP_TOKEN` repo secret) and the unscoped `plumb-cli` npm
+# publish (via the `NPM_TOKEN` repo secret) are hand-authored here as
+# the `publish-homebrew` and `publish-npm` jobs; cargo-dist's built-in
+# publish-jobs require its auto-generated workflow, which we do not use.
 # `dist-workspace.toml` enables npm by listing it in `installers` with
 # `npm-scope` left unset; that emits `plumb-cli-npm-package.tar.gz` and
 # publishes under the cargo package name (`plumb-cli`). Public install:
@@ -147,7 +148,7 @@ jobs:
         run: dist build --tag "${RELEASE_TAG}" --artifacts=global
       - uses: actions/attest-build-provenance@v4
         with:
-          subject-path: target/distrib/plumb-installer.*
+          subject-path: target/distrib/plumb-cli*
       - uses: actions/upload-artifact@v7
         with:
           name: artifacts-installers
@@ -173,3 +174,64 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: dist host --tag "${RELEASE_TAG}" --steps=upload --steps=release
+
+  publish-homebrew:
+    name: Publish Homebrew formula
+    needs: [plan, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: target/distrib/
+          pattern: artifacts-installers
+          merge-multiple: true
+      - name: Push formula to aram-devdocs/homebrew-plumb
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          set -euo pipefail
+          if [ ! -f target/distrib/plumb-cli.rb ]; then
+            echo "::error::plumb-cli.rb not found in target/distrib"
+            ls -la target/distrib/
+            exit 1
+          fi
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/aram-devdocs/homebrew-plumb.git" tap
+          mkdir -p tap/Formula
+          cp target/distrib/plumb-cli.rb tap/Formula/plumb.rb
+          cd tap
+          git add Formula/plumb.rb
+          if git diff --cached --quiet; then
+            echo "No formula changes for ${RELEASE_TAG}"
+          else
+            git commit -m "plumb ${RELEASE_TAG}"
+            git push
+          fi
+
+  publish-npm:
+    name: Publish npm package
+    needs: [plan, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v8
+        with:
+          path: target/distrib/
+          pattern: artifacts-installers
+          merge-multiple: true
+      - name: Publish plumb-cli to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -f target/distrib/plumb-cli-npm-package.tar.gz ]; then
+            echo "::error::plumb-cli-npm-package.tar.gz not found in target/distrib"
+            ls -la target/distrib/
+            exit 1
+          fi
+          npm publish --access public target/distrib/plumb-cli-npm-package.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 From the first release onward, this file is maintained automatically by [`release-please`](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org/) on `main`. Do not edit released sections by hand.
 
+## [Unreleased]
+
+### Added
+- Homebrew tap publish job (`aram-devdocs/homebrew-plumb`) wired into release.yml.
+- npm package publish job (`plumb-cli` unscoped) wired into release.yml.
+
 ## [0.0.10](https://github.com/aram-devdocs/plumb/compare/v0.0.9...v0.0.10) (2026-05-07)
 
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,16 +22,21 @@ github-attestations = true
 pr-run-mode = "plan"
 allow-dirty = ["ci"]
 
-# Homebrew publishing is enabled: the `aram-devdocs/homebrew-plumb` tap
-# (https://github.com/aram-devdocs/homebrew-plumb) exists and is wired for
-# cargo-dist, and the `HOMEBREW_TAP_TOKEN` repo secret is populated.
+# Homebrew formula generation is enabled here so cargo-dist emits
+# `plumb-cli.rb` as a global artifact. Publishing the formula to the
+# `aram-devdocs/homebrew-plumb` tap is hand-authored in the
+# `publish-homebrew` job in `.github/workflows/release.yml` (cargo-dist's
+# built-in publish-jobs require its auto-generated workflow, which we do
+# not use). The `HOMEBREW_TAP_TOKEN` repo secret powers that push.
 tap = "aram-devdocs/homebrew-plumb"
 
-# npm publishing is enabled as an unscoped package. With `npm` in the
-# installers list and no `npm-scope` set, cargo-dist 0.28.0 emits an
-# unscoped `plumb-cli` package (matching the cargo package name) that
-# publishes to the npm account associated with the repo's `NPM_TOKEN`
-# secret. Public install command: `npm i -g plumb-cli`.
+# npm package generation is enabled as an unscoped package. With `npm` in
+# the installers list and no `npm-scope` set, cargo-dist 0.28.0 emits an
+# unscoped `plumb-cli` package (matching the cargo package name) as
+# `plumb-cli-npm-package.tar.gz`. Publishing that tarball is hand-authored
+# in the `publish-npm` job in `.github/workflows/release.yml` (not via
+# cargo-dist's built-in publish-jobs). The `NPM_TOKEN` repo secret powers
+# that push. Public install command: `npm i -g plumb-cli`.
 
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"


### PR DESCRIPTION
## Summary

cargo-dist v0.0.10 [run 25496775188](https://github.com/aram-devdocs/plumb/actions/runs/25496775188) generated all 5 native builds + the four installer artifacts (\`plumb-cli-installer.sh\`, \`plumb-cli-installer.ps1\`, \`plumb-cli.rb\`, \`plumb-cli-npm-package.tar.gz\`) successfully, but:

1. **Attest step glob mismatch** — \`subject-path: target/distrib/plumb-installer.*\` didn't match the actual \`plumb-cli*\` filenames cargo-dist 0.28 emits.
2. **No \`publish-homebrew\` or \`publish-npm\` jobs existed** — the homebrew tap never received the formula and \`plumb-cli\` never went to npm.

## Fix

- Glob: \`plumb-installer.*\` → \`plumb-cli*\`.
- Add \`publish-homebrew\` job: clones \`aram-devdocs/homebrew-plumb\`, copies \`plumb-cli.rb\` to \`Formula/plumb.rb\`, commits, pushes via \`HOMEBREW_TAP_TOKEN\`.
- Add \`publish-npm\` job: extracts \`plumb-cli-npm-package.tar.gz\` and runs \`npm publish\` via \`NPM_TOKEN\`.
- Both depend on the existing \`publish\` job so they only run after the GitHub Release exists.
- Update \`dist-workspace.toml\` comments to reflect that publish-jobs are hand-authored (cargo-dist's built-in publish-jobs require its auto-generated workflow).

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` ✅
- [ ] After merge: release-please cuts v0.0.11 → cargo-dist runs full chain → brew formula appears in tap, \`plumb-cli\` lands on npm
- [ ] \`brew install aram-devdocs/plumb/plumb\` works
- [ ] \`npm i -g plumb-cli\` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)