### PR TITLE
fix(cli): triage flags, exit codes, and grid honoring the spacing scale

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -45,16 +45,18 @@ jobs:
       - name: Lint deployed docs
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-        # `plumb lint` exits 3 on warnings-only — treat that as a
-        # success signal alongside 0. Anything else (errors, infra
-        # failure) still fails the job. Mirrors the test-sites leg
-        # below.
+        # `--min-severity error` keeps warnings off the exit code, so a
+        # warnings-only run (the steady state for the deployed docs)
+        # exits 0. An `error`-severity violation exits 1 and an infra
+        # failure exits 2 — both still fail the job. Mirrors the
+        # test-sites leg below.
         run: |
           set -euo pipefail
           target/release/plumb lint https://plumb.aramhammoudeh.com/ \
-            --executable-path "$CHROME_PATH" || code=$?
+            --executable-path "$CHROME_PATH" \
+            --min-severity error || code=$?
           : "${code:=0}"
-          if [ "$code" != "0" ] && [ "$code" != "3" ]; then
+          if [ "$code" != "0" ]; then
             echo "::error::plumb lint exited $code"
             exit "$code"
           fi
@@ -143,11 +145,12 @@ jobs:
             --config e2e-sites/plumb.toml \
             --format json \
             > deployed.json || code=$?
-          # `plumb lint` exits 3 on warnings-only — that is the expected
-          # steady state for every fixture. Anything else is an infra
-          # failure that bubbles up.
+          # `plumb lint` exits 1 when any violation is at/above the
+          # default `warn` threshold — the expected steady state for
+          # every fixture. The JSON breakdown below is the real gate;
+          # exit 2 (infra failure) still bubbles up here.
           : "${code:=0}"
-          if [ "$code" != "0" ] && [ "$code" != "3" ]; then
+          if [ "$code" != "0" ] && [ "$code" != "1" ]; then
             echo "::error::plumb lint exited $code"
             exit "$code"
           fi

--- a/crates/plumb-cli/AGENTS.md
+++ b/crates/plumb-cli/AGENTS.md
@@ -22,10 +22,14 @@ This is the ONLY crate allowed to:
 
 | Code | Meaning |
 |------|---------|
-| 0 | No violations. |
-| 1 | One or more `error`-severity violations. |
+| 0 | No violations at or above `--min-severity` (default `warn`). |
+| 1 | One or more violations at or above the `--min-severity` threshold. |
 | 2 | CLI / infrastructure failure (bad URL, missing config, driver error). |
-| 3 | Only `warning`-severity violations. |
+
+`--min-severity` (`info` < `warn` < `error`, default `warn`) decides which
+severities count toward the exit code; `--min-severity off` always exits 0.
+Code 3 is reserved by PRD §13.3 for user-facing input errors and is owned
+by clap's own usage-error path, not `exit_code_for`.
 
 ## Non-negotiable invariants
 

--- a/crates/plumb-cli/src/commands/lint.rs
+++ b/crates/plumb-cli/src/commands/lint.rs
@@ -16,10 +16,10 @@ use plumb_cdp::{
     BrowserDriver, ChromiumDriver, ChromiumOptions, Cookie, FakeDriver, Target, is_fake_url,
     parse_header_kv, validate_safe_path,
 };
-use plumb_core::{Config, Severity, ViewportKey};
+use plumb_core::{Config, ViewportKey};
 use thiserror::Error;
 
-use crate::commands::{OutputFormat, selector as selector_filter};
+use crate::commands::{OutputFormat, SeverityFilter, selector as selector_filter};
 
 /// Aggregated args for [`run`]. Bundling them into a struct keeps the
 /// `Command::Lint` dispatch readable as the flag surface grows
@@ -34,6 +34,16 @@ pub struct LintArgs {
     pub config_path: Option<PathBuf>,
     pub executable_path: Option<PathBuf>,
     pub format: OutputFormat,
+    /// Minimum severity to show and count toward the exit code
+    /// (PRD §15.4). Filters `report.reported` before render and exit
+    /// code, independently of the config `[[ignore]]` suppression.
+    pub min_severity: SeverityFilter,
+    /// When non-empty, keep only violations whose `rule_id` is in this
+    /// set. Unknown ids match nothing. Applied alongside `min_severity`.
+    pub rule_ids: Vec<String>,
+    /// Optional cap on the number of findings rendered after filtering
+    /// and the engine's deterministic sort. `None` shows all.
+    pub max_findings: Option<usize>,
     pub output_path: Option<PathBuf>,
     pub viewports: Vec<String>,
     pub selector: Option<String>,
@@ -85,6 +95,9 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
         config_path,
         executable_path,
         format,
+        min_severity,
+        rule_ids,
+        max_findings,
         output_path,
         viewports,
         selector,
@@ -180,10 +193,36 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
 
     let report = plumb_core::run_report(snapshots.iter(), &config);
 
-    let out = render(&report, format, suggest_ignores)?;
+    // PRD §15.4 — `--min-severity` and `--rule` are *view* filters layered
+    // on top of the engine's config `[[ignore]]` suppression (already
+    // reflected in `report.reported`). They narrow what the user sees and
+    // what counts toward the exit code without touching the ignored bucket.
+    let (filtered, severity_hidden) = apply_view_filters(&report.reported, min_severity, &rule_ids);
 
+    let out = render(&RenderInput {
+        violations: &filtered,
+        ignored_count: report.ignored.len(),
+        format,
+        suggest_ignores,
+        max_findings,
+        severity_hidden,
+        min_severity,
+    })?;
+
+    emit(&out, output_path.as_deref())?;
+
+    Ok(exit_code_for(&filtered))
+}
+
+/// Write the rendered lint output to `output_path`, or to stdout when it
+/// is `None`.
+///
+/// # Errors
+///
+/// Returns an error if the destination file cannot be written.
+fn emit(out: &str, output_path: Option<&Path>) -> Result<()> {
     if let Some(path) = output_path {
-        std::fs::write(&path, out)
+        std::fs::write(path, out)
             .with_context(|| format!("write lint output to {}", path.display()))?;
     } else {
         // CLI is the one place writing to stdout is permitted — hence the
@@ -193,8 +232,7 @@ pub async fn run(args: LintArgs) -> Result<ExitCode> {
             print!("{out}");
         }
     }
-
-    Ok(exit_code_for(&report.reported))
+    Ok(())
 }
 
 /// Decide which viewports to snapshot.
@@ -297,72 +335,239 @@ fn load_config(path: Option<&Path>) -> Result<Config> {
     }
 }
 
-/// Format `report` into the requested string output, optionally
-/// appending the `.plumbignore` suggestion block.
+/// Apply the PRD §15.4 view filters to the engine's reported violations.
 ///
-/// `report.ignored.len()` flows into the pretty footer
-/// (`N violation(s) suppressed by config`) and the JSON envelope
-/// (`"ignored": N`) so users can audit how many violations the
-/// loaded `[[ignore]]` entries silenced. SARIF intentionally drops
-/// the count: GitHub Code Scanning consumers parse the strict 2.1.0
-/// schema, and adding a non-standard property would either confuse
-/// them or be silently dropped.
+/// Returns the kept set (severity at/above `min_severity` and, when
+/// `rule_ids` is non-empty, a matching `rule_id`) plus a count of how many
+/// the severity threshold dropped — the pretty footer surfaces the latter.
+/// The count spans the whole reported set so it reflects the threshold's
+/// effect independent of `--rule`.
+fn apply_view_filters(
+    reported: &[plumb_core::Violation],
+    min_severity: SeverityFilter,
+    rule_ids: &[String],
+) -> (Vec<plumb_core::Violation>, usize) {
+    let filtered = reported
+        .iter()
+        .filter(|v| min_severity.keeps(v.severity))
+        .filter(|v| rule_ids.is_empty() || rule_ids.iter().any(|id| id == &v.rule_id))
+        .cloned()
+        .collect();
+    let severity_hidden = reported
+        .iter()
+        .filter(|v| !min_severity.keeps(v.severity))
+        .count();
+    (filtered, severity_hidden)
+}
+
+/// Everything `render` needs to format the post-filter violation set.
 ///
