### PR TITLE
fix(ci,docs): repair install path and attestation references

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -19,6 +19,12 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to smoke (e.g. v0.0.11). Leave empty to use the latest release."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -42,8 +48,11 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "$REF_TYPE" == "tag" ]]; then
+          if [[ -n "$INPUT_TAG" ]]; then
+            tag="$INPUT_TAG"
+          elif [[ "$REF_TYPE" == "tag" ]]; then
             tag="$REF_NAME"
           else
             tag="$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null || true)"
@@ -133,21 +142,21 @@ jobs:
         if: "!matrix.gated && matrix.channel == 'curl' && runner.os != 'Windows'"
         shell: bash
         env:
-          INSTALLER_URL: "https://github.com/${{ github.repository }}/releases/download/${{ needs.resolve-tag.outputs.tag }}/plumb-installer.sh"
+          INSTALLER_URL: "https://github.com/${{ github.repository }}/releases/download/${{ needs.resolve-tag.outputs.tag }}/plumb-cli-installer.sh"
           REPO: ${{ github.repository }}
         run: |
-          curl -LsSf -o plumb-installer.sh "$INSTALLER_URL"
-          gh attestation verify plumb-installer.sh --repo "$REPO"
-          sh plumb-installer.sh
+          curl -LsSf -o plumb-cli-installer.sh "$INSTALLER_URL"
+          gh attestation verify plumb-cli-installer.sh --repo "$REPO"
+          sh plumb-cli-installer.sh
 
       - name: Install via curl (windows)
         if: "!matrix.gated && matrix.channel == 'curl' && runner.os == 'Windows'"
         shell: pwsh
         env:
-          INSTALLER_URL: "https://github.com/${{ github.repository }}/releases/download/${{ needs.resolve-tag.outputs.tag }}/plumb-installer.ps1"
+          INSTALLER_URL: "https://github.com/${{ github.repository }}/releases/download/${{ needs.resolve-tag.outputs.tag }}/plumb-cli-installer.ps1"
           REPO: ${{ github.repository }}
         run: |
-          $installer = Join-Path $PWD "plumb-installer.ps1"
+          $installer = Join-Path $PWD "plumb-cli-installer.ps1"
           Invoke-WebRequest -Uri "$env:INSTALLER_URL" -OutFile $installer
           gh attestation verify $installer --repo "$env:REPO"
           & $installer

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,13 @@
 name: Deploy docs to GitHub Pages
 
+# Triggered on release so the docs site is versioned and never ahead of
+# the published binary. The deployed `install.sh` / `install.ps1` scripts
+# and the JSON Schema sidecar are pulled from the published release, so
+# the one-liners on the install page always resolve to the binary that
+# the rest of the page documents.
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -29,8 +34,64 @@ jobs:
         with:
           mdbook-version: "latest"
 
+      - name: Resolve latest release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName 2>/dev/null || echo dev)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $tag"
+
+      - name: Stamp release version into book theme
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Replace the build-time sentinel in theme/head.hbs so every
+          # page in the deployed book exposes the release tag as a meta
+          # tag (`<meta name="plumb-version" content="vX.Y.Z">`).
+          sed -i "s/__PLUMB_VERSION__/${TAG}/g" theme/head.hbs
+
       - name: mdbook build
         run: mdbook build
+
+      - name: Publish version stamp
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Sibling resource for tooling that wants the deployed version
+          # without parsing HTML.
+          printf '%s\n' "$TAG" > book/version.txt
+
+      - name: Publish JSON schema with the book
+        run: |
+          set -euo pipefail
+          # The starter `plumb.toml` references this URL via `$schema`.
+          # Shipping the schema next to the book keeps that link live.
+          mkdir -p book/schemas
+          cp schemas/plumb.toml.json book/schemas/
+
+      - name: Fetch latest installer scripts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The install page documents `https://plumb.aramhammoudeh.com/install.sh`
+          # and `install.ps1`. Pull the cargo-dist installers from the
+          # latest release and serve them under those paths so the
+          # documented one-liners work.
+          gh release download --repo "$REPO" \
+            --pattern 'plumb-cli-installer.sh' \
+            --output book/install.sh
+          gh release download --repo "$REPO" \
+            --pattern 'plumb-cli-installer.ps1' \
+            --output book/install.ps1
+          chmod +x book/install.sh
 
       - uses: extractions/setup-just@v4
 

--- a/book.toml
+++ b/book.toml
@@ -13,6 +13,7 @@ edit-url-template = "https://github.com/aram-devdocs/plumb/edit/main/{path}"
 git-repository-url = "https://github.com/aram-devdocs/plumb"
 site-url = "/"
 cname = "plumb.aramhammoudeh.com"
+theme = "theme"
 
 [output.html.fold]
 enable = true

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -30,6 +30,13 @@ Windows (PowerShell):
 irm https://plumb.aramhammoudeh.com/install.ps1 | iex
 ```
 
+> **Windows note:** the PowerShell installer relies on the GitHub
+> Actions build attestation for integrity. It does not verify the
+> published `.sha256` sidecar — that gap is in upstream `cargo-dist` and
+> is tracked for follow-up. If you want belt-and-braces verification,
+> download the archive and run `gh attestation verify` (see [Verify
+> release attestations](#verify-release-attestations)).
+
 If you want to read the script first, fetch it without piping to
 `sh`:
 
@@ -54,7 +61,7 @@ This builds from source against the version published to crates.io.
 Pin a version with `--version`:
 
 ```bash
-cargo install plumb-cli --version 0.0.9
+cargo install plumb-cli --version 0.0.11
 ```
 
 ## Homebrew
@@ -148,7 +155,7 @@ tampering.
 Install the [GitHub CLI](https://cli.github.com/) (`gh`), then:
 
 ```bash
