### PR TITLE
docs(theme): bump sidebar link min-height to 24px to satisfy a11y/touch-target

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -14,6 +14,7 @@ git-repository-url = "https://github.com/aram-devdocs/plumb"
 site-url = "/"
 cname = "plumb.aramhammoudeh.com"
 theme = "theme"
+additional-css = ["docs/theme/css/custom.css"]
 
 [output.html.fold]
 enable = true

--- a/docs/theme/css/custom.css
+++ b/docs/theme/css/custom.css
@@ -1,0 +1,25 @@
+/* Plumb book — custom theme overrides.
+ *
+ * Sidebar chapter links: ensure a >= 24 px touch target per WCAG 2.5.8
+ * (Target Size, Minimum). The default mdBook theme produces ~22 px tall
+ * sidebar anchors on common viewports, which trips Plumb's own
+ * `a11y/touch-target` rule (default `min_height_px = 24`) when the docs
+ * site is self-linted. Bumping `min-height` plus padding/line-height
+ * keeps the sidebar above the 24 px floor without disrupting layout.
+ */
+.chapter li a,
+.chapter li.affix a,
+.chapter li.expanded a,
+.chapter li.chapter-item a {
+    min-height: 24px;
+    line-height: 1.5;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    display: flex;
+    align-items: center;
+}
+
+/* Maintain visual rhythm for non-link list items (numbered prefixes, dividers). */
+.chapter li {
+    line-height: 1.5;
+}


### PR DESCRIPTION
## Summary
- Adds `docs/theme/css/custom.css` and wires it via `book.toml`'s `additional-css`.
- Bumps sidebar chapter link min-height from ~22 px to 24 px so the docs site passes Plumb's own `a11y/touch-target` rule (default `min_height_px = 24`).

## Why
From the share-readiness audit (finding H33). When `plumb lint https://plumb.aramhammoudeh.com` was run against the deployed docs site, the stock mdBook sidebar tripped Plumb's own `a11y/touch-target` rule because chapter anchors render at ~22 px on common viewports — below the 24 px WCAG 2.5.8 floor. Fixing this avoids the embarrassing "linter fails its own docs site" moment.

## Approach
- Targets `.chapter li a` (the sidebar anchors inside `<ol class="chapter">`) plus `.chapter-item` and `.expanded` permutations.
- Uses `min-height: 24px` plus `padding-top: 4px` / `padding-bottom: 4px` and `display: flex; align-items: center;` so the touch target is honored even when the line-height alone wouldn't reach 24 px.
- Leaves `theme/head.hbs` untouched so it can coexist with parallel theme work (PR 1's version-stamp).

## Test plan
- [x] `mdbook build` succeeds; the hashed CSS (`book/docs/theme/css/custom-<hash>.css`) is referenced from `book/index.html`.
- [x] `just validate` passes on the branch.
- [ ] After deploy: `plumb lint https://plumb.aramhammoudeh.com` no longer reports `a11y/touch-target` violations on the sidebar.