-/// `suggest_ignores` is independent of the runtime ignore filter:
-/// the suggestion list is derived from `report.reported` only —
-/// already-ignored violations don't need to be suggested back.
-fn render(
-    report: &plumb_core::RunReport,
+/// `violations` is the set after `--min-severity` and `--rule` filtering;
+/// `summary`/`stats` and the JSON envelope are computed from it in full.
+/// `max_findings` caps only the *rendered* findings list, never the
+/// counts — pretty and JSON both derive their stats (counts,
+/// `viewport_count`, `rule_count`, `run_id`) from the full filtered set so
+/// they agree. JSON records the cap in a top-level `truncated` flag and
+/// pretty appends a footer; SARIF is never capped.
+struct RenderInput<'a> {
+    /// The post-filter violations, already sorted by the engine.
+    violations: &'a [plumb_core::Violation],
+    /// How many violations the config `[[ignore]]` entries suppressed.
+    ignored_count: usize,
+    /// Output format.
     format: OutputFormat,
+    /// Append a `.plumbignore` suggestion block (PRD §15).
     suggest_ignores: bool,
-) -> Result<String> {
-    let violations = report.reported.as_slice();
-    let ignored_count = report.ignored.len();
+    /// Optional cap on the rendered findings list.
+    max_findings: Option<usize>,
+    /// How many violations `--min-severity` dropped from the reported set.
+    severity_hidden: usize,
+    /// The active `--min-severity` threshold, for the pretty footer label.
+    min_severity: SeverityFilter,
+}
+
+/// Format the post-filter violations into the requested output.
+///
+/// `ignored_count` flows into the pretty footer
+/// (`N violation(s) suppressed by config`) and the JSON envelope
+/// (`"ignored": N`) so users can audit how many violations the loaded
+/// `[[ignore]]` entries silenced. SARIF intentionally drops the count:
+/// GitHub Code Scanning consumers parse the strict 2.1.0 schema, and a
+/// non-standard property would confuse them or be silently dropped.
+///
+/// `--min-severity` / `--rule` filtering and the `--max-findings` cap are
+/// already reflected in `input.violations` and `input.max_findings`. The
+/// pretty and JSON paths surface the cap (footer / `truncated` flag);
+/// SARIF renders the full filtered set uncapped, because code-scanning
+/// consumers want every finding and the schema has no place for a
+/// truncation indicator.
+///
+/// `suggest_ignores` is independent of the runtime ignore filter: the
+/// suggestion list is derived from the post-filter violations only.
+///
+/// # Errors
+///
+/// Returns an error if JSON or SARIF serialization fails.
+fn render(input: &RenderInput<'_>) -> Result<String> {
+    let &RenderInput {
+        violations,
+        ignored_count,
+        format,
+        suggest_ignores,
+        max_findings,
+        severity_hidden,
+        min_severity,
+    } = input;
+
     Ok(match format {
         OutputFormat::Pretty => {
-            if suggest_ignores {
-                plumb_format::pretty_with_suggested_ignores_and_ignored(violations, ignored_count)
+            // Pass the FULL filtered set plus the display cap so the stats
+            // block (counts, viewport_count, rule_count, run_id) reflects
+            // every filtered violation — identical to the JSON envelope —
+            // while only the first `max_findings` findings render.
+            let mut out = if suggest_ignores {
+                plumb_format::pretty_capped_with_suggested_ignores(
+                    violations,
+                    max_findings,
+                    ignored_count,
+                )
             } else {
-                plumb_format::pretty_with_ignored(violations, ignored_count)
-            }
+                plumb_format::pretty_capped(violations, max_findings, ignored_count)
+            };
+            append_triage_footers(
+                &mut out,
+                violations.len(),
+                display_count(violations.len(), max_findings),
+                severity_hidden,
+                min_severity,
+            );
+            out
         }
         OutputFormat::Json => {
-            if suggest_ignores {
+            // Render the *full* filtered set so `summary`/`stats` count
+            // every post-filter violation, then cap the `violations`
+            // array and record the cap in a `truncated` flag.
+            let rendered = if suggest_ignores {
                 plumb_format::json_with_suggested_ignores_and_ignored(violations, ignored_count)
                     .context("serialize JSON")?
             } else {
                 plumb_format::json_with_ignored(violations, ignored_count)
                     .context("serialize JSON")?
-            }
+            };
+            cap_json_violations(&rendered, max_findings)?
         }
         OutputFormat::Sarif => {
+            // SARIF is uncapped: GitHub Code Scanning and IDE consumers
+            // want every finding, and the format has no place to record a
+            // truncation flag. `--max-findings` is a human-triage knob for
+            // the pretty and JSON paths only.
             plumb_format::sarif_with_rules(violations, &plumb_core::builtin_rule_metadata())
                 .context("serialize SARIF")?
         }
     })
 }
 
-fn exit_code_for(violations: &[plumb_core::Violation]) -> ExitCode {
-    // PRD §13.3 exit-code mapping:
-    //   0 — no violations
-    //   1 — errors present
-    //   2 — reserved for CLI/infra failures (handled in main)
-    //   3 — warnings only (no errors)
-    let mut has_error = false;
-    let mut has_warning = false;
-    for v in violations {
-        match v.severity {
-            Severity::Error => has_error = true,
-            Severity::Warning => has_warning = true,
-            Severity::Info => {}
-        }
+/// Number of findings that render after applying an optional display cap.
+/// `None` (or a cap larger than the set) shows everything; the result
+/// feeds the pretty `… and M more` footer math.
+fn display_count(total: usize, max_findings: Option<usize>) -> usize {
+    match max_findings {
+        Some(n) => n.min(total),
+        None => total,
     }
-    if has_error {
-        ExitCode::from(1)
-    } else if has_warning {
-        ExitCode::from(3)
-    } else {
+}
+
+/// English plural suffix for a count: `""` for one, `"s"` otherwise.
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+/// Append the pretty-format triage footer lines: how many findings the
+/// `--min-severity` threshold hid, then how many the `--max-findings` cap
+/// dropped. Each line is emitted only when its count is non-zero.
+fn append_triage_footers(
+    out: &mut String,
+    total: usize,
+    shown: usize,
+    severity_hidden: usize,
+    min_severity: SeverityFilter,
+) {
+    use std::fmt::Write as _;
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if severity_hidden > 0 {
+        let _ = writeln!(
+            out,
+            "  {severity_hidden} finding{} hidden below --min-severity {} (lower it to see them)",
+            plural(severity_hidden),
+            min_severity.label(),
+        );
+    }
+    let hidden_by_cap = total.saturating_sub(shown);
+    if hidden_by_cap > 0 {
+        let _ = writeln!(
+            out,
+            "  … and {hidden_by_cap} more finding{} (raise --max-findings to see them)",
+            plural(hidden_by_cap),
+        );
+    }
+}
+
+/// Cap the `violations` array of a rendered JSON envelope to
+/// `max_findings`, recording whether anything was dropped under a new
+/// top-level `"truncated"` flag. `summary`/`stats` are left untouched so
+/// they keep reflecting the full filtered set (PRD §15.4).
+///
+/// The envelope is re-emitted with alphabetically ordered top-level keys
+/// for a stable, deterministic shape; nested objects keep their own
+/// insertion order.
+fn cap_json_violations(rendered: &str, max_findings: Option<usize>) -> Result<String> {
+    use std::collections::BTreeMap;
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(rendered).context("re-parse rendered JSON envelope")?;
+    let obj = value
+        .as_object_mut()
+        .context("rendered JSON envelope is not an object")?;
+
+    let total = obj
+        .get("violations")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    let truncated = match max_findings {
+        Some(n) if n < total => {
+            if let Some(arr) = obj
+                .get_mut("violations")
+                .and_then(serde_json::Value::as_array_mut)
+            {
+                arr.truncate(n);
+            }
+            true
+        }
+        _ => false,
+    };
+    obj.insert("truncated".to_owned(), serde_json::Value::Bool(truncated));
+
+    let sorted: BTreeMap<String, serde_json::Value> = std::mem::take(obj).into_iter().collect();
+    serde_json::to_string_pretty(&sorted).context("re-serialize capped JSON envelope")
+}
+
+/// Map the post-filter violation set to a process exit code per
+/// PRD §13.3.
+///
+/// `violations` is the set remaining after `--min-severity` and `--rule`
+/// filtering. Any remaining violation yields exit code 1; an empty set
+/// yields 0. The default `--min-severity warn` drops info-level findings
+/// before this point, so an info-only or clean run exits 0 while a run
+/// with a warning or error at/above the threshold exits 1. Exit code 2
+/// (CLI / infrastructure failure) is produced in `main`; exit code 3
+/// (user-facing input error) is clap's own usage-error path.
+fn exit_code_for(violations: &[plumb_core::Violation]) -> ExitCode {
+    if violations.is_empty() {
         ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
     }
 }
 

--- a/crates/plumb-cli/src/commands/mod.rs
+++ b/crates/plumb-cli/src/commands/mod.rs
@@ -43,3 +43,58 @@ impl fmt::Display for OutputFormat {
         })
     }
 }
