### PR TITLE
fix(codegen): prefer light token exports

### DIFF
--- a/crates/plumb-codegen/src/ts_tokens.rs
+++ b/crates/plumb-codegen/src/ts_tokens.rs
@@ -35,8 +35,9 @@ pub(crate) fn merge_literal_token_module(
 ) -> TokenModuleImport {
     let mut exports = Parser::new(contents).parse_exported_objects();
     exports.sort_by(|a, b| {
-        token_sort_key(&a.name)
-            .cmp(&token_sort_key(&b.name))
+        export_priority(&a.name)
+            .cmp(&export_priority(&b.name))
+            .then_with(|| token_sort_key(&a.name).cmp(&token_sort_key(&b.name)))
             .then_with(|| a.name.cmp(&b.name))
     });
 
@@ -64,6 +65,14 @@ pub(crate) fn merge_literal_token_module(
     config.type_scale.weights.dedup();
 
     import
+}
+
+fn export_priority(name: &str) -> u8 {
+    match token_sort_key(name).as_str() {
+        "light" | "default" | "tokens" | "designtokens" => 0,
+        "dark" => 2,
+        _ => 1,
+    }
 }
 
 #[derive(Debug)]
@@ -852,6 +861,35 @@ mod tests {
                 .families
                 .contains(&"sans-serif".to_owned())
         );
+    }
+
+    #[test]
+    fn prefers_light_exports_before_dark_for_duplicate_color_keys() {
+        let source = r"
+            export const dark = {
+              background: '#000000',
+              primary: '#111111',
+              onlyDark: '#222222',
+            } as const;
+
+            export const light = {
+              background: '#ffffff',
+              primary: '#007068',
+            } as const;
+
+            export const otherColors = {
+              accent: '#123456',
+            } as const;
+        ";
+        let mut config = Config::default();
+
+        let import = merge_literal_token_module(&mut config, Path::new("tokens/colors.ts"), source);
+
+        assert_eq!(import.colors, 4);
+        assert_eq!(config.color.tokens["background"], "#ffffff");
+        assert_eq!(config.color.tokens["primary"], "#007068");
+        assert_eq!(config.color.tokens["accent"], "#123456");
+        assert_eq!(config.color.tokens["onlyDark"], "#222222");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prefer light/default token exports before generic theme exports when merging duplicate literal token keys
- keep dark exports as fallback-only so `plumb init --from` emits light-mode defaults for real projects
- add a regression test for duplicate light/dark color exports

## Dogfood
- IMR agent (`/Users/aramhammoudeh/dev/vertice-labs/imr/imr-agent/apps/web`) was generating dark theme defaults because `dark` sorted before `light` and duplicate color keys are first-write-wins.
- After this change, `plumb init --from apps/web` emits light values such as `background = "#faf7f7"`, `foreground = "#3f5965"`, and `primary = "#007068"`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p plumb-codegen`
- `cargo clippy -p plumb-codegen --all-targets --all-features -- -D warnings`
- `cargo build -p plumb-cli`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --workspace --no-deps`
- `just validate`
- `PLUMB_CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" scripts/noise-scoreboard.sh --live`

## Scoreboard
- kitchen-sink: 24
- example.com: 0
- ui.shadcn.com: 299
- news.ycombinator.com: 410