-gh attestation verify plumb-x86_64-unknown-linux-gnu.tar.xz \
+gh attestation verify plumb-cli-x86_64-unknown-linux-gnu.tar.xz \
   --repo aram-devdocs/plumb
 ```
 
@@ -160,7 +167,7 @@ command exits 0 if the attestation is valid.
 | Artifact kind | Attested? |
 |---------------|-----------|
 | Platform archives (`.tar.xz`, `.zip`) | Yes |
-| Installer scripts (`plumb-installer.sh`, `plumb-installer.ps1`) | Yes |
+| Installer scripts (`plumb-cli-installer.sh`, `plumb-cli-installer.ps1`) | Yes |
 
 The attestation binds each file's SHA-256 digest to the GitHub Actions
 workflow run that produced it. You can inspect the full SLSA provenance
@@ -168,7 +175,7 @@ bundle on the release page under **Attestations**, or query it
 programmatically:
 
 ```bash
-gh attestation verify plumb-x86_64-unknown-linux-gnu.tar.xz \
+gh attestation verify plumb-cli-x86_64-unknown-linux-gnu.tar.xz \
   --repo aram-devdocs/plumb \
   --format json | jq '.verificationResult.statement'
 ```
@@ -180,7 +187,7 @@ release assets. To verify offline, first export the attestation bundle
 while you have network access:
 
 ```bash
-gh attestation download plumb-x86_64-unknown-linux-gnu.tar.xz \
+gh attestation download plumb-cli-x86_64-unknown-linux-gnu.tar.xz \
   --repo aram-devdocs/plumb \
   --output-file bundle.jsonl
 ```
@@ -193,5 +200,5 @@ cosign verify-blob \
   --bundle bundle.jsonl \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github\.com/aram-devdocs/plumb/' \
-  plumb-x86_64-unknown-linux-gnu.tar.xz
+  plumb-cli-x86_64-unknown-linux-gnu.tar.xz
 ```

--- a/tests/install-smoke-validate.sh
+++ b/tests/install-smoke-validate.sh
@@ -164,9 +164,9 @@ else
     fail "cargo channel does not install a locked crates.io source release"
 fi
 
-if grep -Fq 'curl -LsSf -o plumb-installer.sh "$INSTALLER_URL"' "$WORKFLOW" \
-    && grep -Fq 'gh attestation verify plumb-installer.sh --repo "$REPO"' "$WORKFLOW" \
-    && grep -Fq 'sh plumb-installer.sh' "$WORKFLOW"; then
+if grep -Fq 'curl -LsSf -o plumb-cli-installer.sh "$INSTALLER_URL"' "$WORKFLOW" \
+    && grep -Fq 'gh attestation verify plumb-cli-installer.sh --repo "$REPO"' "$WORKFLOW" \
+    && grep -Fq 'sh plumb-cli-installer.sh' "$WORKFLOW"; then
     pass "curl unix channel verifies the fetched installer before execution"
 else
     fail "curl unix channel does not verify the fetched installer before execution"

--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -1,0 +1,6 @@
+<!--
+  Injected by `mdbook build`. The version placeholder is replaced by
+  the GitHub Pages workflow with the latest published release tag, so
+  every deployed page is provably anchored to a release artifact.
+-->
+<meta name="plumb-version" content="__PLUMB_VERSION__">


### PR DESCRIPTION
## Summary

- Wires `plumb-cli-installer.sh`, `plumb-cli-installer.ps1`, and `schemas/plumb.toml.json` into the deployed mdBook so the documented one-liners and the starter `plumb.toml` `$schema` URL stop 404'ing.
- Switches `pages.yml` from `push: main` to `release: published` so the docs site is versioned per release. Stamps the latest release tag into a `theme/head.hbs` override and into `book/version.txt` for tooling.
- Fixes `install-smoke.yml` asset filenames (`plumb-cli-installer.{sh,ps1}`) and adds a `workflow_dispatch.inputs.tag` input for ad-hoc smoke runs.
- Corrects four `gh attestation verify` examples plus the "What gets attested" table in `docs/src/install.md` to use real `plumb-cli-...` asset names; bumps pin example from `0.0.9` to `0.0.11`.
- Investigates `install.ps1` SHA-256 verification — cargo-dist 0.28's `installer.ps1.j2` has no `verify_checksum` helper (string-grep confirmed). Documented as a Windows note; deferred to a follow-up since wrapping the cargo-dist installer is outside this PR's scope.

Closes audit findings B1 (install path 404), B6 (schema URL 404), H1 (attestation example asset name), H3 (smoke workflow asset name), H8 (pin-version stale), and the "version the docs site via release-please" ask.

H2 (install.ps1 sha256 verification) deferred — see the Windows note in `install.md`.

## Test plan

- [x] `just validate` passes locally.
- [x] `just install-smoke-validate` passes (validator updated alongside the asset rename).
- [x] `mdbook build` succeeds; the `__PLUMB_VERSION__` sentinel survives Handlebars rendering and reaches the deployed HTML.
- [ ] After merge: `curl -fI https://plumb.aramhammoudeh.com/install.sh` returns 200.
- [ ] After merge: `curl -fI https://plumb.aramhammoudeh.com/install.ps1` returns 200.
- [ ] After merge: `curl -fI https://plumb.aramhammoudeh.com/schemas/plumb.toml.json` returns 200.
- [ ] After merge: `curl -fI https://plumb.aramhammoudeh.com/version.txt` returns 200 with the published tag as body.
- [ ] Manual `gh workflow run install-smoke.yml -f tag=v0.0.11` passes on every leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)