+
+/// `--min-severity` threshold shared by `lint` and `watch`.
+///
+/// Ordering is `Error` > `Warning` > `Info` (mirroring
+/// [`plumb_core::Severity`]'s own ordering). A violation is kept when its
+/// severity is at or above the selected level. `Off` keeps nothing, which
+/// forces a clean (exit 0) run regardless of findings.
+#[derive(Debug, Clone, Copy)]
+pub enum SeverityFilter {
+    /// Keep info, warnings, and errors.
+    Info,
+    /// Keep warnings and errors; drop info.
+    Warn,
+    /// Keep only errors.
+    Error,
+    /// Keep nothing.
+    Off,
+}
+
+impl SeverityFilter {
+    /// Whether a violation at `severity` is shown — and counts toward the
+    /// exit code — under this threshold.
+    #[must_use]
+    pub fn keeps(self, severity: plumb_core::Severity) -> bool {
+        use plumb_core::Severity;
+        match self {
+            Self::Info => true,
+            Self::Warn => severity >= Severity::Warning,
+            Self::Error => severity >= Severity::Error,
+            Self::Off => false,
+        }
+    }
+
+    /// Lowercase label used in the pretty footer.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+            Self::Off => "off",
+        }
+    }
+}
+
+impl From<crate::MinSeverity> for SeverityFilter {
+    fn from(value: crate::MinSeverity) -> Self {
+        match value {
+            crate::MinSeverity::Info => Self::Info,
+            crate::MinSeverity::Warn => Self::Warn,
+            crate::MinSeverity::Error => Self::Error,
+            crate::MinSeverity::Off => Self::Off,
+        }
+    }
+}

--- a/crates/plumb-cli/src/commands/watch.rs
+++ b/crates/plumb-cli/src/commands/watch.rs
@@ -155,13 +155,14 @@ async fn run_one_cycle(lint: &LintArgs, changed: usize) -> Result<ExitCode> {
 ///
 /// `lint::run` writes the rendered output to stdout itself; the
 /// process-level counter we care about for the status line is the
-/// PRD §13.3 exit-code bucket: errors / warnings-only / clean. We
-/// expose that as a 0-or-1 count today; a finer-grained number can
-/// land in a follow-up by threading the count out of `lint::run`.
+/// PRD §13.3 exit-code bucket: findings-at/above-threshold (exit 1) vs
+/// clean (exit 0). We expose that as a 0-or-1 count today; a
+/// finer-grained number can land in a follow-up by threading the count
+/// out of `lint::run`.
 async fn capture_lint_metrics(args: LintArgs) -> Result<(usize, ExitCode)> {
     let exit_code = run_lint(args).await?;
     let bucket = format!("{exit_code:?}");
-    let count = usize::from(bucket.contains('1') || bucket.contains('3'));
+    let count = usize::from(bucket.contains('1'));
     Ok((count, exit_code))
 }
 
@@ -312,6 +313,9 @@ fn clone_lint_args(src: &LintArgs) -> LintArgs {
         config_path: src.config_path.clone(),
         executable_path: src.executable_path.clone(),
         format: src.format,
+        min_severity: src.min_severity,
+        rule_ids: src.rule_ids.clone(),
+        max_findings: src.max_findings,
         output_path: src.output_path.clone(),
         viewports: src.viewports.clone(),
         selector: src.selector.clone(),

--- a/crates/plumb-cli/src/main.rs
+++ b/crates/plumb-cli/src/main.rs
@@ -63,6 +63,28 @@ enum Command {
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Pretty)]
         format: Format,
+        /// Minimum severity to show and count toward the exit code.
+        ///
+        /// One of `info`, `warn`, `error`, `off`. Ordering is
+        /// `error` > `warn` > `info`. The default `warn` shows warnings
+        /// and errors and hides info; `error` shows only errors; `info`
+        /// shows everything; `off` shows nothing and forces exit 0.
+        #[arg(long, value_enum, default_value_t = MinSeverity::Warn)]
+        min_severity: MinSeverity,
+        /// Show only violations from this rule id (repeatable).
+        ///
+        /// Applied on top of `--min-severity`. Unknown ids simply match
+        /// nothing, so a typo yields an empty, clean (exit 0) run.
+        #[arg(long = "rule", value_name = "RULE_ID", action = ArgAction::Append)]
+        rules: Vec<String>,
+        /// Cap the number of findings shown after severity/rule filtering
+        /// and the engine's deterministic sort.
+        ///
+        /// Pretty output gains a footer counting the hidden findings;
+        /// JSON sets a top-level `truncated` flag while `summary` keeps
+        /// counting the full filtered set. No cap when unset.
+        #[arg(long, value_name = "N")]
+        max_findings: Option<usize>,
         /// Write the rendered lint output to a file instead of stdout.
         #[arg(long, value_name = "PATH")]
         output: Option<PathBuf>,
@@ -207,6 +229,18 @@ enum Command {
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Pretty)]
         format: Format,
+        /// Minimum severity to show and count toward the exit code.
+        /// Mirrors `plumb lint --min-severity`.
+        #[arg(long, value_enum, default_value_t = MinSeverity::Warn)]
+        min_severity: MinSeverity,
+        /// Show only violations from this rule id (repeatable). Mirrors
+        /// `plumb lint --rule`.
+        #[arg(long = "rule", value_name = "RULE_ID", action = ArgAction::Append)]
+        rules: Vec<String>,
+        /// Cap the number of findings shown per cycle. Mirrors
+        /// `plumb lint --max-findings`.
+        #[arg(long, value_name = "N")]
+        max_findings: Option<usize>,
         /// Restrict the run to the named viewports (repeatable).
         #[arg(long = "viewport", value_name = "NAME", action = ArgAction::Append)]
         viewports: Vec<String>,
@@ -290,6 +324,21 @@ enum Format {
     Sarif,
 }
 
