### PR TITLE
fix(ci): unstick Preflight + tolerate Dogfood warnings/nextjs flake

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -45,9 +45,19 @@ jobs:
       - name: Lint deployed docs
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+        # `plumb lint` exits 3 on warnings-only — treat that as a
+        # success signal alongside 0. Anything else (errors, infra
+        # failure) still fails the job. Mirrors the test-sites leg
+        # below.
         run: |
+          set -euo pipefail
           target/release/plumb lint https://plumb.aramhammoudeh.com/ \
-            --executable-path "$CHROME_PATH"
+            --executable-path "$CHROME_PATH" || code=$?
+          : "${code:=0}"
+          if [ "$code" != "0" ] && [ "$code" != "3" ]; then
+            echo "::error::plumb lint exited $code"
+            exit "$code"
+          fi
 
   lint-deployed-test-sites:
     name: lint deployed test-sites
@@ -99,7 +109,13 @@ jobs:
 
       # Lint the local build via the harness — establishes the local
       # violation breakdown that the deployed copy must match.
+      #
+      # Next.js leg is advisory until upstream chromiumoxide handles
+      # the WebSocket "Invalid message" warnings that fire during
+      # Next.js's hydration phase on Linux Chromium — same gate as
+      # e2e-sites.yml. Tracking via re-opened #233.
       - name: Lint local copy via harness
+        continue-on-error: ${{ matrix.framework == 'nextjs' }}
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |
@@ -116,6 +132,7 @@ jobs:
       # promises. This mirrors what the e2e-sites matrix asserts at PR
       # time, but against the live URL.
       - name: Lint deployed copy and diff against expected.json
+        continue-on-error: ${{ matrix.framework == 'nextjs' }}
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,7 +6,7 @@ name: Install smoke test
 # Matrix: {cargo, brew, npm, curl} x {ubuntu, macos, windows}.
 # All four install channels (cargo, brew, npm, curl) run live against
 # the latest published tag.
-# See dist-workspace.toml and docs/src/ci/release-prep.md for details.
+# See dist-workspace.toml for channel wiring details.
 #
 # Non-gated failures open or update a single tracking issue so the team
 # gets notified without duplicate noise.

--- a/crates/plumb-cdp/src/chrome_path.rs
+++ b/crates/plumb-cdp/src/chrome_path.rs
@@ -134,6 +134,12 @@ mod tests {
         }
     }
 
+    /// Static-ordering check that doesn't probe the filesystem. Gated
+    /// to `unix` because the assertions compare forward-slash literals
+    /// against `Path::display()`, which uses `\` separators on Windows
+    /// — and `macos_candidates` is only reached in production on macOS
+    /// (see `detect_with`), so Windows coverage adds no signal.
+    #[cfg(unix)]
     #[test]
     fn macos_candidate_order_lists_system_apps_then_user_apps() {
         let fs = FakeFs::new(&[], Some("/Users/example"));

--- a/crates/plumb-cdp/src/chrome_path.rs
+++ b/crates/plumb-cdp/src/chrome_path.rs
@@ -104,7 +104,9 @@ fn macos_candidates<P: FsProbe>(probe: &P) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{FsProbe, detect_with, macos_candidates};
+    #[cfg(unix)]
+    use super::macos_candidates;
+    use super::{FsProbe, detect_with};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
 

--- a/tests/release-security-validate.sh
+++ b/tests/release-security-validate.sh
@@ -12,7 +12,6 @@ SECURITY_WORKFLOW="$REPO_ROOT/.github/workflows/security.yml"
 DIST_CONFIG="$REPO_ROOT/dist-workspace.toml"
 JUSTFILE="$REPO_ROOT/justfile"
 CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
-RELEASE_PREP_DOC="$REPO_ROOT/docs/src/ci/release-prep.md"
 
 failures=0
 
@@ -266,15 +265,6 @@ if grep -Fq 'npm install -g plumb-cli' "$INSTALL_SMOKE"; then
     pass "install-smoke installs unscoped plumb-cli"
 else
     fail "install-smoke does not install unscoped plumb-cli"
-fi
-
-if [ -f "$RELEASE_PREP_DOC" ] \
-    && grep -Fq 'Homebrew tap publish is verified live' "$RELEASE_PREP_DOC" \
-    && grep -Fq '## npm activation for `plumb-cli`' "$RELEASE_PREP_DOC" \
-    && grep -Fq 'Issue #52 is wired in this repo state.' "$RELEASE_PREP_DOC"; then
-    pass "release prep doc records current Homebrew (verified) + npm (wired) channel state"
-else
-    fail "release prep doc does not record current Homebrew/npm channel state"
 fi
 
 # ── 7. Security audit workflow exists ──────────────────────────────


### PR DESCRIPTION
## Summary

- Drop stale `docs/src/ci/release-prep.md` guard in `tests/release-security-validate.sh`. PR #287 deleted that doc but missed this validator block, breaking CI Preflight on every push since 2026-05-07.
- Tolerate `plumb lint` exit 3 (warnings/info only) in the Dogfood `lint-canonical-docs` job, matching the test-sites leg in the same workflow.
- Add `continue-on-error: ${{ matrix.framework == 'nextjs' }}` to both Dogfood test-site `plumb lint` steps to mirror the `e2e-sites.yml` stance on the chromiumoxide hydration flake tracked in #233.
- Clean up the now-dangling `docs/src/ci/release-prep.md` reference in the `install-smoke.yml` header comment.

## Why now

CI on `main` has been failing on every push since PR #287 — the validator's stale check skips MSRV / deny / Test / Size / Coverage / Determinism / Docs as collateral. The Dogfood scheduled run has been red daily since the Phase 7 rule additions (#202, #204, #207) added rule coverage that flags the live docs site at 318 warnings/info-level violations.

## Test plan

- [x] `bash tests/release-security-validate.sh` — green locally
- [x] `just check` — green locally (fmt + clippy + all wiring validators)
- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` on both touched workflows
- [ ] CI Preflight passes on this PR
- [ ] Downstream CI jobs (MSRV, deny, Test, Size, Coverage, Determinism, Docs) actually run instead of being skipped
- [ ] Manual `gh workflow run dogfood.yml --ref main` after merge — `lint-canonical-docs` exits 0; nextjs leg either passes or shows continue-on-error green

## Out of scope

- The 318 dogfood violations on `plumb.aramhammoudeh.com` itself — content/theme cleanup, separate ticket.
- `install-smoke @ v0.0.12` 404 race vs `release.yml` upload — already healed; if it recurs on v0.0.13, separate ticket to add a wait-for-asset gate.
- e2e-sites cancellation backlog — concurrency is working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)