### PR TITLE
chore(ci): use gh release upload in publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
         run: ls -la target/distrib/
       - name: Upload artifacts to GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,13 +167,31 @@ jobs:
           path: target/distrib/
           pattern: artifacts-*
           merge-multiple: true
-      - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall --no-confirm --force --locked cargo-dist@0.28.0
-      - name: dist host
+      - name: List artifacts to upload
+        run: ls -la target/distrib/
+      - name: Upload artifacts to GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: dist host --tag "${RELEASE_TAG}" --steps=upload --steps=release
+        run: |
+          set -euo pipefail
+          # Upload every file in target/distrib/ as a release asset.
+          # `--clobber` lets us re-run this step against an existing
+          # release (e.g. via workflow_dispatch retry).
+          shopt -s nullglob
+          assets=(target/distrib/plumb-cli-*.tar.xz \
+                  target/distrib/plumb-cli-*.tar.xz.sha256 \
+                  target/distrib/plumb-cli-installer.* \
+                  target/distrib/plumb-cli.rb \
+                  target/distrib/plumb-cli-npm-package.tar.gz \
+                  target/distrib/source.tar.gz \
+                  target/distrib/source.tar.gz.sha256 \
+                  target/distrib/sha256.sum)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::No release assets found in target/distrib/"
+            exit 1
+          fi
+          gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber --repo "${GITHUB_REPOSITORY}"
 
   publish-homebrew:
     name: Publish Homebrew formula


### PR DESCRIPTION
## Summary

Replaces \`dist host --steps=upload --steps=release\` with direct \`gh release upload\` in the publish job. cargo-dist 0.28's \`--steps=release\` is invalid (valid steps are check/create-release/upload/announce) and \`--steps=upload\` apparently no-ops with our hosting config. v0.0.11 [run 25499249346](https://github.com/aram-devdocs/plumb/actions/runs/25499249346) reported success but uploaded zero assets — leaving the Homebrew formula pointing at 404s.

\`gh release upload --clobber\` is deterministic, idempotent for retries, and uses the pre-installed CLI on every runner.

## Test plan

After merge, retest WITHOUT bumping the version:
\`\`\`
gh workflow run release.yml --ref main -f tag=v0.0.11
\`\`\`

Then verify:
- [ ] \`gh release view v0.0.11\` shows the 5 platform tarballs + sha256 sidecars + installer.sh + installer.ps1 + plumb-cli.rb + plumb-cli-npm-package.tar.gz
- [ ] \`brew install aram-devdocs/plumb/plumb\` works (formula already pushed in v0.0.11)
- [ ] \`npm i -g plumb-cli\` works (already published, but re-publish-noop on retry is idempotent)

\`chore(ci):\` type so release-please does not bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)