+/// Minimum severity that `plumb lint` shows and counts toward the exit
+/// code. Ordering is `error` > `warn` > `info`: a violation is kept when
+/// its severity is at or above the selected level.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum MinSeverity {
+    /// Show everything: info, warnings, and errors.
+    Info,
+    /// Show warnings and errors; hide info. The default.
+    Warn,
+    /// Show only errors.
+    Error,
+    /// Show nothing and always exit 0.
+    Off,
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 enum McpTransport {
     /// Serve MCP over stdin/stdout.
@@ -331,6 +380,9 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 config,
                 executable_path,
                 format,
+                min_severity,
+                rules,
+                max_findings,
                 output,
                 viewports,
                 selector,
@@ -351,6 +403,9 @@ fn run(cli: Cli) -> Result<ExitCode> {
                     config_path: config,
                     executable_path,
                     format: format.into(),
+                    min_severity: min_severity.into(),
+                    rule_ids: rules,
+                    max_findings,
                     output_path: output,
                     viewports,
                     selector,
@@ -377,6 +432,9 @@ fn run(cli: Cli) -> Result<ExitCode> {
                 config,
                 executable_path,
                 format,
+                min_severity,
+                rules,
+                max_findings,
                 viewports,
                 selector,
                 wait_for,
@@ -399,6 +457,9 @@ fn run(cli: Cli) -> Result<ExitCode> {
                         config_path: config,
                         executable_path,
                         format: format.into(),
+                        min_severity: min_severity.into(),
+                        rule_ids: rules,
+                        max_findings,
                         output_path: None,
                         viewports,
                         selector,

--- a/crates/plumb-cli/tests/cli_integration.rs
+++ b/crates/plumb-cli/tests/cli_integration.rs
@@ -37,7 +37,10 @@ fn lint_fake_url_emits_one_violation() -> Result<(), Box<dyn std::error::Error>>
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello"])
         .assert()
-        .code(3) // warning-only -> exit 3
+        // The canned snapshot fires one `warning`. Under the default
+        // `--min-severity warn`, a warning is at/above threshold, so the
+        // run fails with exit 1 (PRD §13.3) — not the old exit-3 bug.
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -47,7 +50,7 @@ fn lint_fake_url_json_format() -> Result<(), Box<dyn std::error::Error>> {
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "json"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"rule_id\""));
     Ok(())
 }
@@ -61,7 +64,7 @@ fn lint_fake_url_json_output_writes_exact_payload_to_file() -> Result<(), Box<dy
     let expected = Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "json"])
         .output()?;
-    assert_eq!(expected.status.code(), Some(3));
+    assert_eq!(expected.status.code(), Some(1));
     assert!(expected.stderr.is_empty());
 
     Command::cargo_bin("plumb")?
@@ -74,7 +77,7 @@ fn lint_fake_url_json_output_writes_exact_payload_to_file() -> Result<(), Box<dy
             output_path.to_str().ok_or("non-utf8 output path")?,
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout("")
         .stderr("");
 
@@ -92,7 +95,7 @@ fn lint_fake_url_sarif_output_writes_exact_payload_to_file()
     let expected = Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "sarif"])
         .output()?;
-    assert_eq!(expected.status.code(), Some(3));
+    assert_eq!(expected.status.code(), Some(1));
     assert!(expected.stderr.is_empty());
 
     Command::cargo_bin("plumb")?
@@ -105,7 +108,7 @@ fn lint_fake_url_sarif_output_writes_exact_payload_to_file()
             output_path.to_str().ok_or("non-utf8 output path")?,
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout("")
         .stderr("");
 
@@ -165,7 +168,7 @@ fn lint_fake_url_ignores_executable_path_override() -> Result<(), Box<dyn std::e
             "/definitely/not/a/chromium/binary",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -195,7 +198,7 @@ fn lint_fake_url_ignores_auto_fetch_flag() -> Result<(), Box<dyn std::error::Err
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--auto-fetch-chromium"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -298,7 +301,7 @@ fn lint_runs_every_configured_viewport_when_flag_absent() -> Result<(), Box<dyn 
         .args(["lint", "plumb-fake://hello"])
         .current_dir(workspace.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"))
         .stdout(contains("mobile"))
         .stdout(contains("desktop"));
@@ -312,7 +315,7 @@ fn lint_filters_to_named_viewport() -> Result<(), Box<dyn std::error::Error>> {
         .args(["lint", "plumb-fake://hello", "--viewport", "mobile"])
         .current_dir(workspace.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("mobile"))
         .stdout(contains("desktop").not());
     Ok(())
@@ -332,7 +335,7 @@ fn lint_repeats_viewport_flag() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .current_dir(workspace.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("mobile"))
         .stdout(contains("desktop"))
         .stdout(contains("tablet").not());
@@ -443,7 +446,7 @@ fn init_then_lint_runs_against_fake_driver() -> Result<(), Box<dyn std::error::E
         .args(["lint", "plumb-fake://hello"])
         .current_dir(dir.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/"));
     Ok(())
 }
@@ -459,7 +462,7 @@ fn lint_with_selector_matching_body_keeps_violation() -> Result<(), Box<dyn std:
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--selector", "body"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -521,7 +524,7 @@ fn lint_fake_url_json_rect_matches_requested_viewport() -> Result<(), Box<dyn st
         ])
         .current_dir(workspace.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"viewport\": \"mobile\""))
         .stdout(contains("\"width\": 375"))
         .stdout(contains("\"height\": 812"))
@@ -554,7 +557,7 @@ fn lint_accepts_wait_for_and_wait_ms_against_fake_driver() -> Result<(), Box<dyn
             "10",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -571,7 +574,7 @@ fn lint_accepts_repeated_cookies_against_fake_driver() -> Result<(), Box<dyn std
             "lang=en",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -613,7 +616,7 @@ fn lint_accepts_repeated_headers_against_fake_driver() -> Result<(), Box<dyn std
             "Authorization: Bearer xyz",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -649,7 +652,7 @@ fn lint_accepts_storage_state_path_against_fake_driver() -> Result<(), Box<dyn s
         ])
         .current_dir(dir.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -724,7 +727,7 @@ fn lint_accepts_disable_animations_and_hide_scrollbars_and_dpr()
             "2.0",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"));
     Ok(())
 }
@@ -742,7 +745,7 @@ fn lint_without_suggest_ignores_omits_section() -> Result<(), Box<dyn std::error
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("Suggested .plumbignore").not());
     Ok(())
 }
@@ -758,7 +761,7 @@ fn watch_once_runs_a_single_cycle_and_emits_status_line() -> Result<(), Box<dyn 
     Command::cargo_bin("plumb")?
         .args(["watch", "plumb-fake://hello", "--once"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"))
         .stderr(contains("watching"))
         .stderr(contains("lint:"))
@@ -771,7 +774,7 @@ fn lint_pretty_with_suggest_ignores_appends_footer() -> Result<(), Box<dyn std::
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--suggest-ignores"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("Suggested .plumbignore"))
         .stdout(contains("would suppress 1 violation"))
         .stdout(contains("# Format: <rule_id> <selector_path>"))
@@ -784,7 +787,7 @@ fn watch_once_with_json_format_emits_lint_payload() -> Result<(), Box<dyn std::e
     Command::cargo_bin("plumb")?
         .args(["watch", "plumb-fake://hello", "--once", "--format", "json"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"rule_id\""))
         .stderr(contains("watching"));
     Ok(())
@@ -801,7 +804,7 @@ fn lint_json_with_suggest_ignores_adds_array() -> Result<(), Box<dyn std::error:
             "--suggest-ignores",
         ])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"suggested_ignores\""))
         .stdout(contains("\"rule_id\": \"spacing/grid-conformance\""))
         .stdout(contains("\"selector\": \"html > body\""));
@@ -813,7 +816,7 @@ fn lint_json_without_suggest_ignores_omits_array() -> Result<(), Box<dyn std::er
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "json"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"suggested_ignores\"").not());
     Ok(())
 }
@@ -851,7 +854,7 @@ fn watch_once_with_suggest_ignores_appends_footer() -> Result<(), Box<dyn std::e
     Command::cargo_bin("plumb")?
         .args(["watch", "plumb-fake://hello", "--once", "--suggest-ignores"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("Suggested .plumbignore"))
         .stdout(contains("would suppress 1 violation"))
         .stdout(contains("spacing/grid-conformance html > body"))
@@ -927,7 +930,7 @@ reason = "selector that does not match anything in the canned snapshot"
         .args(["lint", "plumb-fake://hello"])
         .current_dir(dir.path())
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("spacing/grid-conformance"))
         .stdout(contains("suppressed by config").not());
     Ok(())
@@ -961,7 +964,7 @@ fn lint_json_without_ignore_config_emits_zero_ignored_count()
     Command::cargo_bin("plumb")?
         .args(["lint", "plumb-fake://hello", "--format", "json"])
         .assert()
-        .code(3)
+        .code(1)
         .stdout(contains("\"ignored\": 0"));
     Ok(())
 }
@@ -987,5 +990,251 @@ note = "this field does not exist on IgnoreRule"
         .assert()
         .code(2)
         .stderr(contains("note").or(contains("unknown field")));
