### PR TITLE
chore: sync Cargo.lock to v0.0.12 + gitignore mdbook build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ e2e-sites/*/.angular/
 e2e-sites/*/out/
 # Next.js build cache.
 e2e-sites/*/.next/
+
+# mdBook build outputs (book.toml build-dir = "book"; some workflows write to docs/book/).
+/book/
+/docs/book/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cdp"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "chromiumoxide",
  "criterion",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-codegen"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "indexmap",
  "insta",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-config"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "dunce",
  "figment",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-core"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "indexmap",
  "insta",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-e2e"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-format"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "indexmap",
  "insta",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "plumb-mcp"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "axum",
  "indexmap",
@@ -4432,7 +4432,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary

Two small drift fixes spotted in a fresh checkout post-v0.0.12 release:

1. **Cargo.lock sync** — release-please bumps `workspace.package.version` in `Cargo.toml` on each release but does not refresh `Cargo.lock`. The publish job runs `cargo update --workspace` ephemerally for `cargo publish --locked`, but never commits the result. Main's `Cargo.lock` has been drifting since v0.0.6; a fresh `cargo build` always dirties the working tree.

2. **`book/` + `docs/book/` not gitignored** — mdBook build output. `book.toml` has `build-dir = "book"`, and some workflow steps write to `docs/book/`. Neither path was ignored, so `git status` always showed `docs/book/` as untracked. Add both.

A longer-term fix would be a step in release-please.yml that commits the lockfile update alongside the version bump in the release PR. Out of scope for this small chore.

## Test plan
- [x] `git status` clean after `cargo check`.
- [x] `mdbook build` no longer dirties git.