+    Ok(())
+}
+
+// ============================================================
+// Triage flags (PRD §15.4) + exit-code mapping (PRD §13.3).
+//
+// The canned `plumb-fake://hello` snapshot fires exactly one
+// `spacing/grid-conformance` warning at `html > body`. These tests pin
+// `--min-severity`, `--rule`, and `--max-findings` against that fixture
+// without launching Chromium.
+
+/// Default `--min-severity warn`: a warning is at/above the threshold, so
+/// the run fails with exit 1 (PRD §13.3) — the old exit-3 "warning only"
+/// bucket is gone.
+#[test]
+fn lint_warning_only_run_exits_one_under_default_threshold()
+-> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello"])
+        .assert()
+        .code(1)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+/// `--min-severity error` drops the lone warning below the threshold, so
+/// the run is clean (exit 0) and a footer documents the hidden finding.
+#[test]
+fn lint_min_severity_error_hides_warning_and_exits_zero() -> Result<(), Box<dyn std::error::Error>>
+{
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--min-severity", "error"])
+        .assert()
+        .code(0)
+        .stdout(contains("spacing/grid-conformance").not())
+        .stdout(contains("hidden below --min-severity error"));
+    Ok(())
+}
+
+/// `--min-severity info` shows everything including the warning, so the
+/// run still fails with exit 1.
+#[test]
+fn lint_min_severity_info_shows_warning_and_exits_one() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--min-severity", "info"])
+        .assert()
+        .code(1)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+/// `--min-severity off` suppresses every finding and forces a clean
+/// (exit 0) run regardless of what the engine reported.
+#[test]
+fn lint_min_severity_off_shows_nothing_and_exits_zero() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--min-severity", "off"])
+        .assert()
+        .code(0)
+        .stdout(contains("spacing/grid-conformance").not())
+        .stdout(contains("No violations."));
+    Ok(())
+}
+
+/// `--rule <id>` keeps only matching violations. The fixture's rule id
+/// matches, so the warning survives and the run fails with exit 1.
+#[test]
+fn lint_rule_filter_matching_id_keeps_violation() -> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--rule",
+            "spacing/grid-conformance",
+        ])
+        .assert()
+        .code(1)
+        .stdout(contains("spacing/grid-conformance"));
+    Ok(())
+}
+
+/// An unknown `--rule` id matches nothing, leaving an empty filtered set:
+/// no output and a clean (exit 0) run. Validation is intentionally
+/// absent — a typo simply hides every finding.
+#[test]
+fn lint_rule_filter_unknown_id_matches_nothing_and_exits_zero()
+-> Result<(), Box<dyn std::error::Error>> {
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--rule", "does/not-exist"])
+        .assert()
+        .code(0)
+        .stdout(contains("spacing/grid-conformance").not());
+    Ok(())
+}
+
+/// `--max-findings` is a display cap, not a triage filter: it shrinks the
+/// rendered list and appends a footer, but the run still fails with
+/// exit 1 because the post-filter set is non-empty.
+#[test]
+fn lint_max_findings_zero_caps_pretty_output_with_footer() -> Result<(), Box<dyn std::error::Error>>
+{
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--max-findings", "0"])
+        .assert()
+        .code(1)
+        .stdout(contains("spacing/grid-conformance").not())
+        .stdout(contains(
+            "… and 1 more finding (raise --max-findings to see them)",
+        ));
+    Ok(())
+}
+
+/// With more findings than the cap, the pretty footer pluralizes the
+/// hidden count. Three viewports yield three warnings; `--max-findings 1`
+/// shows one and reports two more.
+#[test]
+fn lint_max_findings_pretty_footer_pluralizes() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = workspace_with_three_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--max-findings", "1"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stdout(contains(
+            "… and 2 more findings (raise --max-findings to see them)",
+        ));
+    Ok(())
+}
+
+/// In JSON, `--max-findings` caps the `violations` array and sets a
+/// top-level `truncated` flag, but `summary` keeps counting the full
+/// filtered set (PRD §15.4).
+#[test]
+fn lint_max_findings_json_caps_array_but_keeps_summary() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = workspace_with_two_viewports()?;
+    let output = Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "json",
+            "--max-findings",
+            "1",
+        ])
+        .current_dir(dir.path())
+        .output()?;
+    assert_eq!(output.status.code(), Some(1));
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(envelope["truncated"], serde_json::json!(true));
+    assert_eq!(
+        envelope["violations"].as_array().map(Vec::len),
+        Some(1),
+        "the array is capped to --max-findings"
+    );
+    assert_eq!(
+        envelope["summary"]["total"],
+        serde_json::json!(2),
+        "summary still counts the full filtered set"
+    );
+    Ok(())
+}
+
+/// The pretty `stats` block must count the FULL filtered set, not the
+/// `--max-findings`-capped subset. Three viewports yield three warnings;
+/// `--max-findings 1` renders one finding but the stats line, viewport,
+/// and rule counts still report the full three. Regression guard for the
+/// undercounting bug where pretty stats were computed from the capped
+/// slice.
+#[test]
+fn lint_max_findings_pretty_stats_reflect_full_set() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = workspace_with_three_viewports()?;
+    Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--max-findings", "1"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        // Full count in the stats summary line, despite the cap of 1.
+        .stdout(contains("3 violations (0 error, 3 warning, 0 info)"))
+        .stdout(contains("viewport_count: 3"))
+        .stdout(contains("rule_count: 1"))
+        .stdout(contains(
+            "… and 2 more findings (raise --max-findings to see them)",
+        ));
+    Ok(())
+}
+
+/// The pretty stats count and the JSON `summary.total` must agree for the
+/// same `--max-findings`-capped run: both derive from the full filtered
+/// set, so capping the rendered list never shifts the counts. Also pins
+/// the shared `run_id` so pretty and JSON stay coherent byte for byte.
+#[test]
+fn lint_max_findings_pretty_and_json_counts_agree() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = workspace_with_two_viewports()?;
+
+    let json_out = Command::cargo_bin("plumb")?
+        .args([
+            "lint",
+            "plumb-fake://hello",
+            "--format",
+            "json",
+            "--max-findings",
+            "1",
+        ])
+        .current_dir(dir.path())
+        .output()?;
+    let envelope: serde_json::Value = serde_json::from_slice(&json_out.stdout)?;
+    let json_total = envelope["summary"]["total"]
+        .as_u64()
+        .expect("summary.total");
+    let json_run_id = envelope["run_id"].as_str().expect("run_id").to_owned();
+    assert_eq!(
+        json_total, 2,
+        "two viewports → two warnings in the full set"
+    );
+
+    let pretty_out = Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--max-findings", "1"])
+        .current_dir(dir.path())
+        .output()?;
+    let pretty = String::from_utf8(pretty_out.stdout)?;
+
+    // The pretty stats count line must report the same full total the JSON
+    // summary does — not the capped 1.
+    assert!(
+        pretty.contains(&format!("{json_total} violations (")),
+        "pretty stats must show the full count {json_total}; got:\n{pretty}"
+    );
+    assert!(
+        pretty.contains(&format!("run_id: {json_run_id}")),
+        "pretty run_id must match the JSON run_id ({json_run_id}); got:\n{pretty}"
+    );
+    Ok(())
+}
+
+/// Without `--max-findings`, the JSON envelope always carries
+/// `"truncated": false` so consumers can rely on the key being present.
+#[test]
+fn lint_json_truncated_false_when_uncapped() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::cargo_bin("plumb")?
+        .args(["lint", "plumb-fake://hello", "--format", "json"])
+        .output()?;
+    assert_eq!(output.status.code(), Some(1));
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(envelope["truncated"], serde_json::json!(false));
     Ok(())
 }

--- a/crates/plumb-core/src/rules/spacing/grid_conformance.rs
+++ b/crates/plumb-core/src/rules/spacing/grid_conformance.rs
@@ -5,6 +5,15 @@
 //! per side, plus `gap` / `row-gap` / `column-gap`) and emits one
 //! violation per offending property when the parsed pixel value isn't
 //! a multiple of `config.spacing.base_unit`.
+//!
+//! The rule defers to the configured spacing scale. When
+//! `config.spacing.scale` is non-empty and the parsed value sits within
+//! `GRID_TOLERANCE_PX` of one of its members, the value is treated as
+//! on the design system and skipped — even when it's off the base-unit
+//! grid. This matters for Tailwind, whose scale includes 2px half-steps
+//! (6/10/14px, …) that a pure "multiple of `base_unit`" test would flag.
+//! An empty scale (the default config) restores the plain base-unit
+//! grid behavior.
 
 use indexmap::IndexMap;
 
@@ -12,7 +21,7 @@ use crate::config::Config;
 use crate::report::{Confidence, Fix, FixKind, Severity, Violation, ViolationSink};
 use crate::rules::Rule;
 use crate::rules::spacing::SPACING_PROPERTIES;
-use crate::rules::util::{nearest_multiple, parse_px};
+use crate::rules::util::{nearest_in_scale, nearest_multiple, parse_px};
 use crate::snapshot::SnapshotCtx;
 
 /// Tolerance for the off-grid test, in CSS pixels. A value within this
@@ -23,6 +32,12 @@ use crate::snapshot::SnapshotCtx;
 const GRID_TOLERANCE_PX: f64 = 0.5;
 
 /// Flags spacing values that aren't multiples of `spacing.base_unit`.
+///
+/// Values explicitly listed in `config.spacing.scale` are exempt: when
+/// the parsed value is within `GRID_TOLERANCE_PX` of a scale member it
+/// is treated as on the design system and never flagged, even if it
+/// falls off the base-unit grid. When the scale is empty the rule checks
+/// against the base unit alone.
 #[derive(Debug, Clone, Copy)]
 pub struct GridConformance;
 
@@ -53,6 +68,19 @@ impl Rule for GridConformance {
                     continue;
                 };
                 let Some(value) = parse_px(raw) else { continue };
+                // Defer to the configured spacing scale. When the design
+                // system explicitly lists a value — Tailwind populates
+                // `spacing.scale` with its tokens, including 2px
+                // half-steps like 6/10/14px — that value belongs even
+                // though it's off the `base_unit` grid. Skip the off-grid
+                // test when `value` is within `GRID_TOLERANCE_PX` of its
+                // nearest scale member. An empty scale (default config)
+                // yields `None` here, preserving the pure base-unit grid.
+                if let Some(on_scale) = nearest_in_scale(value, &config.spacing.scale)
+                    && (value.abs() - f64::from(on_scale)).abs() <= GRID_TOLERANCE_PX
+                {
+                    continue;
+                }
                 let suggested = nearest_multiple(value, base_unit);
                 #[allow(clippy::cast_precision_loss)]
                 let nearest = suggested as f64;

--- a/crates/plumb-core/tests/dogfood_phase_gate.rs
+++ b/crates/plumb-core/tests/dogfood_phase_gate.rs
@@ -6,6 +6,13 @@
 //! phase-gate failure. The fixture intentionally includes one clean
 //! control for each configured design-system scale so cross-rule noise
 //! shows up here instead of being hidden by per-rule filtering.
+//!
+//! `spacing/grid-conformance` defers to `spacing.scale`: a value the
+//! scale lists is never flagged off-grid. So a value that is off the
+//! base-unit grid is only reported when it is also off the scale, which
+//! means the same value also trips `spacing/scale-conformance`. The
+//! `#spacing-grid > .off-grid` control (`5px`, off both axes) therefore
+//! co-fires both spacing rules by design.
 
 use std::collections::BTreeMap;
 
@@ -234,7 +241,10 @@ fn dogfood_config() -> Config {
     Config {
         spacing: SpacingSpec {
             base_unit: 4,
-            scale: vec![0, 4, 5, 8, 12, 16, 24, 32, 48],
+            // `5` is deliberately absent so the `5px` off-grid control is
+            // also off-scale; grid-conformance now defers to the scale,
+            // so an on-scale value would no longer be flagged off-grid.
+            scale: vec![0, 4, 8, 12, 16, 24, 32, 48],
             tokens: IndexMap::new(),
         },
         type_scale: TypeScaleSpec {
@@ -317,7 +327,9 @@ fn phase_2_dogfood_fixture_exercises_all_mvp_rules_without_extra_findings() {
         ("radius/scale-conformance".to_owned(), 1),
         ("sibling/height-consistency".to_owned(), 1),
         ("spacing/grid-conformance".to_owned(), 1),
-        ("spacing/scale-conformance".to_owned(), 1),
+        // The `5px` off-grid control is also off-scale, so it co-fires
+        // scale-conformance alongside the `20px` on-grid/off-scale control.
+        ("spacing/scale-conformance".to_owned(), 2),
         ("type/scale-conformance".to_owned(), 1),
     ]);
 

--- a/crates/plumb-core/tests/golden_spacing_grid.rs
+++ b/crates/plumb-core/tests/golden_spacing_grid.rs
@@ -242,6 +242,91 @@ fn spacing_grid_conformance_tolerance_band() {
     );
 }
 
+/// Build a one-node snapshot carrying a single spacing property and
+/// count `spacing/grid-conformance` violations under `config`. Lets the
+/// scale-deferral tests vary both the property value and the configured
+/// `spacing.scale`.
+fn grid_violations_with(prop: &str, value: &str, config: &Config) -> usize {
+    let only = node(
+        2,
+        "html > body > div:nth-child(1)",
+        &[(prop, value)],
+        Some(Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+        }),
+    );
+    let snapshot = PlumbSnapshot {
+        url: "plumb-fake://spacing-grid-scale".into(),
+        viewport: ViewportKey::new("desktop"),
+        viewport_width: 1280,
+        viewport_height: 800,
+        nodes: vec![root_html_with_body(), body_node(), only],
+        text_boxes: Vec::new(),
+    };
+    run(&snapshot, config)
+        .into_iter()
+        .filter(|v| v.rule_id == "spacing/grid-conformance")
+        .count()
+}
+
+/// Config with an explicit `base_unit` and `spacing.scale`, everything
+/// else default. Used by the scale-deferral tests.
+fn config_with_scale(base_unit: u32, scale: Vec<u32>) -> Config {
+    Config {
+        spacing: SpacingSpec {
+            base_unit,
+            scale,
+            tokens: IndexMap::new(),
+        },
+        ..Config::default()
+    }
+}
+
+#[test]
+fn spacing_grid_conformance_defers_to_configured_scale() {
+    // Tailwind-style scale with 2px half-steps. `base_unit` stays 4, so
+    // 10px is off the base-4 grid yet explicitly on the design system's
+    // scale — it must NOT fire.
+    let config = config_with_scale(4, vec![0, 2, 4, 6, 8, 10, 12, 14, 16]);
+
+    assert_eq!(
+        grid_violations_with("padding-top", "10px", &config),
+        0,
+        "10px is on the configured scale (off base-4 grid) — no violation"
+    );
+    assert_eq!(
+        grid_violations_with("padding-top", "13px", &config),
+        1,
+        "13px is neither on the scale nor on the base-4 grid — off-grid"
+    );
+    assert_eq!(
+        grid_violations_with("padding-top", "10.4px", &config),
+        0,
+        "10.4px is within 0.5 of the scale member 10 — on-scale"
+    );
+    assert_eq!(
+        grid_violations_with("padding-top", "10.6px", &config),
+        1,
+        "10.6px is more than 0.5 from every scale member — off-grid"
+    );
+}
+
+#[test]
+fn spacing_grid_conformance_empty_scale_uses_base_unit() {
+    // Default-style config: an empty scale means the rule falls back to
+    // the pure base-unit grid. 10px is off the base-4 grid and there is
+    // no scale member to defer to.
+    let config = config_with_scale(4, Vec::new());
+    assert_eq!(
+        grid_violations_with("padding-top", "10px", &config),
+        1,
+        "empty scale → pure base-4 grid; 10px is off-grid"
+    );
+}
+
 #[test]
 fn spacing_grid_conformance_run_is_deterministic() -> Result<(), serde_json::Error> {
     let snapshot = fixture_snapshot();

--- a/crates/plumb-e2e/src/runner.rs
+++ b/crates/plumb-e2e/src/runner.rs
@@ -191,11 +191,13 @@ fn run_lint(
         site: name.to_owned(),
         reason: format!("spawn plumb binary `{}`: {err}", config.plumb_bin.display()),
     })?;
-    // PRD §13.3: 0 = clean, 1 = errors, 3 = warnings only. The fixtures
-    // intentionally produce warnings, so 3 is the steady state. Any
-    // other code is an infrastructure failure.
+    // PRD §13.3: 0 = clean, 1 = one or more violations at/above the
+    // default `--min-severity warn` threshold, 2 = CLI / infrastructure
+    // failure. The fixtures intentionally produce warnings, so exit 1 is
+    // the steady state; anything outside {0, 1} is an infrastructure
+    // failure.
     let code = output.status.code();
-    let allowed = matches!(code, Some(0 | 1 | 3));
+    let allowed = matches!(code, Some(0 | 1));
     if !allowed {
         return Err(HarnessError::Lint {
             site: name.to_owned(),

--- a/crates/plumb-format/src/lib.rs
+++ b/crates/plumb-format/src/lib.rs
@@ -62,8 +62,34 @@ pub fn pretty(violations: &[Violation]) -> String {
 /// `ignored_count == 0` produces the same output as [`pretty`].
 #[must_use]
 pub fn pretty_with_ignored(violations: &[Violation], ignored_count: usize) -> String {
-    let sorted = pretty_sorted(violations);
-    let run_id = match run_id_for_sorted(&sorted) {
+    pretty_capped(violations, None, ignored_count)
+}
+
+/// Render a pretty block whose stats reflect the FULL `violations` slice
+/// while the findings body shows only the first `display_cap` of them.
+///
+/// `plumb lint --max-findings N` routes through here. The stats block —
+/// `run_id`, the violation count line, `viewport_count`, and `rule_count`
+/// — is always computed from every violation in `violations`, so it
+/// matches the JSON envelope's `stats` for the same filtered set no matter
+/// how small `display_cap` is. `run_id` is the SHA-256 of the canonically
+/// sorted full set, identical to [`json()`]'s `run_id`, so the pretty and
+/// JSON renders of one run agree on it byte for byte.
+///
+/// `display_cap == None`, or a cap at or above `violations.len()`, renders
+/// every finding. A cap of `Some(0)` renders no findings but still prints
+/// the full stats. `ignored_count` appends the
+/// `N violation(s) suppressed by config` footer when non-zero.
+#[must_use]
+pub fn pretty_capped(
+    violations: &[Violation],
+    display_cap: Option<usize>,
+    ignored_count: usize,
+) -> String {
+    // `run_id` hashes the canonically sorted FULL set — the same input
+    // the JSON envelope hashes — so the two formats never disagree on it.
+    let canonical = canonical_sorted(violations);
+    let run_id = match run_id_for_sorted(&canonical) {
         Ok(run_id) => run_id,
         // `Violation` is JSON-serializable by construction, so this
         // branch should be unreachable in practice. Keep the pretty
@@ -71,16 +97,24 @@ pub fn pretty_with_ignored(violations: &[Violation], ignored_count: usize) -> St
         Err(_) => String::from("sha256:unavailable"),
     };
 
+    // The body renders in pretty display order; the cap keeps the first
+    // `display_cap` findings as they appear top to bottom.
+    let sorted = pretty_sorted(violations);
+    let shown: &[&Violation] = match display_cap {
+        Some(n) if n < sorted.len() => &sorted[..n],
+        _ => &sorted,
+    };
+
     let mut out = String::new();
 
-    if sorted.is_empty() {
+    if violations.is_empty() {
         out.push_str("No violations.\n");
     } else {
         let mut current_viewport: Option<&str> = None;
         let mut current_rule: Option<&str> = None;
         let mut current_selector: Option<&str> = None;
 
-        for violation in &sorted {
+        for violation in shown {
             let viewport = violation.viewport.as_str();
             if current_viewport != Some(viewport) {
                 if current_viewport.is_some() {
@@ -248,7 +282,21 @@ pub fn pretty_with_suggested_ignores_and_ignored(
     violations: &[Violation],
     ignored_count: usize,
 ) -> String {
-    let mut out = pretty_with_ignored(violations, ignored_count);
+    pretty_capped_with_suggested_ignores(violations, None, ignored_count)
+}
+
+/// Like [`pretty_capped`] but appends the suggested `.plumbignore` block.
+///
+/// The block — and its `would suppress N violation(s)` count — reflects
+/// the FULL `violations` slice, matching the JSON `suggested_ignores`
+/// array, even when `display_cap` hides some findings from the body.
+#[must_use]
+pub fn pretty_capped_with_suggested_ignores(
+    violations: &[Violation],
+    display_cap: Option<usize>,
+    ignored_count: usize,
+) -> String {
+    let mut out = pretty_capped(violations, display_cap, ignored_count);
     append_suggested_ignores_block(&mut out, violations);
     out
 }
@@ -970,8 +1018,9 @@ mod tests {
     use super::{
         MCP_COMPACT_RESPONSE_CAP_BYTES, json, json_with_ignored, json_with_suggested_ignores,
         json_with_suggested_ignores_and_ignored, mcp_compact, mcp_compact_capped, pretty,
-        pretty_with_ignored, pretty_with_suggested_ignores,
-        pretty_with_suggested_ignores_and_ignored, suggested_ignores,
+        pretty_capped, pretty_capped_with_suggested_ignores, pretty_with_ignored,
+        pretty_with_suggested_ignores, pretty_with_suggested_ignores_and_ignored,
+        suggested_ignores,
     };
     use indexmap::IndexMap;
     use plumb_core::{Severity, ViewportKey, Violation};
@@ -1234,6 +1283,98 @@ mod tests {
     fn pretty_with_ignored_zero_matches_pretty() {
         let v = vec![violation("spacing/grid-conformance", "body", "desktop", 1)];
         assert_eq!(pretty(&v), pretty_with_ignored(&v, 0));
+    }
+
+    /// A three-violation set spanning two viewports and two rules. Each
+    /// finding renders as a `warning: test` line, so counting that
+    /// substring gives the number of findings in the body.
+    fn capped_fixture() -> Vec<Violation> {
+        vec![
+            violation("a/one", "sel1", "desktop", 1),
+            violation("b/two", "sel2", "desktop", 2),
+            violation("a/one", "sel3", "mobile", 3),
+        ]
+    }
+
+    #[test]
+    fn pretty_capped_none_matches_pretty_with_ignored() {
+        // `display_cap == None` is the uncapped path — identical output to
+        // the existing entry point, so the refactor is behavior-preserving.
+        let v = capped_fixture();
+        assert_eq!(pretty_capped(&v, None, 0), pretty_with_ignored(&v, 0));
+    }
+
+    #[test]
+    fn pretty_capped_stats_reflect_full_set_not_the_cap() {
+        let v = capped_fixture();
+        let out = pretty_capped(&v, Some(1), 0);
+
+        // Only the first finding (pretty order: desktop a/one sel1) renders.
+        assert_eq!(
+            out.matches("      warning: test").count(),
+            1,
+            "cap of 1 renders exactly one finding:\n{out}"
+        );
+
+        // Stats count the full three-violation set regardless of the cap.
+        assert!(
+            out.contains("3 violations (0 error, 3 warning, 0 info)"),
+            "stats must show the full count:\n{out}"
+        );
+        assert!(out.contains("viewport_count: 2"), "stats:\n{out}");
+        assert!(out.contains("rule_count: 2"), "stats:\n{out}");
+    }
+
+    #[test]
+    fn pretty_capped_run_id_matches_json_run_id() {
+        // The pretty `run_id` is the SHA-256 of the canonically sorted full
+        // set — the same input JSON hashes — so capping the rendered body
+        // never shifts it and the two formats agree.
+        let v = capped_fixture();
+        let pretty_out = pretty_capped(&v, Some(1), 0);
+        let json_out = json(&v).expect("json serialize");
+        let envelope: serde_json::Value =
+            serde_json::from_str(&json_out).expect("json envelope parses");
+        let json_run_id = envelope["run_id"].as_str().expect("run_id present");
+
+        assert!(
+            pretty_out.contains(&format!("run_id: {json_run_id}")),
+            "pretty run_id must equal json run_id ({json_run_id}):\n{pretty_out}"
+        );
+    }
+
+    #[test]
+    fn pretty_capped_zero_renders_no_findings_but_keeps_stats() {
+        let v = capped_fixture();
+        let out = pretty_capped(&v, Some(0), 0);
+        assert_eq!(
+            out.matches("      warning: test").count(),
+            0,
+            "cap of 0 renders no findings:\n{out}"
+        );
+        assert!(
+            out.contains("3 violations (0 error, 3 warning, 0 info)"),
+            "stats survive a zero cap:\n{out}"
+        );
+        assert!(
+            !out.contains("No violations."),
+            "a capped-out body is not the empty-set 'No violations.' message:\n{out}"
+        );
+    }
+
+    #[test]
+    fn pretty_capped_with_suggested_ignores_counts_full_set() {
+        // The suggested-ignores block reflects the full set (three
+        // violations across two rules), not the single rendered finding.
+        let v = capped_fixture();
+        let out = pretty_capped_with_suggested_ignores(&v, Some(1), 0);
+        assert!(
+            out.contains("Suggested .plumbignore (would suppress 3 violations):"),
+            "suggested-ignores count must reflect the full set:\n{out}"
+        );
+        assert!(out.contains("a/one sel1"), "block lists full set:\n{out}");
+        assert!(out.contains("a/one sel3"), "block lists full set:\n{out}");
+        assert!(out.contains("b/two sel2"), "block lists full set:\n{out}");
     }
 
     #[test]

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -16,6 +16,9 @@ major version falls in Plumb's supported range (see
 | `-c`, `--config <path>` | Config file path. Defaults to `plumb.toml` in CWD. |
 | `--executable-path <path>` | Chrome or Chromium binary to use instead of auto-detection. |
 | `--format <pretty\|json\|sarif>` | Output format. Default: `pretty`. |
+| `--min-severity <info\|warn\|error\|off>` | Lowest severity to show and count toward the exit code. Default: `warn`. `off` shows nothing and exits 0. |
+| `--rule <id>` | Show only violations from this rule id. Repeatable. Unknown ids match nothing. |
+| `--max-findings <n>` | Cap the rendered findings after filtering and sorting. Pretty adds a footer; JSON sets a `truncated` flag while `summary` keeps the full count. |
 | `--output <path>` | Write rendered output to a file instead of stdout. |
 | `-v`, `--verbose` | Increase log verbosity. `-vv` for trace. |
 | `--viewport <name>` | Restrict the run to the named viewport. Repeatable. |
@@ -36,16 +39,17 @@ Exit codes:
 
 | Code | Meaning |
 |------|---------|
-| 0 | No violations, or only `info`-severity violations. |
-| 1 | One or more `error`-severity violations. |
+| 0 | No violations at or above `--min-severity` (default `warn`). |
+| 1 | One or more violations at or above the `--min-severity` threshold. |
 | 2 | CLI or infrastructure failure (bad URL, missing config, etc.). |
-| 3 | Only `warning`-severity violations (no errors). |
 
-`info`-severity violations are reported in the output but never fail
-the run on their own — the bucket is reserved for advisory checks
-(suggestions, low-confidence fixes) you might want surfaced without
-breaking CI. Use `[rules."<id>"] severity = "warning"` to promote a
-specific advisory rule into the CI-failing tier.
+`--min-severity` (`info` < `warn` < `error`, default `warn`) sets the
+threshold. The default hides `info`-severity violations from the output
+and the exit code, so advisory checks (suggestions, low-confidence fixes)
+never break CI on their own; run `--min-severity info` to surface them.
+`--min-severity off` shows nothing and always exits 0. Use
+`[rules."<id>"] severity = "warning"` to promote a specific advisory rule
+into the default CI-failing tier.
 
 ### `plumb init`
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -42,10 +42,9 @@ happened:
 
 | Code | Meaning |
 |------|---------|
-| 0 | No violations. |
-| 1 | One or more `error`-severity violations. |
+| 0 | No violations at or above `--min-severity` (default `warn`). |
+| 1 | One or more violations at or above the `--min-severity` threshold. |
 | 2 | CLI or infrastructure failure (bad URL, missing config, browser not found). |
-| 3 | Only `warning`-severity violations. |
 
 If Chrome is not on the standard path, point at it explicitly:
 

--- a/justfile
+++ b/justfile
@@ -134,14 +134,15 @@ audit:
 
 # Determinism check: run the CLI three times and byte-diff the output.
 #
-# `plumb lint` exits 3 when only warnings are present, which is the
-# walking-skeleton steady state. Bash `set -e` would treat that as a
-# failure, so each invocation is wrapped to swallow the expected code.
+# `plumb lint` exits 1 when any violation is at/above the `--min-severity`
+# threshold (default `warn`), which is the walking-skeleton steady state.
+# Bash `set -e` would treat that as a failure, so each invocation is
+# wrapped to swallow the expected code.
 determinism-check:
     @echo "▸ Determinism check (3 runs, byte-diff JSON output)…"
-    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-1.json || [ $? -eq 3 ]
-    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-2.json || [ $? -eq 3 ]
-    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-3.json || [ $? -eq 3 ]
+    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-1.json || [ $? -eq 1 ]
+    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-2.json || [ $? -eq 1 ]
+    @cargo run --quiet -p plumb-cli -- lint plumb-fake://hello --format json > /tmp/plumb-det-3.json || [ $? -eq 1 ]
     @diff -q /tmp/plumb-det-1.json /tmp/plumb-det-2.json
     @diff -q /tmp/plumb-det-2.json /tmp/plumb-det-3.json
     @echo "▸ OK — all three runs produced byte-identical output."


### PR DESCRIPTION
## Context

Two audit fixes that complete the "usable, correct DX" story.

**CLI triage + exit codes.** `plumb lint` had no way to triage output and returned **exit code 3 for warning-only runs** — which contradicts PRD §13.3 (3 = user-facing input error) and lint convention, breaking CI/agent gating.

**Grid double-flagging.** On a Tailwind project, `merge_tailwind` puts Tailwind's tokens (incl. 2px half-steps: 6/10/14px) into `spacing.scale`, but `grid-conformance` still flagged them for not being base-4 multiples — **283 false findings on ui.shadcn.com**.

## What changed

- **`--min-severity <info|warn|error|off>`** (default `warn`) — filters output *and* the exit code; the default hides advisory `info` findings (kitchen-sink 28 → 24). `--rule <id>` (repeatable) and `--max-findings <n>` (display cap; pretty footer; JSON `truncated` flag).
- **Exit codes** rewritten per PRD §13.3: any violation at/above `--min-severity` → **1**, else **0**. The `warning → 3` branch is deleted. Exit-code tables corrected in AGENTS.md, docs, the justfile determinism check, and dogfood.yml; dead exit-3 acceptance removed from `plumb-e2e`.
- **Pretty/JSON/SARIF coherence** — all derive counts and `run_id` from the *full filtered* set; `--max-findings` only caps the rendered list (new `plumb-format::pretty_capped`). Parity tests assert pretty stats == JSON `summary.total`.
- **grid-conformance respects `spacing.scale`** — a value within 0.5px of a configured scale member is no longer flagged (the scale is the explicit allow-list). Empty scale → unchanged base-unit behavior.

## Verification

`plumb lint plumb-fake://hello` → exit **1** (was 3); `--min-severity error` → **0**. New golden test proves a 10px on-scale value no longer trips grid while 13px (off-scale) still does. Full workspace suite, `clippy -D warnings`, `fmt --check`, `cargo doc -Dwarnings`, `just determinism-check`, `cargo deny` all green. Reviewed via spec / test / code-quality gates (all APPROVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)